### PR TITLE
Harden Monero sync read: monerod get_info RPC with log fallback (closes #29)

### DIFF
--- a/build/dashboard/README.md
+++ b/build/dashboard/README.md
@@ -10,7 +10,7 @@ dashboard (behind Caddy) on `127.0.0.1:8000`.
 mining_dashboard/
 ├── main.py            # entry point: build_app() wires everything; `python -m mining_dashboard.main`
 ├── config/            # configuration from environment variables
-├── client/            # external service clients (xmrig, xmrig-proxy, xvb, tari gRPC)
+├── client/            # external service clients (xmrig, xmrig-proxy, xvb, tari gRPC, monerod RPC)
 ├── collector/         # local stats collectors (pools, system, docker logs)
 ├── service/           # algo_service (XvB switching), data_service (aggregation), storage_service (SQLite)
 ├── web/               # aiohttp server + HTML template + static assets

--- a/build/dashboard/mining_dashboard/client/monero/monero_client.py
+++ b/build/dashboard/mining_dashboard/client/monero/monero_client.py
@@ -1,0 +1,86 @@
+import logging
+import requests
+from requests.auth import HTTPDigestAuth
+
+from mining_dashboard.config.config import (
+    MONERO_RPC_URL,
+    MONERO_NODE_USERNAME,
+    MONERO_NODE_PASSWORD,
+)
+
+logger = logging.getLogger("MoneroClient")
+
+
+class MoneroClient:
+    """
+    Reads monerod state from its `get_info` RPC instead of scraping docker logs.
+
+    The dashboard runs `network_mode: host` and monerod publishes 127.0.0.1:18081, so
+    the RPC is directly reachable. Reading height/target_height from `get_info` is
+    format-stable, unlike the log line (which broke once already when v0.18.x changed
+    "Synced N/M" to "... top block candidate: X -> Y").
+
+    monerod runs with `restricted-rpc=1` + `rpc-login`, so calls use HTTP digest auth.
+    This client is synchronous (requests + HTTPDigestAuth); the async data loop calls it
+    via `asyncio.to_thread`, mirroring how XvbClient / proxy_client are used.
+    """
+
+    def __init__(self, url=MONERO_RPC_URL, username=MONERO_NODE_USERNAME,
+                 password=MONERO_NODE_PASSWORD, timeout=5):
+        self.url = url.rstrip("/") + "/get_info"
+        # No creds (e.g. a remote node deployment) → send unauthenticated; the request
+        # will simply fail and the caller falls back to log scraping.
+        self._auth = HTTPDigestAuth(username, password) if username else None
+        self.timeout = timeout
+
+    def get_info(self):
+        """Return monerod's `get_info` payload as a dict, or None if unreachable/errored."""
+        try:
+            resp = requests.get(self.url, auth=self._auth, timeout=self.timeout)
+        except requests.RequestException as e:
+            logger.warning(f"monerod get_info unreachable at {self.url}: {e}")
+            return None
+
+        if resp.status_code != 200:
+            logger.warning(f"monerod get_info returned HTTP {resp.status_code}")
+            return None
+
+        try:
+            data = resp.json()
+        except ValueError:
+            logger.error("monerod get_info returned a non-JSON body")
+            return None
+
+        # get_info embeds its own status string; anything other than OK (e.g. "BUSY")
+        # means the heights aren't trustworthy yet.
+        status = data.get("status")
+        if status not in (None, "OK"):
+            logger.warning(f"monerod get_info status={status}")
+            return None
+
+        return data
+
+    def get_sync_status(self):
+        """
+        Map `get_info` onto the dashboard's sync dict.
+
+        Returns the same shape as the log-scraping path so it's a drop-in:
+          - syncing:   {"is_syncing": True, "current", "target", "percent"}
+          - synced:    {"is_syncing": False}
+          - unreachable: None  (signals the caller to fall back to log scraping)
+        """
+        info = self.get_info()
+        if info is None:
+            return None
+
+        height = int(info.get("height", 0) or 0)
+        target = int(info.get("target_height", 0) or 0)
+
+        # `synchronized` is monerod's authoritative "caught up" flag; once synced it also
+        # reports target_height: 0. Trust it over the height comparison (mirrors how the
+        # Tari client trusts initial_sync_achieved).
+        if info.get("synchronized") or target == 0 or height >= target:
+            return {"is_syncing": False}
+
+        percent = int((height / target) * 100)
+        return {"is_syncing": True, "current": height, "target": target, "percent": percent}

--- a/build/dashboard/mining_dashboard/collector/logs.py
+++ b/build/dashboard/mining_dashboard/collector/logs.py
@@ -1,4 +1,5 @@
 import aiohttp
+import asyncio
 import logging
 import re
 import struct
@@ -6,8 +7,12 @@ import json
 import aiofiles
 
 from mining_dashboard.config.config import DOCKER_PROXY_URL, LOG_TAIL_LINES, DOCKER_TIMEOUT, NETWORK_STATS_PATH, MONERO_NODE_HOST
+from mining_dashboard.client.monero.monero_client import MoneroClient
 
 logger = logging.getLogger("LogCollector")
+
+# Stateless client reused across cycles; reads monerod's get_info RPC (Issue #29).
+_monero_client = MoneroClient()
 
 async def fetch_docker_logs(container_name, tail=None):
     """
@@ -110,6 +115,21 @@ async def _get_remote_monero_sync_status():
         return {"is_syncing": False}
 
 async def _get_local_monero_sync_status():
+    """
+    Sync status for a local monerod.
+
+    Prefers monerod's get_info RPC (format-stable, Issue #29); the RPC runs in a thread
+    because the client is synchronous (requests + digest auth). Falls back to scraping
+    docker logs when the RPC is unreachable — e.g. creds not plumbed into the dashboard
+    env, or monerod briefly down — so this is never worse than the previous behaviour.
+    """
+    rpc_status = await asyncio.to_thread(_monero_client.get_sync_status)
+    if rpc_status is not None:
+        return rpc_status
+    return await _get_monero_sync_status_from_logs()
+
+
+async def _get_monero_sync_status_from_logs():
     """
     Parses local monerod docker logs to determine if the node is currently syncing.
 

--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -69,6 +69,14 @@ DOCKER_TIMEOUT = int(os.environ.get("DOCKER_TIMEOUT", 5))
 # Used to determine if the node is local (Docker) or remote
 MONERO_NODE_HOST = os.environ.get("MONERO_NODE_HOST", "172.28.0.26")
 
+# monerod's get_info RPC, used to read sync height/target directly instead of scraping
+# docker logs (Issue #29). Reachable because the dashboard runs network_mode: host and
+# monerod publishes 127.0.0.1:18081. Credentials are required by monerod's restricted-rpc
+# + rpc-login (digest auth); absent creds simply make the RPC fail and fall back to logs.
+MONERO_RPC_URL = os.environ.get("MONERO_RPC_URL", "http://127.0.0.1:18081")
+MONERO_NODE_USERNAME = os.environ.get("MONERO_NODE_USERNAME", "")
+MONERO_NODE_PASSWORD = os.environ.get("MONERO_NODE_PASSWORD", "")
+
 # --- Tari Configuration ---
 # Connection details for the Tari Base Node and Block Explorer
 TARI_GRPC_ADDRESS = os.environ.get("TARI_GRPC_ADDRESS", "127.0.0.1:18142")

--- a/build/dashboard/tests/client/test_monero_client.py
+++ b/build/dashboard/tests/client/test_monero_client.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch, MagicMock
+
+import requests
+
+import mining_dashboard.client.monero.monero_client as monero_mod
+from mining_dashboard.client.monero.monero_client import MoneroClient
+
+
+def _resp(status_code=200, json_data=None, raise_json=False):
+    resp = MagicMock(status_code=status_code)
+    if raise_json:
+        resp.json.side_effect = ValueError("no json")
+    else:
+        resp.json.return_value = json_data or {}
+    return resp
+
+
+class TestGetInfo:
+    def test_url_and_digest_auth_built(self):
+        client = MoneroClient(url="http://127.0.0.1:18081/", username="u", password="p")
+        assert client.url == "http://127.0.0.1:18081/get_info"
+        assert isinstance(client._auth, requests.auth.HTTPDigestAuth)
+
+    def test_no_username_means_no_auth(self):
+        assert MoneroClient(url="http://x:18081", username="", password="")._auth is None
+
+    def test_success_returns_payload(self):
+        client = MoneroClient(username="u", password="p")
+        data = {"status": "OK", "height": 5, "target_height": 10}
+        with patch.object(monero_mod.requests, "get", return_value=_resp(json_data=data)) as mock_get:
+            assert client.get_info() == data
+        # Digest auth and a bounded timeout are passed through on every call.
+        assert mock_get.call_args.kwargs["timeout"] == client.timeout
+        assert mock_get.call_args.kwargs["auth"] is client._auth
+
+    def test_network_error_returns_none(self):
+        client = MoneroClient(username="u", password="p")
+        with patch.object(monero_mod.requests, "get",
+                          side_effect=requests.RequestException("refused")):
+            assert client.get_info() is None
+
+    def test_non_200_returns_none(self):
+        client = MoneroClient(username="u", password="p")
+        with patch.object(monero_mod.requests, "get", return_value=_resp(status_code=401)):
+            assert client.get_info() is None
+
+    def test_non_json_returns_none(self):
+        client = MoneroClient(username="u", password="p")
+        with patch.object(monero_mod.requests, "get", return_value=_resp(raise_json=True)):
+            assert client.get_info() is None
+
+    def test_busy_status_returns_none(self):
+        client = MoneroClient(username="u", password="p")
+        with patch.object(monero_mod.requests, "get",
+                          return_value=_resp(json_data={"status": "BUSY"})):
+            assert client.get_info() is None
+
+
+class TestGetSyncStatus:
+    def _client_with_info(self, info):
+        client = MoneroClient(username="u", password="p")
+        client.get_info = MagicMock(return_value=info)
+        return client
+
+    def test_syncing(self):
+        client = self._client_with_info({"status": "OK", "height": 50, "target_height": 100})
+        assert client.get_sync_status() == {
+            "is_syncing": True, "current": 50, "target": 100, "percent": 50,
+        }
+
+    def test_synced_via_flag(self):
+        # `synchronized` is authoritative even if heights look mid-sync.
+        client = self._client_with_info(
+            {"status": "OK", "synchronized": True, "height": 90, "target_height": 100})
+        assert client.get_sync_status() == {"is_syncing": False}
+
+    def test_synced_via_zero_target(self):
+        # Synced monerod reports target_height: 0.
+        client = self._client_with_info({"status": "OK", "height": 100, "target_height": 0})
+        assert client.get_sync_status() == {"is_syncing": False}
+
+    def test_synced_when_height_reaches_target(self):
+        client = self._client_with_info({"status": "OK", "height": 100, "target_height": 100})
+        assert client.get_sync_status() == {"is_syncing": False}
+
+    def test_unreachable_returns_none(self):
+        client = self._client_with_info(None)
+        assert client.get_sync_status() is None

--- a/build/dashboard/tests/collector/test_logs.py
+++ b/build/dashboard/tests/collector/test_logs.py
@@ -90,11 +90,13 @@ class TestRemoteSyncStatus:
             assert await logs._get_remote_monero_sync_status() == {"is_syncing": False}
 
 
-class TestLocalSyncStatus:
+class TestLogSyncStatus:
+    """Log-scraping fallback path (`_get_monero_sync_status_from_logs`)."""
+
     async def test_new_format_top_block_candidate(self):
         with patch.object(logs, "get_monero_logs",
                           AsyncMock(return_value=["top block candidate: 100 -> 200 [node]"])):
-            status = await logs._get_local_monero_sync_status()
+            status = await logs._get_monero_sync_status_from_logs()
         assert status["is_syncing"] is True
         assert status["current"] == 100 and status["target"] == 200
         assert status["percent"] == 50
@@ -102,16 +104,37 @@ class TestLocalSyncStatus:
     async def test_old_synced_format(self):
         with patch.object(logs, "get_monero_logs",
                           AsyncMock(return_value=["Synced 50/100 (50%, ...)"])):
-            assert (await logs._get_local_monero_sync_status())["percent"] == 50
+            assert (await logs._get_monero_sync_status_from_logs())["percent"] == 50
 
     async def test_already_synchronized(self):
         with patch.object(logs, "get_monero_logs",
                           AsyncMock(return_value=["You are now synchronized with the network"])):
-            assert await logs._get_local_monero_sync_status() == {"is_syncing": False}
+            assert await logs._get_monero_sync_status_from_logs() == {"is_syncing": False}
 
     async def test_error_logs(self):
         with patch.object(logs, "get_monero_logs", AsyncMock(return_value=["Error: nope"])):
-            assert await logs._get_local_monero_sync_status() == {"is_syncing": False}
+            assert await logs._get_monero_sync_status_from_logs() == {"is_syncing": False}
+
+
+class TestLocalSyncStatus:
+    """Orchestrator: prefer the get_info RPC, fall back to log scraping when unreachable."""
+
+    async def test_rpc_result_used_when_available(self):
+        # RPC returns a status → use it directly, never touch the docker logs.
+        rpc_status = {"is_syncing": True, "current": 10, "target": 20, "percent": 50}
+        with patch.object(logs._monero_client, "get_sync_status", return_value=rpc_status), \
+             patch.object(logs, "get_monero_logs", AsyncMock()) as mock_logs:
+            status = await logs._get_local_monero_sync_status()
+        assert status == rpc_status
+        mock_logs.assert_not_called()
+
+    async def test_falls_back_to_logs_when_rpc_unreachable(self):
+        # RPC returns None (node unreachable / creds absent) → scrape logs instead.
+        with patch.object(logs._monero_client, "get_sync_status", return_value=None), \
+             patch.object(logs, "get_monero_logs",
+                          AsyncMock(return_value=["Synced 50/100 (50%, ...)"])):
+            status = await logs._get_local_monero_sync_status()
+        assert status["is_syncing"] is True and status["percent"] == 50
 
 
 class TestDispatch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,11 @@ services:
       - HOST_IP=${HOST_IP:-127.0.0.1}
       - TZ=${TZ:-America/Chicago}
       - MONERO_NODE_HOST=${MONERO_NODE_HOST:-172.28.0.26}
+      # monerod get_info RPC creds (Issue #29): the dashboard reads sync height/target over
+      # 127.0.0.1:18081 (reachable via network_mode: host) using digest auth, instead of
+      # scraping docker logs. Only used for a local node; harmless for remote-node setups.
+      - MONERO_NODE_USERNAME=${MONERO_NODE_USERNAME}
+      - MONERO_NODE_PASSWORD=${MONERO_NODE_PASSWORD}
       - P2POOL_URL=${P2POOL_URL}
       - MONERO_WALLET_ADDRESS=${MONERO_WALLET_ADDRESS}
       - XVB_ENABLED=${XVB_ENABLED}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ plain HTTP, edit `config.json` and run `./stack.sh apply`.
 |---|---|---|
 | `monero.mode` | `local` | `local` runs the bundled Monero node; `remote` connects to an external node (see `monero.remote`). |
 | `monero.wallet_address` | _required_ | Your Monero payout address. |
-| `monero.node_username` / `node_password` | _auto (local)_ | Credentials for the local node's RPC. `setup` auto-generates them; they're internal to the stack (only monerod and p2pool use them). For a remote node, set only if it requires auth. |
+| `monero.node_username` / `node_password` | _auto (local)_ | Credentials for the local node's RPC. `setup` auto-generates them; they're internal to the stack (monerod, p2pool, and the dashboard use them — the dashboard reads the node's `get_info` RPC for sync status). For a remote node, set only if it requires auth. |
 | `monero.prune` | `true` | Prune the Monero blockchain to save disk space. |
 | `monero.prep_blocks_threads` | `auto` | Block-verification threads during sync. `auto` = host cores − 2, clamped to 4–8. |
 | `monero.rpc_lan_access` | `false` | `true` publishes the node's RPC on the LAN (`0.0.0.0`) for wallets on other machines; default is localhost-only. |


### PR DESCRIPTION
## What & why

The dashboard determined Monero sync state by regex-parsing monerod's docker logs (`_get_local_monero_sync_status()`), which is format-fragile — it already broke once when v0.18.x changed `Synced N/M` → `top block candidate: X -> Y`. This reads `height`/`target_height` from monerod's **`get_info` RPC** instead, now reachable because the dashboard is `network_mode: host` and monerod publishes `127.0.0.1:18081`.

Closes #29.

## Approach

- **New `MoneroClient`** (`build/dashboard/mining_dashboard/client/monero/`) reads `get_info` over HTTP **digest auth** using `requests`, called via `asyncio.to_thread` from the async loop — mirrors `XvbClient`/`proxy_client` usage and the existing monerod healthcheck (`curl --digest .../get_info`). Trusts monerod's `synchronized` flag as authoritative, the same way the Tari client trusts `initial_sync_achieved`.
- **RPC-first with log fallback:** `_get_local_monero_sync_status()` tries the RPC, then falls back to the renamed `_get_monero_sync_status_from_logs()` when the RPC is unreachable (no creds plumbed, or monerod briefly down). **Never worse than the previous behaviour.**
- **Creds plumbed** into the dashboard service env (`MONERO_NODE_USERNAME`/`PASSWORD`) — the gap that deferred this out of the security PR. Harmless for remote-node setups (no creds → RPC fails → log fallback).

## Tests

- 13 new `MoneroClient` unit tests + RPC-first orchestration tests; existing log-parsing tests retargeted to the fallback helper.
- Full dashboard suite: **172 passed**, coverage **86%** (gate 80%), new client **100%**. Stack tests: **28 passed**.

## How to verify on a server

A fully-synced node looks identical in the UI (both RPC and log fallback report "synced"); the visible benefit shows during a re-sync. To confirm the **RPC path is live** vs silently falling back:

1. **Dashboard logs** — the new code only logs on failure (`monerod get_info unreachable…`). Absence of those = RPC working.
2. **Manual curl** (host network):
   ```bash
   curl -s --digest -u "$MONERO_NODE_USERNAME:$MONERO_NODE_PASSWORD" \
     http://127.0.0.1:18081/get_info | jq '{height, target_height, synchronized, status}'
   ```
3. **End-to-end:** `docker stop monerod` (or wrong creds) → dashboard logs the fallback warning and still reports from logs.

## Follow-ons (not in this PR)

This client was built to expose the full down-signal + heights so **#31** (node-down indicator for monerod/tari) and **#32** (pruned-vs-full panel) drop in as small follow-ons on the same client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)