### PR TITLE
added light mode support for p2pool

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -18,6 +18,7 @@
     },
     "p2pool": {
         "pool": "main",
+        "light_mode": false,
         "data_dir": "DYNAMIC_DATA"
     },
     "xvb": {

--- a/p2pool-starter-stack.sh
+++ b/p2pool-starter-stack.sh
@@ -371,6 +371,12 @@ finalize_env() {
         P2POOL_PORT="37890"
     fi
 
+    # Light Mode
+    LIGHT_MODE=$(jq -r '.p2pool.light_mode // false' "$CONFIG_FILE")
+    if [ "$LIGHT_MODE" == "true" ]; then
+        P2POOL_FLAGS="$P2POOL_FLAGS --light-mode"
+    fi
+
     # XvB Config
     XVB_ENABLED=$(jq -r 'if .xvb.enabled != null then .xvb.enabled elif .xmrig_proxy.enabled != null then .xmrig_proxy.enabled else "true" end' "$CONFIG_FILE")
     XVB_POOL_URL=$(jq -r '.xvb.url // .xmrig_proxy.url // empty' "$CONFIG_FILE")


### PR DESCRIPTION
Tested working this time with it both set to false and true:
true terminal output:

$ sudo docker exec p2pool cat /proc/1/cmdline | tr '\0' ' ' && echo
p2pool --host 172.28.0.26 --rpc-port 18081 --rpc-login <redacted> --zmq-port 18083 --wallet <redacted> --merge-mine tari://172.28.0.27:18142 <redacted> --onion-address omc7jcowqvnbvfmtqcgfyybsglyfxxuqyggr3bjck2zday6mb5hutwqd.onion --local-api --stratum 0.0.0.0:3333 --p2p 0.0.0.0:37889 --data-api /stats --light-mode