### PR TITLE
Set memory limit for tari container to 2048m

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
   tari:
     image: quay.io/tarilabs/minotari_node:v5.2.1-mainnet
     container_name: tari
+    mem_limit: 2048m
     restart: unless-stopped
     stop_grace_period: 1m
     logging: *default-logging


### PR DESCRIPTION
tari still has a memory leak and it will slowly eat the system memory.  Setting an upperbound of 2048m is more than enough for it to run and will cause a restart when it exceeds the limit though an OOM error.  This will improve stability on systems with 16 GB RAM.