### PR TITLE
Header P2Pool 1h/24h averages from DB + symmetric pool graying (closes #27)

### DIFF
--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -352,6 +352,34 @@ def _get_pool_network_context(data):
         'net_ts': format_time_abs(network_stats.get('timestamp', 0)),
     }
 
+def _avg_p2pool_over_window(history, window_seconds):
+    """Time-weighted P2Pool hashrate over the trailing window, from DB history.
+
+    Averages the per-sample ``v_p2pool`` (hashrate attributed to P2Pool) for
+    samples within the window. Samples are written at a fixed cadence
+    (UPDATE_INTERVAL), so a simple mean approximates a time-weighted average.
+    Mirrors the chart's legacy-data fallback: rows predating the p2pool/xvb
+    split (v_p2pool == v_xvb == 0 but v > 0) are counted as P2Pool. (Issue #27)
+    """
+    if not history:
+        return 0.0
+
+    cutoff = time.time() - window_seconds
+    total = 0.0
+    count = 0
+    for x in history:
+        if x.get('timestamp', 0) < cutoff:
+            continue
+        vp = x.get('v_p2pool', 0) or 0
+        vx = x.get('v_xvb', 0) or 0
+        v = x.get('v', 0) or 0
+        if vp == 0 and vx == 0 and v > 0:
+            vp = v
+        total += vp
+        count += 1
+
+    return total / count if count else 0.0
+
 def _get_algo_context(data, state_mgr, history):
     """Calculates algorithm switching logic, donation tiers, and hashrate averages."""
     xvb_stats = state_mgr.get_xvb_stats() or {}
@@ -363,20 +391,25 @@ def _get_algo_context(data, state_mgr, history):
     c_blue = "#58a6ff"
     c_muted = "#8b949e"
 
-    mode_color = c_green
-    p2p_color = c_green
-    xvb_color = c_muted
-
-    if "XVB" in current_mode: 
-        mode_color = c_purple
-        p2p_color = c_muted
-        xvb_color = c_purple
-    if "Split" in current_mode: 
+    # Pool activity coloring: the active pool is colored, the inactive one muted.
+    # Symmetric — P2Pool dims when XvB is active, and vice versa (Issue #27).
+    # Checked most-specific first: "XVB (Split)" contains both "Split" and "XVB".
+    if not ENABLE_XVB:
+        current_mode = "P2POOL (XvB Disabled)"
+        mode_color = c_green
+        p2p_color = c_green
+        xvb_color = c_muted
+    elif "Split" in current_mode:
+        # Split cycle alternates pools within the window — both are active.
         mode_color = c_blue
         p2p_color = c_green
         xvb_color = c_purple
-    if not ENABLE_XVB: 
-        current_mode = "P2POOL (XvB Disabled)"
+    elif "XVB" in current_mode:
+        mode_color = c_purple
+        p2p_color = c_muted
+        xvb_color = c_purple
+    else:  # P2POOL
+        mode_color = c_green
         p2p_color = c_green
         xvb_color = c_muted
 
@@ -384,9 +417,12 @@ def _get_algo_context(data, state_mgr, history):
     xvb_1h_val = xvb_stats.get('avg_1h', 0)
     xvb_24h_val = xvb_stats.get('avg_24h', 0)
 
-    stratum_stats = data.get('stratum', {})
-    p2p_1h_val = stratum_stats.get('hashrate_1h', 0)
-    p2p_24h_val = stratum_stats.get('hashrate_24h', 0)
+    # P2Pool 1h/24h averages from our own DB history: the time-weighted hashrate
+    # actually delivered to P2Pool (v_p2pool), rather than p2pool's noisy stratum
+    # estimate or a total-minus-XvB subtraction. The raw stratum reading is still
+    # shown separately in the "Stratum (15m/1h/24h)" card. (Issue #27)
+    p2p_1h_val = _avg_p2pool_over_window(history, 3600)
+    p2p_24h_val = _avg_p2pool_over_window(history, 86400)
 
     tiers = state_mgr.get_tiers()
     tier_name, _ = get_tier_info(xvb_24h_val, tiers)

--- a/build/dashboard/mining_dashboard/web/templates/index.html
+++ b/build/dashboard/mining_dashboard/web/templates/index.html
@@ -214,10 +214,10 @@
                 <div class="stat-card"><h5>Total Hashrate</h5><p class="text-accent">{total_hr}</p></div>
                 <div class="stat-card"><h5>Share In Window</h5><p>{pool_shares_window}</p></div>
                 <div class="stat-card"><h5>Last Share</h5><p>{strat_last_share}</p></div>
-                <div class="stat-card"><h5>P2Pool 1h Avg</h5><p>{p2p_1h}</p></div>
-                <div class="stat-card"><h5>P2Pool 24h Avg</h5><p>{p2p_24h}</p></div>
-                <div class="stat-card"><h5>XvB 1h Avg</h5><p>{xvb_1h}</p></div>
-                <div class="stat-card"><h5>XvB 24h Avg</h5><p>{xvb_24h}</p></div>
+                <div class="stat-card"><h5>P2Pool 1h Avg</h5><p style="color:{p2p_color}">{p2p_1h}</p></div>
+                <div class="stat-card"><h5>P2Pool 24h Avg</h5><p style="color:{p2p_color}">{p2p_24h}</p></div>
+                <div class="stat-card"><h5>XvB 1h Avg</h5><p style="color:{xvb_color}">{xvb_1h}</p></div>
+                <div class="stat-card"><h5>XvB 24h Avg</h5><p style="color:{xvb_color}">{xvb_24h}</p></div>
                 <div class="stat-card"><h5>Current Tier</h5><p>{tier_name}</p></div>
                 <div class="stat-card"><h5>Target Tier</h5><p>{target_tier_name}</p></div>
                 <div class="stat-card"><h5>Tari Mining</h5><p class="{tari_status_class}">{tari_status}</p></div>
@@ -232,8 +232,8 @@
             <div class="stat-grid">
                 <div class="stat-card"><h5>Mining Mode</h5><p style="color:{mode_color}">{mode_name}</p></div>
                 <div class="stat-card"><h5>Total Hashrate</h5><p class="text-accent">{total_hr}</p></div>
-                <div class="stat-card"><h5>P2Pool 1h Avg</h5><p>{p2p_1h}</p></div>
-                <div class="stat-card"><h5>P2Pool 24h Avg</h5><p>{p2p_24h}</p></div>
+                <div class="stat-card"><h5>P2Pool 1h Avg</h5><p style="color:{p2p_color}">{p2p_1h}</p></div>
+                <div class="stat-card"><h5>P2Pool 24h Avg</h5><p style="color:{p2p_color}">{p2p_24h}</p></div>
                 
                 <div class="stat-card col-span-2">
                     <h5>Stratum (15m / 1h / 24h)</h5>
@@ -273,8 +273,8 @@
             <div class="stat-grid">
                 <div class="stat-card"><h5>Current Tier</h5><p>{tier_name}</p></div>
                 <div class="stat-card"><h5>Target Tier</h5><p>{target_tier_name}</p></div>
-                <div class="stat-card"><h5>1h Avg (Pool)</h5><p>{xvb_1h}</p></div>
-                <div class="stat-card"><h5>24h Avg (Pool)</h5><p>{xvb_24h}</p></div>
+                <div class="stat-card"><h5>1h Avg (Pool)</h5><p style="color:{xvb_color}">{xvb_1h}</p></div>
+                <div class="stat-card"><h5>24h Avg (Pool)</h5><p style="color:{xvb_color}">{xvb_24h}</p></div>
                 <div class="stat-card"><h5>Fail Count</h5><p>{xvb_fail_count}</p></div>
             </div>
             <div class="text-xs text-muted" style="margin-top:10px;">Stats fetched from xmrvsbeast.com (Updated: {xvb_updated})</div>

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -92,6 +92,74 @@ class TestChartContext:
         assert isinstance(ctx, dict)
 
 
+class TestAvgP2poolOverWindow:
+    def test_empty_history_returns_zero(self):
+        assert server._avg_p2pool_over_window([], 3600) == 0.0
+
+    def test_averages_v_p2pool_in_window(self):
+        now = time.time()
+        history = [
+            {"timestamp": now - 30, "v": 1000, "v_p2pool": 1000, "v_xvb": 0},
+            {"timestamp": now - 60, "v": 500, "v_p2pool": 500, "v_xvb": 0},
+        ]
+        assert server._avg_p2pool_over_window(history, 3600) == 750.0
+
+    def test_excludes_samples_outside_window(self):
+        now = time.time()
+        history = [
+            {"timestamp": now - 30, "v": 1000, "v_p2pool": 1000, "v_xvb": 0},
+            {"timestamp": now - 7200, "v": 200, "v_p2pool": 200, "v_xvb": 0},
+        ]
+        assert server._avg_p2pool_over_window(history, 3600) == 1000.0
+
+    def test_legacy_rows_count_as_p2pool(self):
+        now = time.time()
+        history = [{"timestamp": now - 30, "v": 800, "v_p2pool": 0, "v_xvb": 0}]
+        assert server._avg_p2pool_over_window(history, 3600) == 800.0
+
+    def test_xvb_samples_drag_average_down(self):
+        # Time spent donating to XvB reduces the P2Pool average (v_p2pool == 0 then).
+        now = time.time()
+        history = [
+            {"timestamp": now - 30, "v": 1000, "v_p2pool": 1000, "v_xvb": 0},
+            {"timestamp": now - 60, "v": 1000, "v_p2pool": 0, "v_xvb": 1000},
+        ]
+        assert server._avg_p2pool_over_window(history, 3600) == 500.0
+
+
+class TestAlgoContextColors:
+    MUTED = "#8b949e"
+
+    def _ctx(self, mode):
+        sm = StateManager(db_path=":memory:")
+        sm.update_xvb_stats(mode=mode)
+        try:
+            return server._get_algo_context({"total_live_h15": 100000}, sm, [])
+        finally:
+            sm.close()
+
+    def test_p2pool_mode_grays_xvb(self):
+        ctx = self._ctx("P2POOL")
+        assert ctx["xvb_color"] == self.MUTED
+        assert ctx["p2p_color"] != self.MUTED
+
+    def test_xvb_mode_grays_p2pool(self):
+        ctx = self._ctx("XVB")
+        assert ctx["p2p_color"] == self.MUTED
+        assert ctx["xvb_color"] != self.MUTED
+
+    def test_split_mode_both_active(self):
+        ctx = self._ctx("XVB (Split)")
+        assert ctx["p2p_color"] != self.MUTED
+        assert ctx["xvb_color"] != self.MUTED
+
+    def test_xvb_disabled_grays_xvb(self, monkeypatch):
+        monkeypatch.setattr(server, "ENABLE_XVB", False)
+        ctx = self._ctx("XVB")
+        assert ctx["xvb_color"] == self.MUTED
+        assert "Disabled" in ctx["mode_name"]
+
+
 class TestHelpers:
     def test_get_cached_template_returns_str(self):
         assert isinstance(get_cached_template(), str)


### PR DESCRIPTION
Closes #27.

## What & why

**1. P2Pool 1h/24h header averages now come from our DB.**
Previously sourced from p2pool's own stratum estimate (`hashrate_1h`/`hashrate_24h`) — noisy, and redundant with the existing "Stratum (15m/1h/24h)" card. New `_avg_p2pool_over_window` computes them as the time-weighted average of `v_p2pool` over the trailing 1h/24h windows — the hashrate actually routed to P2Pool (drops when time is donated to XvB). This is our best estimate of P2Pool contribution; there is no pool-side receipt for P2Pool, and p2pool's share-based stratum number just re-measures the same thing more noisily.

**2. XvB 1h/24h stays sourced from xmrvsbeast.com.**
The XvB API is the *definitive* record of donation actually credited — it's what counts for tier qualification and donations — so it remains the source for the XvB averages (header, Overview, and the "XvB Donation Stats" card). In steady state `p2p(DB) + xvb(API) ≈ total`, so the pair still reads as a rough P2Pool-vs-XvB ratio; any gap reflects donation lag/loss (a useful signal). Note: right after starting to donate, the API average ramps up over the first 1h/24h.

**3. Symmetric pool graying.**
The header already grayed XvB when P2Pool was active but not the reverse. Reworked the color logic so the **inactive pool is muted in both directions**, the `"XVB (Split)"` mode shows **both** pools active, and the active/inactive colors reach the Overview, Node, and XvB-Donation **stat cards**, not just the header.

## Behavior on deploy
The P2Pool average divides by samples actually present (not a fixed 24h of slots), so it shows a real rate from the first 30s sample and the window grows toward 24h over the first day (it does **not** read 0 for 24h). Genuine donation periods count as 0 for P2Pool; only dashboard downtime is excluded (we don't assume P2Pool got 0 while we weren't watching). History persists across restarts.

Sanity check after deploy: **P2Pool avg + XvB avg should land near your total hashrate** (1h and 24h), modulo the XvB API ramp-up, and the inactive pool should be grayed.

## Tests
- `TestAvgP2poolOverWindow` — empty, in-window mean, window exclusion, legacy fallback, XvB drag-down.
- `TestAlgoContextColors` — P2POOL / XVB / Split / XvB-disabled.
- Full dashboard suite (140 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)