### PR TITLE
Improved algo switching, reduce wasted hash towards xvb

### DIFF
--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -69,6 +69,11 @@ TARI_EXPLORER_URL = "https://textexplore.tari.com/?json"
 # --- Algorithm Safety Margins ---
 # Over-provisioning buffer (5%) to maintain hashrate comfortably above the target
 ALGO_TARGET_BUFFER = 0.05
+# Maximum absolute buffer (in H/s) to add to the target when catching up.
+# Prevents massive waste at higher donation tiers (e.g., 5% of 1M = 50k H/s).
+XVB_MAX_ABSOLUTE_BUFFER = int(os.environ.get("XVB_MAX_ABSOLUTE_BUFFER", 1000))
+# Minimal buffer multiplier used when averages are fully satisfied.
+XVB_MIN_MAINTENANCE_BUFFER = float(os.environ.get("XVB_MIN_MAINTENANCE_BUFFER", 0.01))
 # Switching overhead (ms) to account for connection ramp-up time
 XVB_SWITCH_OVERHEAD_MS = 5000
 

--- a/build/dashboard/mining_dashboard/service/algo_service.py
+++ b/build/dashboard/mining_dashboard/service/algo_service.py
@@ -183,6 +183,45 @@ class AlgoService:
         needed += XVB_SWITCH_OVERHEAD_MS
         
         return math.ceil(needed)
+        
+    async def _smart_sleep(self, duration_sec, check_interval_sec=10):
+        """
+        Sleeps in chunks, evaluating the hashrate target frequently.
+        Aborts sleep early if the 1H average drops below the tier target.
+        """
+        sleep_elapsed = 0
+        while sleep_elapsed < duration_sec:
+            # Calculate time for this specific tick
+            sleep_time = min(check_interval_sec, duration_sec - sleep_elapsed)
+            await asyncio.sleep(sleep_time)
+            sleep_elapsed += sleep_time
+            
+            try:
+                # Fetch fresh state
+                latest_data = self.data_service.latest_data
+                stable_hr = latest_data.get("total_live_h15", 0)
+                if stable_hr == 0:
+                    stable_hr = latest_data.get("total_live_h10", 0)
+                    
+                xvb_stats = self.state_manager.get_xvb_stats()
+                avg_1h = xvb_stats.get('avg_1h', 0)
+                target_hr = self._get_target_donation_hr(stable_hr)
+
+                # Polling condition: Instantly break if we dip below target
+                if target_hr > 0 and avg_1h < target_hr:
+                    # Dry-run the decision engine to ensure PPLNS constraints still allow XVB
+                    current_hr = latest_data.get("total_live_h10", 0) or stable_hr
+                    p2pool_stats = latest_data.get("pool", {}).get("pool", {})
+                    p2p_stats = latest_data.get("pool", {}).get("p2p", {})
+                    shares = latest_data.get("shares", [])
+                    
+                    decision, _ = self.get_decision(current_hr, stable_hr, p2pool_stats, p2p_stats, xvb_stats, shares)
+                    
+                    if decision in ["XVB", "SPLIT"]:
+                        logger.warning(f"Interrupting P2Pool sleep: 1H AVG ({avg_1h:.2f}) < Target ({target_hr:.2f}). Catching up.")
+                        return # Break out of sleep early to trigger a new cycle
+            except Exception as e:
+                logger.debug(f"Error during smart sleep check: {e}")
 
     async def run(self):
         """
@@ -218,7 +257,8 @@ class AlgoService:
                 
                 if decision == "P2POOL":
                     await self.switch_miners("P2POOL", state_label="P2POOL")
-                    await asyncio.sleep(XVB_TIME_ALGO_MS / 1000)
+                    # Use smart sleep to poll for drops
+                    await self._smart_sleep(XVB_TIME_ALGO_MS / 1000)
                     
                 elif decision == "XVB":
                     await self.switch_miners("XVB", state_label="XVB")
@@ -232,7 +272,8 @@ class AlgoService:
                     remainder = (XVB_TIME_ALGO_MS - xvb_duration) / 1000
                     if remainder > 0:
                         await self.switch_miners("P2POOL", state_label="P2POOL (Split)")
-                        await asyncio.sleep(remainder)
+                        # Use smart sleep during the P2Pool remainder
+                        await self._smart_sleep(remainder)
 
             except Exception as e:
                 logger.error(f"Algorithm Error: {e}")

--- a/build/dashboard/mining_dashboard/service/algo_service.py
+++ b/build/dashboard/mining_dashboard/service/algo_service.py
@@ -13,7 +13,8 @@ from config.config import (
     ALGO_TARGET_BUFFER,
     XVB_SWITCH_OVERHEAD_MS,
     XVB_MAX_ABSOLUTE_BUFFER,
-    XVB_MIN_MAINTENANCE_BUFFER
+    XVB_MIN_MAINTENANCE_BUFFER,
+    UPDATE_INTERVAL
 )
 from helper.utils import get_tier_info
 
@@ -183,11 +184,11 @@ class AlgoService:
         needed += XVB_SWITCH_OVERHEAD_MS
         
         return math.ceil(needed)
-        
-    async def _smart_sleep(self, duration_sec, check_interval_sec=10):
+
+    async def _smart_sleep(self, duration_sec, check_interval_sec=UPDATE_INTERVAL):
         """
         Sleeps in chunks, evaluating the hashrate target frequently.
-        Aborts sleep early if the 1H average drops below the tier target.
+        Aborts sleep early if either the 1H or 24H average drops below the tier target.
         """
         sleep_elapsed = 0
         while sleep_elapsed < duration_sec:
@@ -205,10 +206,12 @@ class AlgoService:
                     
                 xvb_stats = self.state_manager.get_xvb_stats()
                 avg_1h = xvb_stats.get('avg_1h', 0)
+                avg_24h = xvb_stats.get('avg_24h', 0) 
+                
                 target_hr = self._get_target_donation_hr(stable_hr)
 
-                # Polling condition: Instantly break if we dip below target
-                if target_hr > 0 and avg_1h < target_hr:
+                # Polling condition now checks both 1H and 24H averages
+                if target_hr > 0 and (avg_1h < target_hr or avg_24h < target_hr):
                     # Dry-run the decision engine to ensure PPLNS constraints still allow XVB
                     current_hr = latest_data.get("total_live_h10", 0) or stable_hr
                     p2pool_stats = latest_data.get("pool", {}).get("pool", {})
@@ -218,7 +221,7 @@ class AlgoService:
                     decision, _ = self.get_decision(current_hr, stable_hr, p2pool_stats, p2p_stats, xvb_stats, shares)
                     
                     if decision in ["XVB", "SPLIT"]:
-                        logger.warning(f"Interrupting P2Pool sleep: 1H AVG ({avg_1h:.2f}) < Target ({target_hr:.2f}). Catching up.")
+                        logger.warning(f"Interrupting P2Pool sleep: 1H AVG ({avg_1h:.2f}) or 24H AVG ({avg_24h:.2f}) < Target ({target_hr:.2f}). Catching up.")
                         return # Break out of sleep early to trigger a new cycle
             except Exception as e:
                 logger.debug(f"Error during smart sleep check: {e}")

--- a/build/dashboard/mining_dashboard/service/algo_service.py
+++ b/build/dashboard/mining_dashboard/service/algo_service.py
@@ -11,7 +11,9 @@ from config.config import (
     XVB_MIN_TIME_SEND_MS,
     ENABLE_XVB,
     ALGO_TARGET_BUFFER,
-    XVB_SWITCH_OVERHEAD_MS
+    XVB_SWITCH_OVERHEAD_MS,
+    XVB_MAX_ABSOLUTE_BUFFER,
+    XVB_MIN_MAINTENANCE_BUFFER
 )
 from helper.utils import get_tier_info
 
@@ -109,20 +111,12 @@ class AlgoService:
         if target_hr == 0:
              return "P2POOL", 0
 
-        # Verify if donation targets are currently satisfied
-        # Criteria: 24h Avg >= Target AND 1h Avg >= (Target - Margin)
         avg_24h = xvb_stats.get('avg_24h', 0)
         avg_1h = xvb_stats.get('avg_1h', 0)
 
-        is_fulfilled = (avg_24h >= target_hr) and (avg_1h >= target_hr)
-
-        if not is_fulfilled:
-            logger.info(f"Decision Strategy: Force XVB (Target {target_hr} not met, 24h: {avg_24h:.0f})")
-            return "XVB", XVB_TIME_ALGO_MS
-        
-        # Split Mode: Calculate precise maintenance duration
-        # Uses current_hr (real-time) to adjust donation time dynamically
-        needed_time_ms = self._get_needed_time(current_hr, target_hr)
+        # Split Mode: Calculate precise maintenance duration dynamically.
+        # This now handles deficits smoothly without forcing full 10-minute blocks.
+        needed_time_ms = self._get_needed_time(current_hr, target_hr, avg_1h, avg_24h)
         
         if needed_time_ms > 0:
             # Clamp duration to configured bounds
@@ -135,7 +129,7 @@ class AlgoService:
                 needed_time_ms = XVB_TIME_ALGO_MS
 
             if needed_time_ms >= XVB_TIME_ALGO_MS:
-                logger.info(f"Decision Strategy: Split Mode (Full Cycle allocated to XvB)")
+                logger.info(f"Decision Strategy: Force/Full XVB ({needed_time_ms}ms needed)")
                 return "XVB", XVB_TIME_ALGO_MS
 
             logger.info(f"Decision Strategy: Split Mode ({needed_time_ms}ms allocated to XvB)")
@@ -156,18 +150,36 @@ class AlgoService:
         _, threshold = get_tier_info(safe_capacity, tiers)
         return threshold
 
-    def _get_needed_time(self, current_hr, target_hr):
+    def _get_needed_time(self, current_hr, target_hr, avg_1h, avg_24h):
         """
         Computes the precise duration (in milliseconds) required to sustain the target average.
-        
-        Formula: (Target Hashrate / Current Hashrate) * Cycle Length
+        Uses a dynamic PID-like approach to prevent overshooting at high hashrates.
         """
         if current_hr == 0: return 0
-        # Apply buffer to target hashrate to prevent dropping below threshold
-        target_with_buffer = target_hr * (1.0 + self.target_buffer)
-        needed = (target_with_buffer / current_hr) * XVB_TIME_ALGO_MS
         
-        # Add switching overhead compensation
+        effective_target = target_hr
+        
+        # 1. Deficit Compensation (Proportional Catch-up)
+        # If lagging behind, inject an extra hashrate target to catch up quickly 
+        # without blindly forcing full 10-minute cycles.
+        if avg_1h < target_hr:
+            effective_target += (target_hr - avg_1h) * 1.5 
+        if avg_24h < target_hr:
+            effective_target += (target_hr - avg_24h) * 0.5
+
+        # 2. Dynamic Safety Buffer
+        # Once target is met, reduce the buffer to a minimal percentage to prevent waste.
+        # If the target is not met, use the configured percentage buffer but CAP it to prevent 
+        # massive absolute waste at high tiers.
+        if avg_1h >= target_hr and avg_24h >= target_hr:
+            buffer_hr = target_hr * XVB_MIN_MAINTENANCE_BUFFER  # Minimal maintenance buffer
+        else:
+            calculated_buffer = target_hr * self.target_buffer
+            buffer_hr = min(calculated_buffer, XVB_MAX_ABSOLUTE_BUFFER)
+            
+        effective_target += buffer_hr
+
+        needed = (effective_target / current_hr) * XVB_TIME_ALGO_MS
         needed += XVB_SWITCH_OVERHEAD_MS
         
         return math.ceil(needed)

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -217,8 +217,8 @@ class DataService:
                     snapshot_data.pop("shares", None)
                     await asyncio.to_thread(self.state_manager.save_snapshot, snapshot_data)
 
-                    # 7. External API Sync (Throttled to every 10th iteration)
-                    if iteration_count % 10 == 0:
+                    # 7. External API Sync (UPDATED: Throttled to match UPDATE_INTERVAL)
+                    if iteration_count % 1 == 0:
                         real_xvb_stats = await asyncio.to_thread(self.xvb_client.get_stats)
                         if real_xvb_stats:
                             await asyncio.to_thread(self.state_manager.update_xvb_stats, **real_xvb_stats)


### PR DESCRIPTION
Before

 - Static Buffer: A flat 5% buffer (ALGO_TARGET_BUFFER = 0.05) was always applied to the target hashrate, meaning higher donation tiers wasted significantly more hashrate (e.g., a 1M H/s target required a 50,000 H/s buffer).

 - All-or-Nothing Catch-up: If the 1-hour or 24-hour average dropped even slightly below the target, the algorithm bypassed SPLIT mode entirely and forced a full 10-minute mining cycle on XvB (return "XVB", XVB_TIME_ALGO_MS).

 - Limited Split Mode: SPLIT mode was only utilized for maintenance after the target averages were fully satisfied.

After

 - Dynamic, Capped Buffer: * When catching up, the 5% buffer is still applied but is now capped by XVB_MAX_ABSOLUTE_BUFFER (defaulting to 1000 H/s). This prevents massive hashrate waste at high tiers.

- Once the 1-hour and 24-hour averages meet the target, the buffer dynamically shrinks to XVB_MIN_MAINTENANCE_BUFFER (defaulting to 1%) to conserve hash for P2Pool.

 - Proportional Catch-up: The algorithm now calculates the precise hashrate deficit (effective_target += (target_hr - avg_1h) * 1.5) instead of forcing a full 10-minute cycle.

 - Active Split Mode: SPLIT mode is now the primary mechanism for fixing deficits. It calculates the exact seconds needed to inject the missing hashrate, allowing for much faster and shorter switches to XvB to quickly patch drops in the average.