### PR TITLE
Hold the miner until synced + non-blocking Tari (closes #35, #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ addresses, provisions Tor, tunes the kernel for RandomX, and offers to start the
 
 1. **Open the dashboard** at `https://<your-hostname>` (the script prints the exact URL).
 2. **Let it sync.** On first boot the dashboard shows **Sync Mode** while your Monero and Tari
-   nodes catch up to the network — it switches to the live view automatically once synced.
+   nodes catch up to the network — it switches to the live view automatically once synced. p2pool
+   and the proxy stay parked until then, so the sync logs stay clean.
 3. **Add a worker** by pointing any [XMRig](https://github.com/xmrig/xmrig) rig at
    `YOUR_STACK_IP:3333`. No wallet address needed in the worker config.
 

--- a/build/dashboard/mining_dashboard/client/docker/docker_control.py
+++ b/build/dashboard/mining_dashboard/client/docker/docker_control.py
@@ -29,17 +29,21 @@ class DockerControl:
         self.base_url = base.rstrip("/")
         self.timeout = timeout
 
-    async def stop(self, container, stop_timeout=10):
-        """Stop a container. Returns True on success (incl. already-stopped)."""
-        return await self._post(f"/containers/{container}/stop", params={"t": stop_timeout},
-                                action="stop", container=container)
+    async def stop(self, container, stop_timeout=10, quiet=False):
+        """Stop a container. Returns True on success (incl. already-stopped).
 
-    async def start(self, container):
+        `quiet` logs success at debug instead of info — used by the sync-gate hold (#35),
+        which re-asserts the stop every cycle and would otherwise flood the log for hours.
+        """
+        return await self._post(f"/containers/{container}/stop", params={"t": stop_timeout},
+                                action="stop", container=container, quiet=quiet)
+
+    async def start(self, container, quiet=False):
         """Start a container. Returns True on success (incl. already-running)."""
         return await self._post(f"/containers/{container}/start", params=None,
-                                action="start", container=container)
+                                action="start", container=container, quiet=quiet)
 
-    async def _post(self, path, params, action, container):
+    async def _post(self, path, params, action, container, quiet=False):
         url = f"{self.base_url}{path}"
         try:
             async with aiohttp.ClientSession() as session:
@@ -47,7 +51,8 @@ class DockerControl:
                     # 204 No Content = done; 304 Not Modified = already in that state
                     # (Docker's idempotent response) — both are success for us.
                     if resp.status in (204, 304):
-                        logger.info(f"Container {container} {action}: ok (HTTP {resp.status})")
+                        log = logger.debug if quiet else logger.info
+                        log(f"Container {container} {action}: ok (HTTP {resp.status})")
                         return True
                     body = await resp.text()
                     logger.error(f"Container {container} {action} failed: HTTP {resp.status} {body[:200]}")

--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -69,22 +69,35 @@ DOCKER_CONTROL_URL = os.environ.get("DOCKER_CONTROL_URL", "tcp://172.28.0.31:237
 LOG_TAIL_LINES = int(os.environ.get("LOG_TAIL_LINES", 100))
 DOCKER_TIMEOUT = int(os.environ.get("DOCKER_TIMEOUT", 5))
 
-# --- Reject Workers on Node Down (Issue #31) ---
-# When a required node is unreachable, the stack can't mine on the workers' behalf — so stop
-# the xmrig-proxy container to close :3333, forcing miners to fail over to the backup pools
-# they've configured instead of sitting idle on us.
+# --- Monero is required; Tari is optional (Issues #31, #35, #51) ---
+# monerod is the chain the stack actually mines: if it's unreachable or still syncing, the
+# workers can't mine no matter what, so those behaviours aren't configurable.
+#   - A monerod outage ALWAYS rejects workers (stops xmrig-proxy → closes :3333) so miners
+#     fail over to the backup pools they've configured instead of idling on us (Issue #31).
+#   - The miner (p2pool + xmrig-proxy) is ALWAYS held until monerod has fully synced — it
+#     can't mine against an unsynced node, and p2pool's merge-mining chatter would just flood
+#     the logs during the hours-long initial sync (Issue #35).
 #
-# Per-node so you can match what each chain means to you: monerod is REQUIRED for p2pool
-# mining (down = can't mine, reject), while Tari is only merge-mining gravy (you can still
-# mine Monero on p2pool without it). Both default true (reject if either is down); set
-# reject_workers_on_tari_down:false if you'd rather keep mining Monero through a Tari outage.
-# Safe to leave on: if the socket-proxy stop grant is missing the stop simply no-ops, and the
-# debounce + ever-up guard keep a blip or initial sync from tripping it.
-REJECT_WORKERS_ON_MONERO_DOWN = os.environ.get("REJECT_WORKERS_ON_MONERO_DOWN", "true").strip().lower() == "true"
-REJECT_WORKERS_ON_TARI_DOWN = os.environ.get("REJECT_WORKERS_ON_TARI_DOWN", "true").strip().lower() == "true"
+# Tari is merge-mining gravy — you can mine Monero on p2pool without it — so a single flag,
+# `dashboard.tari_required` (default true), decides how much Tari blocks the stack. When true
+# (Tari treated as required), a Tari outage rejects workers, the miner waits for Tari's sync
+# too, and a Tari-only (re)sync drives the full Sync-Mode dashboard. Set it false to make Tari
+# NON-BLOCKING: keep mining Monero through a Tari outage, start the miner as soon as monerod is
+# synced (Tari finishes in the background), and keep the operational dashboard — with a "Tari
+# syncing" indicator — instead of the takeover screen (Issue #51).
+TARI_REQUIRED = os.environ.get("TARI_REQUIRED", "true").strip().lower() == "true"
 
-# Container the dashboard stops/starts to reject/readmit workers.
+# Container the dashboard stops/starts to reject/readmit workers on a monerod/Tari outage.
 REJECT_WORKERS_CONTAINER = os.environ.get("REJECT_WORKERS_CONTAINER", "xmrig-proxy")
+
+# Containers held stopped until the required chain(s) finish syncing, then started together
+# (p2pool first so the proxy has something to connect to). Comma-separated; order preserved.
+# The hold is a one-way latch: after the first release we never re-hold (a later node blip is
+# #31's job — it stops only xmrig-proxy so p2pool keeps its sidechain position), and the latch
+# is persisted across dashboard restarts so a restart mid-sync doesn't prematurely release.
+SYNC_GATE_CONTAINERS = [
+    c.strip() for c in os.environ.get("SYNC_GATE_CONTAINERS", "p2pool,xmrig-proxy").split(",") if c.strip()
+]
 
 # Debounce: a node must be unreachable this long before it's declared DOWN, and reachable
 # this long before recovery — so a single transient timeout or a brief restart doesn't

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -5,9 +5,9 @@ from aiohttp import ClientSession
 
 from mining_dashboard.config.config import (
     UPDATE_INTERVAL,
-    REJECT_WORKERS_ON_MONERO_DOWN,
-    REJECT_WORKERS_ON_TARI_DOWN,
+    TARI_REQUIRED,
     REJECT_WORKERS_CONTAINER,
+    SYNC_GATE_CONTAINERS,
 )
 from mining_dashboard.client.xmrig_client import XMRigWorkerClient
 from mining_dashboard.client.tari.tari_client import TariClient
@@ -41,7 +41,10 @@ class DataService:
             "monero_sync": {},
             "tari_sync": {},
             "global_sync": False,
+            "tari_syncing_passive": False,
             "workers_rejected": False,
+            "miner_released": False,
+            "miner_held": False,
             "timestamp": 0
         }
 
@@ -53,11 +56,21 @@ class DataService:
         # a dashboard restart mid-outage still readmits workers once the node recovers.
         self.workers_rejected = False
 
+        # Hold the miner (p2pool + xmrig-proxy) until the required chain(s) finish syncing
+        # (Issue #35). One-way latch: `miner_released` flips True the first time the gate is
+        # satisfied, and we never re-hold after that (a later node blip is #31's job, which
+        # stops only xmrig-proxy so p2pool keeps its sidechain position). Persisted so a
+        # restart mid-sync keeps holding, and a restart after release doesn't re-stop a
+        # running, mining stack. `miner_held` is transient UI/log state, not persisted.
+        self.miner_released = False
+        self.miner_held = False
+
         # Restore persistent state from DB to prevent empty dashboard on service restart
         loaded_snapshot = self.state_manager.load_snapshot()
         if loaded_snapshot and isinstance(loaded_snapshot, dict):
             self.latest_data.update(loaded_snapshot)
             self.workers_rejected = bool(self.latest_data.get("workers_rejected", False))
+            self.miner_released = bool(self.latest_data.get("miner_released", False))
 
     async def _apply_worker_rejection(self, monero_down, tari_down):
         """
@@ -65,17 +78,13 @@ class DataService:
         to their backup pools; readmit them (start the proxy) once those nodes are confirmed
         healthy.
 
-        Per-node: monerod and Tari each have their own toggle (both default on), so a Tari-only
-        outage need not reject workers if you're happy to keep mining Monero on p2pool. A no-op
-        when both toggles are off. Only acts on transitions (tracked by `workers_rejected`), and
-        Docker treats a repeat stop/start as already-done (HTTP 304), so it's safe every cycle.
+        monerod is required to mine, so a monerod outage always rejects. Tari is only merge-
+        mining gravy: a Tari outage rejects only when `TARI_REQUIRED` (dashboard.tari_required),
+        so a non-blocking Tari can go down without kicking miners off Monero. Only acts on
+        transitions (tracked by `workers_rejected`), and Docker treats a repeat stop/start as
+        already-done (HTTP 304), so it's safe every cycle.
         """
-        reject_monero = REJECT_WORKERS_ON_MONERO_DOWN
-        reject_tari = REJECT_WORKERS_ON_TARI_DOWN
-        if not (reject_monero or reject_tari):
-            return
-
-        should_reject = (monero_down and reject_monero) or (tari_down and reject_tari)
+        should_reject = monero_down or (tari_down and TARI_REQUIRED)
 
         if should_reject and not self.workers_rejected:
             logger.warning(
@@ -88,15 +97,62 @@ class DataService:
 
         # Readmit only once every node we reject on is confirmed healthy (not merely 'not
         # down'), so a dashboard restart mid-outage doesn't bring workers back to a still-down
-        # stack. A node whose toggle is off is ignored here.
-        recovered = ((not reject_monero) or self.monero_health.healthy) and \
-                    ((not reject_tari) or self.tari_health.healthy)
+        # stack. Tari's health is ignored when it's non-blocking.
+        recovered = self.monero_health.healthy and \
+                    ((not TARI_REQUIRED) or self.tari_health.healthy)
         if self.workers_rejected and recovered:
             logger.info(
                 f"Required nodes recovered — starting {REJECT_WORKERS_CONTAINER} to readmit workers."
             )
             if await self.docker_control.start(REJECT_WORKERS_CONTAINER):
                 self.workers_rejected = False
+
+    async def _apply_sync_gate(self, gate_satisfied):
+        """
+        Hold p2pool + xmrig-proxy stopped until the required chain(s) have fully synced once,
+        then start them (Issue #35). Keeps p2pool from flooding Tari's logs with merge-mining
+        junk during the long initial sync, when it can't usefully mine anyway.
+
+        `gate_satisfied` is True once monerod is synced AND Tari is synced-or-non-blocking — so
+        a non-blocking Tari (dashboard.tari_required:false) releases the miner as soon as
+        monerod is ready and lets Tari finish in the background.
+
+        One-way latch: once released we never re-hold, so this can't fight #31 (a transient
+        node-down later stops only xmrig-proxy and keeps p2pool on the sidechain — that's #31's
+        job, gated behind `miner_released` by the caller). While holding we re-assert the stop
+        every cycle (quietly), so a `docker compose up` mid-sync — which would restart the held
+        containers — is undone within a cycle.
+
+        `gate_satisfied` must be derived from the *raw* per-node sync signals (RPC/gRPC), not
+        the network-height UI override: that override is fed by p2pool's own stats file, so
+        while p2pool is held it would read 0 and falsely report Monero as syncing forever.
+        """
+        if self.miner_released:
+            return
+
+        if gate_satisfied:
+            ok = True
+            for container in SYNC_GATE_CONTAINERS:
+                ok = (await self.docker_control.start(container)) and ok
+            if ok:
+                self.miner_released = True
+                self.miner_held = False
+                logger.info(
+                    f"Required chain(s) synced — starting {', '.join(SYNC_GATE_CONTAINERS)}; mining can begin."
+                )
+            # On a partial-start failure leave the latch closed so the next cycle retries.
+            return
+
+        # Still syncing: keep the miner held. Log the human-facing notice only on the first
+        # cycle of a hold; the per-cycle re-assert stops are quiet to avoid flooding the log.
+        for container in SYNC_GATE_CONTAINERS:
+            await self.docker_control.stop(container, quiet=self.miner_held)
+        if not self.miner_held:
+            self.miner_held = True
+            logger.info(
+                f"Required chain(s) still syncing — holding {', '.join(SYNC_GATE_CONTAINERS)} "
+                f"until synced."
+            )
 
     async def run(self):
         """
@@ -229,6 +285,16 @@ class DataService:
                     monero_sync = await get_monero_sync_status()
                     tari_sync = await tari_client.get_sync_status()
 
+                    # Raw per-node "fully synced" signals for the sync gate (Issue #35),
+                    # captured BEFORE the network-height UI override below. A node counts as
+                    # synced only when it's reachable AND not syncing — an unreachable node
+                    # reports is_syncing=False too, and we must not mistake that for synced
+                    # (that's what #31's node-down handling is for). Reading the raw signal
+                    # also avoids a deadlock: the height override is fed by p2pool's stats
+                    # file, which reads 0 while p2pool is held — falsely "syncing" forever.
+                    monero_synced = monero_sync.get('reachable', True) and not monero_sync.get('is_syncing', False)
+                    tari_synced = tari_sync.get('reachable', True) and not tari_sync.get('is_syncing', False)
+
                     # Determine effective Tari status for UI display
                     tari_active = tari_stats.get('active', False)
                     tari_status_str = tari_stats.get('status', 'Waiting...') if tari_active else 'Waiting...'
@@ -240,10 +306,16 @@ class DataService:
                         if 'percent' not in monero_sync:
                             monero_sync.update({'percent': 0, 'current': 0, 'target': 1})
                     
-                    # 2. Global Sync Logic
+                    # 2. Global Sync Logic. monerod always drives the full-screen Sync Mode;
+                    # Tari does so only when it's required (Issue #51). A non-blocking Tari
+                    # (dashboard.tari_required:false) keeps the operational view and surfaces
+                    # its progress in the Tari panel instead of hijacking the whole dashboard.
                     is_monero_syncing = monero_sync.get('is_syncing', False)
                     is_tari_syncing = tari_sync.get('is_syncing', False)
-                    global_sync = is_monero_syncing or is_tari_syncing
+                    global_sync = is_monero_syncing or (is_tari_syncing and TARI_REQUIRED)
+                    # True when Tari is syncing but we're staying in the operational view — the
+                    # UI shows a "Tari syncing" indicator rather than the takeover screen.
+                    tari_syncing_passive = is_tari_syncing and not global_sync
 
                     if global_sync:
                         if not is_monero_syncing and 'percent' not in monero_sync:
@@ -253,14 +325,22 @@ class DataService:
                             h = tari_stats.get('height', 0)
                             tari_sync.update({'percent': 100, 'current': h, 'target': h})
 
-                    # 3. Node-down detection + optional worker rejection (Issue #31).
-                    # Debounce each node's live reachability into a stable DOWN flag, then
-                    # (if enabled) stop the proxy so workers fail over to their backups.
+                    # 3. Node-down detection + worker rejection (Issue #31). Debounce each
+                    # node's live reachability into a stable DOWN flag; monerod-down always
+                    # rejects, Tari-down rejects only when required (handled in the helper).
                     monero_down = self.monero_health.update(monero_sync.get('reachable', True))
                     tari_down = self.tari_health.update(tari_sync.get('reachable', True))
                     monero_sync['down'] = monero_down
                     tari_sync['down'] = tari_down
-                    await self._apply_worker_rejection(monero_down, tari_down)
+
+                    # 4. Sync gate (Issue #35): hold p2pool + xmrig-proxy until the required
+                    # chain(s) first sync, then release. monerod must be synced; Tari must be
+                    # synced too unless it's non-blocking. #31's runtime failover only applies
+                    # once released — before that there are no workers to fail over, and it
+                    # keeps the two features from both driving xmrig-proxy.
+                    await self._apply_sync_gate(monero_synced and (tari_synced or not TARI_REQUIRED))
+                    if self.miner_released:
+                        await self._apply_worker_rejection(monero_down, tari_down)
 
                     # Fetch fresh shares list to populate UI
                     shares_list = await asyncio.to_thread(self.state_manager.get_shares)
@@ -276,7 +356,10 @@ class DataService:
                         "monero_sync": monero_sync,
                         "tari_sync": tari_sync,
                         "global_sync": global_sync,
+                        "tari_syncing_passive": tari_syncing_passive,
                         "workers_rejected": self.workers_rejected,
+                        "miner_released": self.miner_released,
+                        "miner_held": self.miner_held,
                         "system": {
                             "disk": get_disk_usage(),
                             "hugepages": get_hugepages_status(),

--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -583,6 +583,19 @@ async def handle_index(request):
             header_badges += '<span class="badge badge-bad badge-pool">Tari DOWN</span>'
         if data.get('workers_rejected'):
             header_badges += '<span class="badge badge-bad badge-pool" title="Workers rejected so they fail over to their backup pools">Workers rejected</span>'
+        # Miner held until the required chain(s) finish their initial sync (Issue #35).
+        if data.get('miner_held'):
+            header_badges += '<span class="badge badge-warn badge-pool" title="p2pool and xmrig-proxy are held until the required chains finish syncing">Miner held (sync)</span>'
+        # Non-blocking Tari (Issue #51): Tari is (re)syncing but we stay in the operational
+        # view — surface it as a top-bar badge instead of the full-screen takeover. Show the
+        # progress percentage once it's known (omitted early on, before a target height, so it
+        # doesn't read a misleading "0%").
+        if data.get('tari_syncing_passive'):
+            t_pct = tari_sync.get('percent', 0)
+            label = f'Tari syncing {t_pct}%' if t_pct > 0 else 'Tari syncing'
+            header_badges += (f'<span class="badge badge-warn badge-pool" '
+                              f'title="Tari is still syncing — merge mining resumes when it catches up; '
+                              f'Monero mining continues">{label}</span>')
 
         template = get_cached_template()
         

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -22,7 +22,12 @@ def _make_service():
     state_manager.get_xvb_stats.return_value = {"current_mode": "P2POOL"}
     proxy_client = MagicMock()
     xvb_client = MagicMock()
-    return DataService(state_manager, proxy_client, xvb_client), state_manager, proxy_client
+    svc = DataService(state_manager, proxy_client, xvb_client)
+    # Mock the docker-control proxy so run()'s sync gate / failover don't hit the network.
+    svc.docker_control = MagicMock()
+    svc.docker_control.stop = AsyncMock(return_value=True)
+    svc.docker_control.start = AsyncMock(return_value=True)
+    return svc, state_manager, proxy_client
 
 
 class TestInit:
@@ -47,6 +52,20 @@ class TestInit:
         svc = DataService(sm, MagicMock(), MagicMock())
         assert svc.workers_rejected is True
 
+    def test_restores_miner_released_latch(self):
+        # A restart after the miner was released must NOT re-hold a running, mining stack (#35).
+        sm = MagicMock()
+        sm.load_snapshot.return_value = {"miner_released": True}
+        svc = DataService(sm, MagicMock(), MagicMock())
+        assert svc.miner_released is True
+
+    def test_holds_miner_when_restart_mid_sync(self):
+        # Fresh state (no snapshot) → the miner is held until the gate is first satisfied.
+        sm = MagicMock()
+        sm.load_snapshot.return_value = None
+        svc = DataService(sm, MagicMock(), MagicMock())
+        assert svc.miner_released is False
+
 
 class TestWorkerRejection:
     def _svc(self):
@@ -58,41 +77,30 @@ class TestWorkerRejection:
         svc.docker_control.start = AsyncMock(return_value=True)
         return svc
 
-    def _flags(self, monero=True, tari=True):
-        # Both reject toggles patched in the data_service module namespace.
-        return (patch.object(ds_mod, "REJECT_WORKERS_ON_MONERO_DOWN", monero),
-                patch.object(ds_mod, "REJECT_WORKERS_ON_TARI_DOWN", tari))
-
-    async def test_no_action_when_both_disabled(self):
-        svc = self._svc()
-        m, t = self._flags(monero=False, tari=False)
-        with m, t:
-            await svc._apply_worker_rejection(monero_down=True, tari_down=True)
-        svc.docker_control.stop.assert_not_called()
-        assert svc.workers_rejected is False
+    def _tari(self, required=True):
+        # Tari's "is it required?" flag, patched in the data_service module namespace.
+        return patch.object(ds_mod, "TARI_REQUIRED", required)
 
     async def test_stop_when_monero_down(self):
+        # monerod is required, so its outage always rejects — even with Tari non-blocking.
         svc = self._svc()
-        m, t = self._flags()
-        with m, t, patch.object(ds_mod, "REJECT_WORKERS_CONTAINER", "xmrig-proxy"):
+        with self._tari(required=False), patch.object(ds_mod, "REJECT_WORKERS_CONTAINER", "xmrig-proxy"):
             await svc._apply_worker_rejection(monero_down=True, tari_down=False)
         svc.docker_control.stop.assert_awaited_once_with("xmrig-proxy")
         assert svc.workers_rejected is True
 
-    async def test_stop_when_tari_down_and_enabled(self):
+    async def test_stop_when_tari_down_and_required(self):
         svc = self._svc()
-        m, t = self._flags()
-        with m, t:
+        with self._tari(required=True):
             await svc._apply_worker_rejection(monero_down=False, tari_down=True)
         svc.docker_control.stop.assert_awaited_once()
         assert svc.workers_rejected is True
 
-    async def test_tari_down_ignored_when_tari_toggle_off(self):
-        # Per-node: a Tari-only outage must NOT reject workers when reject-on-tari is off —
-        # we can still mine Monero on p2pool.
+    async def test_tari_down_ignored_when_non_blocking(self):
+        # A Tari-only outage must NOT reject workers when Tari is non-blocking — we can still
+        # mine Monero on p2pool.
         svc = self._svc()
-        m, t = self._flags(monero=True, tari=False)
-        with m, t:
+        with self._tari(required=False):
             await svc._apply_worker_rejection(monero_down=False, tari_down=True)
         svc.docker_control.stop.assert_not_called()
         assert svc.workers_rejected is False
@@ -100,16 +108,14 @@ class TestWorkerRejection:
     async def test_stop_failure_keeps_flag_false_for_retry(self):
         svc = self._svc()
         svc.docker_control.stop = AsyncMock(return_value=False)
-        m, t = self._flags()
-        with m, t:
+        with self._tari():
             await svc._apply_worker_rejection(monero_down=True, tari_down=False)
         assert svc.workers_rejected is False  # so the next cycle retries
 
     async def test_no_double_stop_when_already_rejected(self):
         svc = self._svc()
         svc.workers_rejected = True
-        m, t = self._flags()
-        with m, t:
+        with self._tari():
             await svc._apply_worker_rejection(monero_down=True, tari_down=True)
         svc.docker_control.stop.assert_not_called()
         svc.docker_control.start.assert_not_called()
@@ -119,8 +125,7 @@ class TestWorkerRejection:
         svc.workers_rejected = True
         svc.monero_health.healthy = True
         svc.tari_health.healthy = True
-        m, t = self._flags()
-        with m, t:
+        with self._tari(required=True):
             await svc._apply_worker_rejection(monero_down=False, tari_down=False)
         svc.docker_control.start.assert_awaited_once()
         assert svc.workers_rejected is False
@@ -132,23 +137,93 @@ class TestWorkerRejection:
         svc.workers_rejected = True
         svc.monero_health.healthy = True
         svc.tari_health.healthy = False
-        m, t = self._flags()
-        with m, t:
+        with self._tari(required=True):
             await svc._apply_worker_rejection(monero_down=False, tari_down=False)
         svc.docker_control.start.assert_not_called()
         assert svc.workers_rejected is True
 
-    async def test_readmit_ignores_node_whose_toggle_is_off(self):
-        # reject-on-tari off → Tari health is irrelevant to readmission; monero healthy is enough.
+    async def test_readmit_ignores_tari_when_non_blocking(self):
+        # Tari non-blocking → Tari health is irrelevant to readmission; monerod healthy is enough.
         svc = self._svc()
         svc.workers_rejected = True
         svc.monero_health.healthy = True
         svc.tari_health.healthy = False
-        m, t = self._flags(monero=True, tari=False)
-        with m, t:
+        with self._tari(required=False):
             await svc._apply_worker_rejection(monero_down=False, tari_down=False)
         svc.docker_control.start.assert_awaited_once()
         assert svc.workers_rejected is False
+
+    async def test_no_readmit_until_monero_healthy_even_if_tari_non_blocking(self):
+        # monerod is mandatory: never readmit while it's unconfirmed, regardless of Tari.
+        svc = self._svc()
+        svc.workers_rejected = True
+        svc.monero_health.healthy = False
+        with self._tari(required=False):
+            await svc._apply_worker_rejection(monero_down=False, tari_down=False)
+        svc.docker_control.start.assert_not_called()
+        assert svc.workers_rejected is True
+
+
+class TestSyncGate:
+    """Hold p2pool + xmrig-proxy until the required chain(s) finish their initial sync (#35)."""
+
+    def _svc(self):
+        sm = MagicMock()
+        sm.load_snapshot.return_value = None
+        svc = DataService(sm, MagicMock(), MagicMock())
+        svc.docker_control = MagicMock()
+        svc.docker_control.stop = AsyncMock(return_value=True)
+        svc.docker_control.start = AsyncMock(return_value=True)
+        return svc
+
+    async def test_holds_all_containers_when_not_synced(self):
+        svc = self._svc()
+        with patch.object(ds_mod, "SYNC_GATE_CONTAINERS", ["p2pool", "xmrig-proxy"]):
+            await svc._apply_sync_gate(gate_satisfied=False)
+        stopped = {c.args[0] for c in svc.docker_control.stop.await_args_list}
+        assert stopped == {"p2pool", "xmrig-proxy"}
+        svc.docker_control.start.assert_not_called()
+        assert svc.miner_held is True
+        assert svc.miner_released is False
+
+    async def test_releases_when_gate_satisfied(self):
+        svc = self._svc()
+        with patch.object(ds_mod, "SYNC_GATE_CONTAINERS", ["p2pool", "xmrig-proxy"]):
+            await svc._apply_sync_gate(gate_satisfied=True)
+        started = {c.args[0] for c in svc.docker_control.start.await_args_list}
+        assert started == {"p2pool", "xmrig-proxy"}
+        svc.docker_control.stop.assert_not_called()
+        assert svc.miner_released is True
+        assert svc.miner_held is False
+
+    async def test_noop_once_released(self):
+        # One-way latch: after release we never touch the containers again, so a later
+        # not-synced reading (e.g. a node blip) can't fight #31 by re-stopping the miner.
+        svc = self._svc()
+        svc.miner_released = True
+        await svc._apply_sync_gate(gate_satisfied=False)
+        await svc._apply_sync_gate(gate_satisfied=True)
+        svc.docker_control.stop.assert_not_called()
+        svc.docker_control.start.assert_not_called()
+
+    async def test_partial_start_failure_keeps_latch_closed(self):
+        # If only one container starts, stay unreleased so the next cycle retries the rest.
+        svc = self._svc()
+        svc.docker_control.start = AsyncMock(side_effect=[True, False])
+        with patch.object(ds_mod, "SYNC_GATE_CONTAINERS", ["p2pool", "xmrig-proxy"]):
+            await svc._apply_sync_gate(gate_satisfied=True)
+        assert svc.miner_released is False
+
+    async def test_rehold_stops_quietly_after_first_cycle(self):
+        # The first hold logs (quiet=False); subsequent re-asserts are quiet so a multi-hour
+        # sync doesn't flood the dashboard log.
+        svc = self._svc()
+        with patch.object(ds_mod, "SYNC_GATE_CONTAINERS", ["p2pool"]):
+            await svc._apply_sync_gate(gate_satisfied=False)
+            await svc._apply_sync_gate(gate_satisfied=False)
+        first, second = svc.docker_control.stop.await_args_list
+        assert first.kwargs.get("quiet") is False
+        assert second.kwargs.get("quiet") is True
 
 
 class TestRunIteration:
@@ -189,6 +264,122 @@ class TestRunIteration:
         assert svc.latest_data["total_live_h15"] == 2000.0
         sm.update_history.assert_called()
         sm.save_snapshot.assert_called()
+
+    async def test_run_holds_miner_while_syncing(self):
+        # A syncing Monero node → gate holds p2pool + xmrig-proxy and #31's failover stays
+        # dormant (no workers to fail over before we've even started mining).
+        svc, sm, proxy = _make_service()
+        proxy.get_workers.return_value = {"workers": []}
+        svc._apply_worker_rejection = AsyncMock()
+
+        worker_client = MagicMock()
+        worker_client.get_stats = AsyncMock(return_value={})
+        tari_client = MagicMock()
+        tari_client.get_sync_status = AsyncMock(return_value={"is_syncing": False, "reachable": True})
+        tari_client.close = AsyncMock()
+
+        with patch.object(ds_mod, "ClientSession", _FakeClientSession), \
+             patch.object(ds_mod, "XMRigWorkerClient", return_value=worker_client), \
+             patch.object(ds_mod, "TariClient", return_value=tari_client), \
+             patch.object(ds_mod, "SYNC_GATE_CONTAINERS", ["p2pool", "xmrig-proxy"]), \
+             patch.object(ds_mod, "get_stratum_stats", return_value=({}, [])), \
+             patch.object(ds_mod, "get_network_stats", return_value={"height": 100}), \
+             patch.object(ds_mod, "get_tari_stats", return_value={"active": True, "status": "OK", "height": 3}), \
+             patch.object(ds_mod, "get_p2pool_stats", return_value={"pool": {"last_share_time": 0, "difficulty": 0}}), \
+             patch.object(ds_mod, "get_monero_sync_status", AsyncMock(return_value={"is_syncing": True, "reachable": True, "percent": 50, "current": 50, "target": 100})), \
+             patch.object(ds_mod, "get_disk_usage", return_value={}), \
+             patch.object(ds_mod, "get_hugepages_status", return_value=("Enabled", "ok", "1/2")), \
+             patch.object(ds_mod, "get_memory_usage", return_value={}), \
+             patch.object(ds_mod, "get_load_average", return_value="0"), \
+             patch.object(ds_mod, "get_cpu_usage", return_value="0%"), \
+             patch("asyncio.sleep", AsyncMock(side_effect=StopAsyncIteration)):
+            with pytest.raises(StopAsyncIteration):
+                await svc.run()
+
+        stopped = {c.args[0] for c in svc.docker_control.stop.await_args_list}
+        assert stopped == {"p2pool", "xmrig-proxy"}
+        svc.docker_control.start.assert_not_called()
+        svc._apply_worker_rejection.assert_not_called()
+        assert svc.miner_released is False
+        assert svc.latest_data["miner_held"] is True
+
+    async def test_run_releases_despite_height_override(self):
+        # Both nodes are synced per their RPC/gRPC, but p2pool is held so its stats file is
+        # empty → get_network_stats height 0 trips the UI "syncing" override. The gate must
+        # key off the raw sync signals (captured before the override) or it would deadlock,
+        # never starting p2pool because p2pool isn't running. (Releases → start the miner.)
+        svc, sm, proxy = _make_service()
+        proxy.get_workers.return_value = {"workers": []}
+
+        worker_client = MagicMock()
+        worker_client.get_stats = AsyncMock(return_value={})
+        tari_client = MagicMock()
+        tari_client.get_sync_status = AsyncMock(return_value={"is_syncing": False, "reachable": True})
+        tari_client.close = AsyncMock()
+
+        with patch.object(ds_mod, "ClientSession", _FakeClientSession), \
+             patch.object(ds_mod, "XMRigWorkerClient", return_value=worker_client), \
+             patch.object(ds_mod, "TariClient", return_value=tari_client), \
+             patch.object(ds_mod, "SYNC_GATE_CONTAINERS", ["p2pool", "xmrig-proxy"]), \
+             patch.object(ds_mod, "get_stratum_stats", return_value=({}, [])), \
+             patch.object(ds_mod, "get_network_stats", return_value={"height": 0}), \
+             patch.object(ds_mod, "get_tari_stats", return_value={"active": True, "status": "OK", "height": 3}), \
+             patch.object(ds_mod, "get_p2pool_stats", return_value={"pool": {"last_share_time": 0, "difficulty": 0}}), \
+             patch.object(ds_mod, "get_monero_sync_status", AsyncMock(return_value={"is_syncing": False, "reachable": True})), \
+             patch.object(ds_mod, "get_disk_usage", return_value={}), \
+             patch.object(ds_mod, "get_hugepages_status", return_value=("Enabled", "ok", "1/2")), \
+             patch.object(ds_mod, "get_memory_usage", return_value={}), \
+             patch.object(ds_mod, "get_load_average", return_value="0"), \
+             patch.object(ds_mod, "get_cpu_usage", return_value="0%"), \
+             patch("asyncio.sleep", AsyncMock(side_effect=StopAsyncIteration)):
+            with pytest.raises(StopAsyncIteration):
+                await svc.run()
+
+        started = {c.args[0] for c in svc.docker_control.start.await_args_list}
+        assert started == {"p2pool", "xmrig-proxy"}
+        assert svc.miner_released is True
+        # The UI override still marks Monero as syncing for display — that's fine; only the
+        # gate must ignore it.
+        assert svc.latest_data["monero_sync"]["is_syncing"] is True
+
+    async def test_run_nonblocking_tari_releases_and_stays_operational(self):
+        # Monero synced, Tari still syncing, Tari non-blocking (#51): release the miner (don't
+        # wait for Tari), keep the operational view (global_sync False), and flag Tari's
+        # passive sync so the UI shows a "Tari syncing" indicator instead of the takeover.
+        svc, sm, proxy = _make_service()
+        proxy.get_workers.return_value = {"workers": []}
+
+        worker_client = MagicMock()
+        worker_client.get_stats = AsyncMock(return_value={})
+        tari_client = MagicMock()
+        tari_client.get_sync_status = AsyncMock(
+            return_value={"is_syncing": True, "reachable": True, "percent": 42, "current": 42, "target": 100})
+        tari_client.close = AsyncMock()
+
+        with patch.object(ds_mod, "ClientSession", _FakeClientSession), \
+             patch.object(ds_mod, "XMRigWorkerClient", return_value=worker_client), \
+             patch.object(ds_mod, "TariClient", return_value=tari_client), \
+             patch.object(ds_mod, "SYNC_GATE_CONTAINERS", ["p2pool", "xmrig-proxy"]), \
+             patch.object(ds_mod, "TARI_REQUIRED", False), \
+             patch.object(ds_mod, "get_stratum_stats", return_value=({}, [])), \
+             patch.object(ds_mod, "get_network_stats", return_value={"height": 100}), \
+             patch.object(ds_mod, "get_tari_stats", return_value={"active": True, "status": "OK", "height": 3}), \
+             patch.object(ds_mod, "get_p2pool_stats", return_value={"pool": {"last_share_time": 0, "difficulty": 0}}), \
+             patch.object(ds_mod, "get_monero_sync_status", AsyncMock(return_value={"is_syncing": False, "reachable": True})), \
+             patch.object(ds_mod, "get_disk_usage", return_value={}), \
+             patch.object(ds_mod, "get_hugepages_status", return_value=("Enabled", "ok", "1/2")), \
+             patch.object(ds_mod, "get_memory_usage", return_value={}), \
+             patch.object(ds_mod, "get_load_average", return_value="0"), \
+             patch.object(ds_mod, "get_cpu_usage", return_value="0%"), \
+             patch("asyncio.sleep", AsyncMock(side_effect=StopAsyncIteration)):
+            with pytest.raises(StopAsyncIteration):
+                await svc.run()
+
+        started = {c.args[0] for c in svc.docker_control.start.await_args_list}
+        assert started == {"p2pool", "xmrig-proxy"}
+        assert svc.miner_released is True
+        assert svc.latest_data["global_sync"] is False
+        assert svc.latest_data["tari_syncing_passive"] is True
 
     async def test_iteration_survives_collector_error(self):
         svc, sm, proxy = _make_service()

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -72,6 +72,35 @@ class TestIndexRoute:
         assert "Tari DOWN" not in html
         assert "Workers rejected" in html
 
+    async def test_passive_tari_syncing_badge_rendered(self, aiohttp_client):
+        # Non-blocking Tari (Issue #51): the operational view stays up and shows a top-bar
+        # "Tari syncing" badge with the live percentage instead of the Sync-Mode takeover.
+        data = {
+            "shares": [], "workers": [], "global_sync": False,
+            "monero_sync": {"percent": 100, "current": 10, "target": 10},
+            "tari_sync": {"percent": 42, "current": 42, "target": 100, "is_syncing": True},
+            "tari_syncing_passive": True,
+        }
+        sm = StateManager(db_path=":memory:")
+        cli = await aiohttp_client(create_app(sm, data))
+        html = await (await cli.get("/")).text()
+        sm.close()
+        assert "Tari syncing 42%" in html
+
+    async def test_no_passive_tari_badge_when_not_syncing(self, aiohttp_client):
+        # Default (Tari synced / blocking): no passive badge in the operational view.
+        data = {
+            "shares": [], "workers": [], "global_sync": False,
+            "monero_sync": {"percent": 100, "current": 10, "target": 10},
+            "tari_sync": {"percent": 100, "current": 10, "target": 10},
+            "tari_syncing_passive": False,
+        }
+        sm = StateManager(db_path=":memory:")
+        cli = await aiohttp_client(create_app(sm, data))
+        html = await (await cli.get("/")).text()
+        sm.close()
+        assert "Tari syncing" not in html
+
 
 class TestErrorHandling:
     async def test_render_error_is_sanitized(self, aiohttp_client, app_data):

--- a/config.advanced.example.json
+++ b/config.advanced.example.json
@@ -44,7 +44,6 @@
         "secure": true,
         "host": "auto",
         "data_dir": "auto",
-        "reject_workers_on_monero_down": true,
-        "reject_workers_on_tari_down": true
+        "tari_required": true
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,10 +221,12 @@ services:
       - DOCKER_PROXY_URL=tcp://172.28.0.30:2375
       - DOCKER_CONTROL_URL=tcp://172.28.0.31:2375
       - TARI_GRPC_ADDRESS=172.28.0.27:18142
-      # Reject workers when a required node is down so miners fail over to backups (Issue #31).
-      # Per-node, both default on; tune via dashboard.reject_workers_on_*_down in config.json.
-      - REJECT_WORKERS_ON_MONERO_DOWN=${REJECT_WORKERS_ON_MONERO_DOWN:-true}
-      - REJECT_WORKERS_ON_TARI_DOWN=${REJECT_WORKERS_ON_TARI_DOWN:-true}
+      # monerod is required: a monerod outage always rejects workers (Issue #31) and the miner
+      # is always held until monerod syncs (Issue #35) — not configurable. Tari is optional:
+      # TARI_REQUIRED (default true) decides whether a Tari outage rejects workers, whether the
+      # miner waits for Tari's sync, and whether a Tari-only sync takes over the dashboard
+      # (Issue #51). Set dashboard.tari_required:false to make Tari non-blocking.
+      - TARI_REQUIRED=${TARI_REQUIRED:-true}
 
   # --- Docker Socket Proxy (read-only) ---
   # Read-only window onto the Docker API for the dashboard's container stats/logs.
@@ -244,11 +246,12 @@ services:
         ipv4_address: 172.28.0.30
 
   # --- Docker Control Proxy (start/stop only) ---
-  # A second, minimal proxy used ONLY to stop/start xmrig-proxy for node-down worker
-  # failover (Issue #31). With POST=1 but every section (CONTAINERS, EXEC, IMAGES, …) left
-  # off, the v0.4.2 ruleset allows exactly `POST /containers/<id>/{start,stop}` and denies
-  # everything else (create/kill/exec/reads). Kept separate from the read-only proxy above
-  # so opening POST here can't widen that proxy's container access. (Reused later for #35.)
+  # A second, minimal proxy used ONLY to stop/start p2pool + xmrig-proxy: node-down worker
+  # failover (Issue #31) and holding the miner until the nodes finish syncing (Issue #35).
+  # With POST=1 but every section (CONTAINERS, EXEC, IMAGES, …) left off, the v0.4.2 ruleset
+  # allows exactly `POST /containers/<id>/{start,stop}` and denies everything else
+  # (create/kill/exec/reads). Kept separate from the read-only proxy above so opening POST
+  # here can't widen that proxy's container access.
   docker-control:
     image: tecnativa/docker-socket-proxy:v0.4.2
     container_name: docker-control

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ endpoint, and a monitoring dashboard — all behind Tor, with no public port for
 | 5 | **Tor** | A centralized anonymity layer providing SOCKS5 proxies and hidden services (onion addresses) for the other containers. |
 | 6 | **Dashboard** | The web monitoring UI and the algorithmic switching engine. |
 | 7 | **Docker Proxy** | A **read-only** proxy onto the Docker socket so the dashboard can read container stats/logs — no write access. |
-| 8 | **Docker Control** | A second, minimal socket proxy scoped to **only** `start`/`stop` (nothing else — not create/kill/exec/reads), so the dashboard can reject workers when a node is down (Issue #31). Kept separate so its write grant can't widen the read-only proxy. |
+| 8 | **Docker Control** | A second, minimal socket proxy scoped to **only** `start`/`stop` (nothing else — not create/kill/exec/reads), so the dashboard can reject workers when a node is down (Issue #31) and hold p2pool + xmrig-proxy until the chains finish syncing (Issue #35). Kept separate so its write grant can't widen the read-only proxy. |
 | 9 | **Caddy** | A reverse proxy that serves the dashboard over HTTPS (automatic local TLS) on the LAN. |
 
 ## High-level diagram

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,8 +93,7 @@ plain HTTP, edit `config.json` and run `./stack.sh apply`.
 | `dashboard.secure` | `true` | `true` serves the dashboard over HTTPS (Caddy `tls internal`); `false` uses plain HTTP. |
 | `dashboard.host` | `auto` | Hostname you use to reach the dashboard. `auto` = this machine's hostname. |
 | `dashboard.data_dir` | `auto` | Where the dashboard's database lives. `auto` = `./data/dashboard`. |
-| `dashboard.reject_workers_on_monero_down` | `true` | When a sustained monerod outage is detected, stop the `xmrig-proxy` container so miners disconnect and **fail over to their configured backup pools** instead of idling (it restarts on recovery). monerod is **required** to mine, so this defaults on. No effect for a remote node. |
-| `dashboard.reject_workers_on_tari_down` | `true` | Same, for a Tari outage. Tari is **only needed for merge mining** — you can still mine Monero on p2pool without it — so set this to `false` if you'd rather keep mining through a Tari outage. Defaults on (reject if *either* node is down). |
+| `dashboard.tari_required` | `true` | How much a Tari problem holds up the rest of the stack. Monero is **required** to mine, so its behavior isn't configurable: a monerod outage always rejects workers (stops `xmrig-proxy` so miners **fail over to their backup pools**), and the miner is always held until monerod finishes syncing. Tari is **only needed for merge mining**, so this one flag decides how much it blocks. **`true` (default):** a Tari outage also rejects workers, the miner waits for Tari's initial sync too, and a Tari-only (re)sync shows the full-screen Sync view. **`false` (non-blocking):** keep mining Monero through a Tari outage, start mining as soon as Monero is synced (Tari finishes in the background), and keep the normal dashboard — with a `Tari syncing` indicator — instead of the takeover screen. |
 
 ---
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -35,8 +35,16 @@ an eye on resources during the initial download.
 **Why this screen exists:** a Monero or Tari node can't mine until it has downloaded and verified
 the blockchain, which on a first run can take from a few hours to over a day depending on your
 hardware, disk, and network. Sync Mode makes that progress visible instead of leaving you
-guessing. Once **both** chains report fully synced, the dashboard automatically swaps Sync Mode
-for the operational view and mining begins — no refresh or restart needed.
+guessing. Once the required chains report fully synced, the dashboard automatically swaps Sync
+Mode for the operational view and mining begins — no refresh or restart needed.
+
+While the chains are syncing, the dashboard keeps `p2pool` and `xmrig-proxy` **stopped** (a
+**`Miner held (sync)`** badge shows next to the hostname) and starts them automatically once
+they're ready. Running p2pool against an unsynced node achieves nothing and floods Tari's logs
+with merge-mining chatter that buries the messages you'd actually want while debugging a sync.
+Releasing the miner is one-way — once it starts it stays up. By default the stack waits for
+**both** Monero and Tari; if you've set [`dashboard.tari_required: false`](configuration.md), it
+waits only for Monero and starts mining while Tari finishes syncing in the background.
 
 > **Want to skip most of the wait?** Point the stack at an existing synced blockchain, or connect
 > to a remote node. See [Configuration › Reusing an existing node](configuration.md#reusing-an-existing-node).
@@ -73,10 +81,15 @@ that a log line changed.
 While a node is down, the dashboard also **rejects workers** so they fail over to the backup pools
 you've configured, instead of sitting idle on a stack that can't mine for them — a sustained outage
 stops the `xmrig-proxy` container (a **`Workers rejected`** badge shows) and a confirmed recovery
-restarts it. This is **on by default**, with a per-node toggle: monerod is required to mine so
-`reject_workers_on_monero_down` defaults on, and `reject_workers_on_tari_down` defaults on too but
-can be set to `false` if you'd rather keep mining Monero through a Tari (merge-mining) outage. See
-[Configuration](configuration.md). It never triggers for a remote node.
+restarts it. monerod is required to mine, so a monerod outage always rejects. Tari is merge-mining
+gravy, so whether a Tari outage rejects follows [`dashboard.tari_required`](configuration.md): when
+it's `true` (default) a Tari outage rejects too; set it `false` to keep mining Monero straight
+through a Tari outage. (Rejection never triggers for a remote monerod — the stack doesn't manage
+that node.)
+
+**Non-blocking Tari.** With `tari_required: false`, a Tari-only (re)sync no longer takes over the
+screen: the operational view stays up, mining continues, and a **`Tari syncing`** badge shows Tari's
+progress until it catches up and merge mining resumes.
 
 ### Hashrate chart
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,7 +14,7 @@ the full list.
 | `./stack.sh restart` | Restart the stack. |
 | `./stack.sh upgrade` | Rebuild and restart the containers (run after a `git pull`). |
 | `./stack.sh logs [service]` | Follow logs for all containers, or a single service (e.g. `logs p2pool`). |
-| `./stack.sh status` | Show container status **and health-check every expected service** — warns about anything down/unhealthy and exits non-zero if so (handy for cron/monitoring). Profile-aware, and treats a stopped `xmrig-proxy` as intentional when a node is down (reject-workers failover). |
+| `./stack.sh status` | Show container status **and health-check every expected service** — warns about anything down/unhealthy and exits non-zero if so (handy for cron/monitoring). Profile-aware, and treats a stopped `p2pool`/`xmrig-proxy` as intentional during a node-down failover or while the miner is held until the chains sync. |
 | `./stack.sh reset-dashboard` | **DESTRUCTIVE** — wipes and recreates the dashboard and P2Pool data. |
 | `./stack.sh help` | Show all commands. |
 
@@ -36,8 +36,9 @@ Service names for `logs` match the containers: `monerod`, `p2pool`, `tari`, `xmr
 `status` prints the usual compose table, then a per-service health check — a green ✓ for each
 running (and healthy) service, and a ⚠/✗ for anything unhealthy, restarting, stopped, or missing.
 It exits non-zero when something needs attention, so you can wire it into a cron/monitoring check.
-A stopped `xmrig-proxy` while a node is down is reported as **intentional** (that's the
-node-down worker failover doing its job), not an error.
+A stopped `p2pool`/`xmrig-proxy` is reported as **intentional**, not an error: the dashboard stops
+it either to fail workers over a node-down outage or while the miner is held until the required
+chains finish their initial sync — check the dashboard to see which.
 
 **Start / stop / restart:**
 

--- a/stack.sh
+++ b/stack.sh
@@ -89,7 +89,8 @@ stack_upgrade() {
 # Show the compose table, then health-check every service we expect to be running and warn
 # about anything that isn't. Returns non-zero if any service needs attention (handy for cron).
 # Profile-aware (the bundled monerod only counts in local-node mode), and aware that a stopped
-# xmrig-proxy can be intentional when reject-workers (#31) has kicked in because a node is down.
+# p2pool/xmrig-proxy can be intentional: reject-workers (#31) stops xmrig-proxy when a node is
+# down, and the sync hold (#35) stops both until the required chains finish their initial sync.
 stack_status() {
     docker compose ps || true
     echo ""
@@ -103,7 +104,7 @@ stack_status() {
         return 1
     fi
 
-    local problems=0 proxy_state="" node_down=0
+    local problems=0 proxy_state="" p2pool_state="" node_down=0
     local s cid info state health
     while IFS= read -r s; do
         [ -z "$s" ] && continue
@@ -128,9 +129,14 @@ stack_status() {
             fi
         fi
 
-        # Defer the proxy verdict until we know whether a node is down.
+        # Defer the verdict for the miner containers until we know whether a node is down /
+        # the sync hold is on: a stopped p2pool or xmrig-proxy is often intentional (#31/#35).
         if [ "$s" = "xmrig-proxy" ] && [ "$state" != "running" ]; then
             proxy_state="$state"
+            continue
+        fi
+        if [ "$s" = "p2pool" ] && [ "$state" != "running" ]; then
+            p2pool_state="$state"
             continue
         fi
 
@@ -148,16 +154,21 @@ stack_status() {
         esac
     done <<< "$expected"
 
-    # A stopped xmrig-proxy is expected when reject-workers (#31) stopped it because a node is
-    # down — flag it loudly only when the nodes actually look fine.
-    if [ -n "$proxy_state" ]; then
+    # A stopped p2pool/xmrig-proxy is normally intentional: the dashboard stops xmrig-proxy to
+    # fail workers over a node-down (#31), and holds the miner until the required chains finish
+    # syncing (#35). We can't tell those apart from a genuine fault here (a healthy node can
+    # still be syncing), so report it as likely-intentional and point at the dashboard.
+    local held name st why
+    for held in "p2pool=$p2pool_state" "xmrig-proxy=$proxy_state"; do
+        name=${held%%=*}; st=${held#*=}
+        [ -z "$st" ] && continue
         if [ "$node_down" -eq 1 ]; then
-            printf '  %b⚠%b %-13s %s — likely intentional: a node is down, so workers were rejected to fail over to backups\n' "$C_YELLOW" "$C_RESET" "xmrig-proxy" "$proxy_state"
+            why="a node is down, so workers were rejected to fail over to backups"
         else
-            printf '  %b✗%b %-13s %s — but nodes look healthy, so workers are NOT mining\n' "$C_RED" "$C_RESET" "xmrig-proxy" "$proxy_state"
-            problems=$((problems + 1))
+            why="held until the required chains finish syncing — check the dashboard"
         fi
-    fi
+        printf '  %b⚠%b %-13s %s — likely intentional: %s\n' "$C_YELLOW" "$C_RESET" "$name" "$st" "$why"
+    done
 
     echo ""
     if [ "$problems" -eq 0 ]; then
@@ -701,11 +712,12 @@ render_env() {
     xvb_donation_level=$(jq -r '.xvb.donation_level // empty' "$CONFIG_FILE")
     [ -z "$xvb_donation_level" ] && xvb_donation_level="auto"
 
-    # Reject workers when a required node is down so miners fail over to their backups (#31).
-    # Per-node (monerod required for mining; Tari optional merge-mining), both default true.
-    local reject_monero reject_tari
-    reject_monero=$(jq -r 'if .dashboard.reject_workers_on_monero_down != null then .dashboard.reject_workers_on_monero_down | tostring else "true" end' "$CONFIG_FILE")
-    reject_tari=$(jq -r 'if .dashboard.reject_workers_on_tari_down != null then .dashboard.reject_workers_on_tari_down | tostring else "true" end' "$CONFIG_FILE")
+    # How much Tari blocks the stack (#31/#35/#51). monerod is required and not configurable
+    # (a monerod outage always rejects workers; the miner always waits for monerod's sync).
+    # tari_required (default true): a Tari outage rejects workers, the miner waits for Tari's
+    # sync, and a Tari-only sync drives full Sync Mode. false = non-blocking Tari.
+    local tari_required
+    tari_required=$(jq -r 'if .dashboard.tari_required != null then .dashboard.tari_required | tostring else "true" end' "$CONFIG_FILE")
 
     log "Monero block-prep threads: $prep_threads | pool: $pool_type | mode: $MONERO_MODE"
 
@@ -728,8 +740,7 @@ XVB_POOL_URL=$xvb_url
 XVB_DONOR_ID=$xvb_donor
 XVB_ENABLED=$xvb_enabled
 XVB_DONATION_LEVEL=$xvb_donation_level
-REJECT_WORKERS_ON_MONERO_DOWN=$reject_monero
-REJECT_WORKERS_ON_TARI_DOWN=$reject_tari
+TARI_REQUIRED=$tari_required
 P2POOL_URL=172.28.0.28:3333
 PROXY_API_PORT=3344
 PROXY_AUTH_TOKEN=$PROXY_AUTH_TOKEN
@@ -890,8 +901,12 @@ describe_change() {
             msg="Monero node RPC credential updated ($key)." ;;
         XVB_ENABLED|XVB_POOL_URL|XVB_DONOR_ID|XVB_DONATION_LEVEL)
             msg="XMRvsBeast setting ($key): $old → $new." ;;
-        REJECT_WORKERS_ON_MONERO_DOWN|REJECT_WORKERS_ON_TARI_DOWN)
-            msg="$key → $new — when on, that node being down stops xmrig-proxy so miners fail over to their backups." ;;
+        TARI_REQUIRED)
+            if [ "$new" == "true" ]; then
+                msg="Tari → required — a Tari outage rejects workers, the miner waits for Tari's sync, and a Tari-only sync takes over the dashboard."
+            else
+                msg="Tari → non-blocking — keep mining Monero through a Tari outage, start as soon as Monero is synced, and keep the operational dashboard while Tari syncs."
+            fi ;;
         DASHBOARD_SECURE)
             msg="Dashboard scheme → $([ "$new" == "true" ] && echo HTTPS || echo HTTP) (secure=$new)." ;;
         HOST_IP)

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -123,7 +123,14 @@ out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./stack.sh apply 
 assert_eq "pool flag propagated"  "$(run_sourced "$V" env_get_file "$V/.env" P2POOL_FLAGS)"  "--mini"
 assert_eq "token preserved"       "$(run_sourced "$V" env_get_file "$V/.env" PROXY_AUTH_TOKEN)" "ORIGINALTOKEN"
 assert_eq "onion preserved"       "$(run_sourced "$V" env_get_file "$V/.env" P2POOL_ONION_ADDRESS)" "p2pa.onion"
+assert_eq "tari_required default"  "$(run_sourced "$V" env_get_file "$V/.env" TARI_REQUIRED)" "true"
 assert_contains "compose up called" "$(cat "$DOCKER_LOG")" "compose up -d --remove-orphans"
+
+# Non-blocking Tari (dashboard.tari_required:false) propagates as TARI_REQUIRED=false.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan","tari_required":false} }\n' "$WALLET" > "$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./stack.sh apply -y 2>&1)"
+assert_eq "tari_required propagated false" "$(run_sourced "$V" env_get_file "$V/.env" TARI_REQUIRED)" "false"
 
 echo "== black-box: status health check =="
 # A docker stub driven by FAKE_STATES ("svc=state:health ..."; state "missing" = no container)
@@ -167,11 +174,18 @@ out="$(cd "$ST" && FAKE_STATES="$NODE_DOWN" PATH="$ST/bin:$PATH" ./stack.sh stat
 assert_rc "status: node down exits 1" "$rc" "1"
 assert_contains "status: proxy stop is intentional" "$out" "likely intentional"
 
-# Proxy stopped while nodes are healthy -> flagged as a real problem.
+# A stopped p2pool/xmrig-proxy with healthy nodes is intentional — the nodes pass their
+# healthchecks while still syncing and the dashboard holds the miner until they're synced
+# (#35), so status reports it as likely-intentional (exit 0), not a fault.
 PROXY_ONLY="${ALL_UP/xmrig-proxy=running:none/xmrig-proxy=exited:none}"
 out="$(cd "$ST" && FAKE_STATES="$PROXY_ONLY" PATH="$ST/bin:$PATH" ./stack.sh status 2>&1)"; rc=$?
-assert_rc "status: lone proxy stop exits 1" "$rc" "1"
-assert_contains "status: lone proxy stop warns" "$out" "NOT mining"
+assert_rc "status: proxy stop under sync hold exits 0" "$rc" "0"
+assert_contains "status: proxy stop notes sync hold" "$out" "finish syncing"
+
+P2POOL_ONLY="${ALL_UP/p2pool=running:none/p2pool=exited:none}"
+out="$(cd "$ST" && FAKE_STATES="$P2POOL_ONLY" PATH="$ST/bin:$PATH" ./stack.sh status 2>&1)"; rc=$?
+assert_rc "status: p2pool stop under sync hold exits 0" "$rc" "0"
+assert_contains "status: p2pool stop notes sync hold" "$out" "finish syncing"
 
 # Remote-node mode: the bundled monerod is not expected even if absent.
 printf 'DEPLOYMENT_COMPLETED=true\nCOMPOSE_PROFILES=\nHOST_IP=box.lan\n' > "$ST/.env"


### PR DESCRIPTION
## What & why

Two related improvements to how the stack behaves while the chains are still syncing:

- **#35 — Don't start p2pool/xmrig-proxy until synced.** p2pool can't mine against an unsynced monerod, and its merge-mining chatter **floods Tari's logs** for the hours-long initial sync, burying the messages you actually want while debugging. The dashboard now **holds `p2pool` + `xmrig-proxy` stopped until the required chains finish their initial sync**, then starts them automatically.
- **#51 — Non-blocking Tari UI.** When Tari is optional, a Tari-only (re)sync no longer hijacks the whole dashboard with the full-screen Sync view — the operational view stays up with a short **`Tari syncing`** top-bar badge.

## One flag instead of three

monerod is the chain you actually mine, so its behaviour isn't configurable: a **monerod outage always rejects workers**, and the **miner is always held until monerod syncs**. Tari is merge-mining gravy, so a single flag decides how much it blocks the stack:

| `dashboard.tari_required` | Worker rejection on Tari-down | Wait for Tari's sync | Tari-only sync UI |
|---|---|---|---|
| `true` (default) | yes | yes | full Sync Mode |
| `false` (non-blocking) | no — keep mining Monero | no — start once Monero syncs | operational view + `Tari syncing` badge |

This **replaces** `reject_workers_on_monero_down` and `reject_workers_on_tari_down` (and supersedes the interim `hold_miner_until_synced` idea). **Default behaviour is unchanged** — only opting into `tari_required: false` changes anything.

## How it works

- The miner is gated via the existing **`docker-control`** start/stop proxy (the one whose ruleset is scoped to `POST /containers/<id>/{start,stop}` for the #31 failover).
- The hold is a **one-way, persisted latch**: it releases on the first confirmed sync and never re-holds, so it can't fight the #31 failover (which stops only `xmrig-proxy` and keeps p2pool on the sidechain). While holding it re-asserts the stop each cycle (quietly) so a `docker compose up` mid-sync is undone within a cycle.
- The gate reads the **raw** monerod-RPC / Tari-gRPC sync signals, captured *before* the dashboard's network-height UI override — otherwise the override (fed by p2pool's own stats file, which reads 0 while p2pool is held) would mark Monero "syncing" forever and **deadlock** the gate.
- A node counts as synced only when **reachable AND not syncing**, so an unreachable node (which also reports `is_syncing: false`) is handled by the #31 failover, not mistaken for synced.

## Tests

`make test` is green:
- **212 dashboard tests** (87.6% coverage, ≥80% gate) — incl. the sync gate (hold/release/latch/partial-start/quiet re-assert), the consolidated worker-rejection rules, the height-override deadlock guard, the non-blocking-Tari run path, and the new `Tari syncing` badge.
- **39 stack-shell tests** — `status` reports a held miner as intentional, and `tari_required` propagation.
- **shellcheck** + **docker-compose** interpolation validation.

## Docs

Updated `docs/configuration.md` (single `dashboard.tari_required` row), `docs/dashboard.md` (Sync Mode hold + non-blocking Tari badge), `docs/operations.md`, `docs/architecture.md`, and `config.advanced.example.json`.

Closes #35
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)