### PR TITLE
Dashboard refactor: typed view layer + data_service worker helpers (closes #38, #39)

### DIFF
--- a/build/dashboard/README.md
+++ b/build/dashboard/README.md
@@ -13,7 +13,8 @@ mining_dashboard/
 ├── client/            # external service clients (xmrig, xmrig-proxy, xvb, tari gRPC, monerod RPC, docker control)
 ├── collector/         # local stats collectors (pools, system, docker logs)
 ├── service/           # algo_service (XvB switching), data_service (aggregation), storage_service (SQLite)
-├── web/               # aiohttp server + HTML template + static assets
+├── web/               # server.py (transport: routing + middleware), views.py (rendering:
+│                      #   typed context dataclasses + render_dashboard), HTML template, static assets
 └── helper/            # formatting utilities
 ```
 

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -19,53 +19,73 @@ from mining_dashboard.service.node_health import NodeHealthMonitor
 
 logger = logging.getLogger("DataService")
 
+# xmrig-proxy 6.x /workers rows are positional arrays; name the fields we read so the
+# normalization below isn't a wall of magic indices. A row has >= _PX_MIN_FIELDS entries.
+_PX_NAME = 0
+_PX_IP = 1
+_PX_CONNECTIONS = 2     # active connections; 0 means a stale/disconnected worker
+_PX_LAST_SHARE_MS = 7   # epoch ms of the last accepted share
+_PX_HR_1M = 8           # 1-minute hashrate, kH/s
+_PX_HR_10M = 9          # 10-minute hashrate, kH/s
+_PX_MIN_FIELDS = 13
+
+# xmrig-proxy reports hashrate in kH/s; the dashboard works in H/s.
+_KHS_TO_HS = 1000
+
+
+def _parse_proxy_list_worker(w):
+    """Parse one xmrig-proxy 6.x positional row into a worker dict.
+
+    Online/offline is derived from the active connection count, not mere presence —
+    xmrig-proxy keeps a worker in /workers with a decaying hashrate after it disconnects,
+    so a stopped miner would otherwise stay green and inflate the total. The proxy lacks a
+    10s window, so the 1-minute rate backs both h10 and h60; the 10-minute rate is h15.
+    """
+    # Last-share timestamp gives a fallback "seconds since last share" for uptime when the
+    # direct worker API isn't reachable.
+    last_share_ms = w[_PX_LAST_SHARE_MS] or 0
+    uptime_estimate = int(time.time() - last_share_ms / 1000) if last_share_ms > 0 else 0
+    return {
+        "name": w[_PX_NAME],
+        "ip": w[_PX_IP],
+        "status": "online" if w[_PX_CONNECTIONS] > 0 else "offline",
+        "h10": w[_PX_HR_1M] * _KHS_TO_HS,
+        "h60": w[_PX_HR_1M] * _KHS_TO_HS,
+        "h15": w[_PX_HR_10M] * _KHS_TO_HS,
+        "uptime": uptime_estimate,
+    }
+
+
+def _parse_legacy_dict_worker(w):
+    """Parse one legacy dict-format xmrig-proxy worker into a worker dict."""
+    hr = w.get("hashrate", [0, 0, 0])
+    return {
+        "name": w.get("id", "Unknown"),
+        "ip": w.get("ip", "0.0.0.0"),
+        "status": "online",
+        "h10": hr[0] if len(hr) > 0 else 0,
+        "h60": hr[1] if len(hr) > 1 else 0,
+        "h15": hr[2] if len(hr) > 2 else 0,
+        "uptime": w.get("uptime", 0),
+    }
+
 
 def _normalize_proxy_workers(proxy_data):
     """Normalize an xmrig-proxy ``/workers`` payload into a uniform worker list.
 
-    Handles both shapes the proxy can return: the 6.x list format (>=13 positional
-    fields) and the legacy dict format. Online/offline is derived from the active
-    connection count (``w[2]``), not mere presence — xmrig-proxy keeps a worker in
-    ``/workers`` with a decaying hashrate after it disconnects, so a stopped miner would
-    otherwise stay green and inflate the total. Proxy hashrates are kH/s and scaled to
-    H/s here. Returns ``[]`` for a missing/empty payload.
+    Dispatches each entry to the right parser for the two shapes the proxy emits — the 6.x
+    positional-list format and the legacy dict format — and drops anything that matches
+    neither (e.g. a truncated row). Returns ``[]`` for a missing/empty payload.
     """
-    workers = []
     if not proxy_data or "workers" not in proxy_data:
-        return workers
+        return []
 
+    workers = []
     for w in proxy_data["workers"]:
-        # Handle list format (XMRig Proxy 6.x+)
-        if isinstance(w, list) and len(w) >= 13:
-            # w[7] = last share timestamp (ms). Use it as a fallback "seconds since last
-            # share" for uptime when the direct worker API isn't reachable.
-            last_share_ms = w[7] if w[7] else 0
-            uptime_estimate = int(time.time() - last_share_ms / 1000) if last_share_ms > 0 else 0
-            # w[2] = active connection count.
-            connections = w[2] if len(w) > 2 else 0
-            workers.append({
-                "name": w[0],
-                "ip": w[1],
-                "status": "online" if connections > 0 else "offline",
-                # Proxy returns kH/s, convert to H/s
-                # Mapping: 1m(idx8)->10s & 60s (Proxy lacks 10s), 10m(idx9)->15m
-                "h10": w[8] * 1000,
-                "h60": w[8] * 1000,
-                "h15": w[9] * 1000,
-                "uptime": uptime_estimate
-            })
-        # Handle dict format (Legacy)
+        if isinstance(w, list) and len(w) >= _PX_MIN_FIELDS:
+            workers.append(_parse_proxy_list_worker(w))
         elif isinstance(w, dict):
-            hr = w.get("hashrate", [0, 0, 0])
-            workers.append({
-                "name": w.get("id", "Unknown"),
-                "ip": w.get("ip", "0.0.0.0"),
-                "status": "online",
-                "h10": hr[0] if len(hr) > 0 else 0,
-                "h60": hr[1] if len(hr) > 1 else 0,
-                "h15": hr[2] if len(hr) > 2 else 0,
-                "uptime": w.get("uptime", 0)
-            })
+            workers.append(_parse_legacy_dict_worker(w))
     return workers
 
 
@@ -86,7 +106,7 @@ def _merge_direct_stats(workers, results, active_pool_port):
             w['uptime'] = extra_stats.get('uptime', w['uptime'])
 
             is_proxy = extra_stats.get('kind') == 'proxy'
-            hr_scale = 1000 if is_proxy else 1
+            hr_scale = _KHS_TO_HS if is_proxy else 1
 
             hr_total = extra_stats.get('hashrate', {}).get('total', [])
             if isinstance(hr_total, list) and len(hr_total) >= 3:

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -19,6 +19,107 @@ from mining_dashboard.service.node_health import NodeHealthMonitor
 
 logger = logging.getLogger("DataService")
 
+
+def _normalize_proxy_workers(proxy_data):
+    """Normalize an xmrig-proxy ``/workers`` payload into a uniform worker list.
+
+    Handles both shapes the proxy can return: the 6.x list format (>=13 positional
+    fields) and the legacy dict format. Online/offline is derived from the active
+    connection count (``w[2]``), not mere presence — xmrig-proxy keeps a worker in
+    ``/workers`` with a decaying hashrate after it disconnects, so a stopped miner would
+    otherwise stay green and inflate the total. Proxy hashrates are kH/s and scaled to
+    H/s here. Returns ``[]`` for a missing/empty payload.
+    """
+    workers = []
+    if not proxy_data or "workers" not in proxy_data:
+        return workers
+
+    for w in proxy_data["workers"]:
+        # Handle list format (XMRig Proxy 6.x+)
+        if isinstance(w, list) and len(w) >= 13:
+            # w[7] = last share timestamp (ms). Use it as a fallback "seconds since last
+            # share" for uptime when the direct worker API isn't reachable.
+            last_share_ms = w[7] if w[7] else 0
+            uptime_estimate = int(time.time() - last_share_ms / 1000) if last_share_ms > 0 else 0
+            # w[2] = active connection count.
+            connections = w[2] if len(w) > 2 else 0
+            workers.append({
+                "name": w[0],
+                "ip": w[1],
+                "status": "online" if connections > 0 else "offline",
+                # Proxy returns kH/s, convert to H/s
+                # Mapping: 1m(idx8)->10s & 60s (Proxy lacks 10s), 10m(idx9)->15m
+                "h10": w[8] * 1000,
+                "h60": w[8] * 1000,
+                "h15": w[9] * 1000,
+                "uptime": uptime_estimate
+            })
+        # Handle dict format (Legacy)
+        elif isinstance(w, dict):
+            hr = w.get("hashrate", [0, 0, 0])
+            workers.append({
+                "name": w.get("id", "Unknown"),
+                "ip": w.get("ip", "0.0.0.0"),
+                "status": "online",
+                "h10": hr[0] if len(hr) > 0 else 0,
+                "h60": hr[1] if len(hr) > 1 else 0,
+                "h15": hr[2] if len(hr) > 2 else 0,
+                "uptime": w.get("uptime", 0)
+            })
+    return workers
+
+
+def _merge_direct_stats(workers, results, active_pool_port):
+    """Augment proxy-derived workers with direct-API stats (uptime + hashrate).
+
+    ``results`` is the per-worker output of the direct worker API, positionally aligned
+    with ``workers``. xmrig-proxy ``/1/summary`` reports kH/s while an xmrig miner reports
+    H/s; the ``kind`` field distinguishes them so we scale to H/s. If the direct API is
+    unreachable (falsy ``extra_stats``) the worker keeps its proxy-derived hashrate/uptime
+    and stays online — the proxy already confirmed it's connected and submitting shares —
+    rather than dropping out of the hashrate total and reading zero (Fixes #28). Each
+    worker is tagged with ``active_pool`` for the UI badge.
+    """
+    final_workers = []
+    for w, extra_stats in zip(workers, results):
+        if extra_stats:
+            w['uptime'] = extra_stats.get('uptime', w['uptime'])
+
+            is_proxy = extra_stats.get('kind') == 'proxy'
+            hr_scale = 1000 if is_proxy else 1
+
+            hr_total = extra_stats.get('hashrate', {}).get('total', [])
+            if isinstance(hr_total, list) and len(hr_total) >= 3:
+                w['h10'] = (hr_total[0] or 0) * hr_scale
+                w['h60'] = (hr_total[1] or 0) * hr_scale
+                w['h15'] = (hr_total[2] or 0) * hr_scale
+
+        w['active_pool'] = active_pool_port
+        final_workers.append(w)
+    return final_workers
+
+
+def _aggregate_hashrate(workers):
+    """Total live hashrate across online workers, as ``(total_h15, total_h10)``.
+
+    The headline figure prefers the 15m average, falling back to 60s then 10s when a
+    longer window hasn't accumulated yet (Priority: 15m > 60s > 10s). Offline workers
+    contribute nothing.
+    """
+    total_hr = 0
+    total_h10 = 0
+    for w in workers:
+        if w.get('status') == 'online':
+            w_hr = w.get('h15', 0)
+            if w_hr == 0:
+                w_hr = w.get('h60', 0)
+            if w_hr == 0:
+                w_hr = w.get('h10', 0)
+            total_hr += w_hr
+            total_h10 += w.get('h10', 0)
+    return total_hr, total_h10
+
+
 class DataService:
     """
     Core service responsible for aggregating mining statistics from various sources
@@ -180,47 +281,11 @@ class DataService:
                     # 1. Collect Local Statistics (High Frequency Polling)
                     stratum_raw, worker_configs = get_stratum_stats()
                     
-                    # 2. Fetch Worker Statistics from XMRig Proxy
+                    # 2. Fetch Worker Statistics from XMRig Proxy + normalize the payload.
                     proxy_workers = []
                     try:
                         proxy_data = await asyncio.to_thread(self.proxy_client.get_workers)
-                        if proxy_data and "workers" in proxy_data:
-                            for w in proxy_data["workers"]:
-                                # Handle list format (XMRig Proxy 6.x+)
-                                if isinstance(w, list) and len(w) >= 13:
-                                    # w[7] = last share timestamp (ms). Use it as a fallback
-                                    # "seconds since last share" for uptime when the direct
-                                    # worker API isn't reachable.
-                                    last_share_ms = w[7] if w[7] else 0
-                                    uptime_estimate = int(time.time() - last_share_ms / 1000) if last_share_ms > 0 else 0
-                                    # w[2] = active connection count. xmrig-proxy keeps a worker
-                                    # in /workers (with a decaying hashrate) after it disconnects,
-                                    # so mere presence != connected — use the connection count, or
-                                    # a stopped miner stays green and inflates the total.
-                                    connections = w[2] if len(w) > 2 else 0
-                                    proxy_workers.append({
-                                        "name": w[0],
-                                        "ip": w[1],
-                                        "status": "online" if connections > 0 else "offline",
-                                        # Proxy returns kH/s, convert to H/s
-                                        # Mapping: 1m(idx8)->10s & 60s (Proxy lacks 10s), 10m(idx9)->15m
-                                        "h10": w[8] * 1000,
-                                        "h60": w[8] * 1000,
-                                        "h15": w[9] * 1000,
-                                        "uptime": uptime_estimate
-                                    })
-                                # Handle dict format (Legacy)
-                                elif isinstance(w, dict):
-                                    hr = w.get("hashrate", [0, 0, 0])
-                                    proxy_workers.append({
-                                        "name": w.get("id", "Unknown"),
-                                        "ip": w.get("ip", "0.0.0.0"),
-                                        "status": "online",
-                                        "h10": hr[0] if len(hr) > 0 else 0,
-                                        "h60": hr[1] if len(hr) > 1 else 0,
-                                        "h15": hr[2] if len(hr) > 2 else 0,
-                                        "uptime": w.get("uptime", 0)
-                                    })
+                        proxy_workers = _normalize_proxy_workers(proxy_data)
                     except Exception as e:
                         logger.error(f"Proxy Data Fetch Error: {e}")
 
@@ -228,47 +293,14 @@ class DataService:
                     tasks = [worker_client.get_stats(w['ip'], w['name']) for w in proxy_workers]
                     worker_results = await asyncio.gather(*tasks)
 
-                    final_workers = []
                     current_mode = self.state_manager.get_xvb_stats().get("current_mode", "P2POOL")
-                    
                     # Determine active pool port for UI badges based on current Algo mode
                     active_pool_port = "3344" if "XVB" in current_mode else "3333"
+                    final_workers = _merge_direct_stats(proxy_workers, worker_results, active_pool_port)
 
-                    for w, extra_stats in zip(proxy_workers, worker_results):
-                        if extra_stats:
-                            w['uptime'] = extra_stats.get('uptime', w['uptime'])
-
-                            # xmrig-proxy /1/summary reports hashrate in kH/s; an xmrig miner
-                            # reports H/s. The 'kind' field distinguishes them, so scale to H/s.
-                            is_proxy = extra_stats.get('kind') == 'proxy'
-                            hr_scale = 1000 if is_proxy else 1
-
-                            hr_total = extra_stats.get('hashrate', {}).get('total', [])
-                            if isinstance(hr_total, list) and len(hr_total) >= 3:
-                                w['h10'] = (hr_total[0] or 0) * hr_scale
-                                w['h60'] = (hr_total[1] or 0) * hr_scale
-                                w['h15'] = (hr_total[2] or 0) * hr_scale
-                        # If the direct worker API is unreachable, keep the worker 'online' with
-                        # the proxy-derived hashrate/uptime (the proxy already confirmed it's
-                        # connected and submitting shares) instead of marking it 'unreachable',
-                        # which would drop it from the hashrate total and read zero. (Fixes #28.)
-
-                        w['active_pool'] = active_pool_port
-                        final_workers.append(w)
-                    
                     # 4. Calculate Aggregates (Priority: 15m > 60s > 10s)
-                    total_hr = 0
-                    total_h10 = 0
-                    for w in final_workers:
-                        if w.get('status') == 'online':
-                            w_hr = w.get('h15', 0)
-                            if w_hr == 0:
-                                w_hr = w.get('h60', 0)
-                            if w_hr == 0:
-                                w_hr = w.get('h10', 0)
-                            total_hr += w_hr
-                            total_h10 += w.get('h10', 0)
-                    
+                    total_hr, total_h10 = _aggregate_hashrate(final_workers)
+
                     # 5. Fetch Network & Sync Status
                     network_stats = get_network_stats()
                     tari_stats = get_tari_stats()

--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -1,28 +1,17 @@
 import os
-import time
-import html
 import logging
-import bisect
-import json
 from aiohttp import web
-from mining_dashboard.config.config import (
-    HOST_IP, BLOCK_PPLNS_WINDOW_MAIN, ENABLE_XVB,
-    XVB_DONATION_LEVEL, XVB_MAX_DONATION_FRACTION,
-    MONERO_PRUNE, MONERO_NODE_HOST,
-)
-from mining_dashboard.helper.utils import (
-    format_hashrate, format_duration, format_time_abs, get_tier_info,
-    resolve_target_threshold,
+from mining_dashboard.config.config import HOST_IP
+from mining_dashboard.web.views import (
+    _get_chart_context, _get_system_context, _get_pool_network_context,
+    _get_algo_context, _get_tari_context, _get_worker_rows,
+    build_sync_context, build_header_badges,
 )
 
 logger = logging.getLogger("WebServer")
 
 # Absolute path to the HTML template file
 TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "templates", "index.html")
-
-BADGE_P2POOL = '<span class="badge badge-ok">P2Pool</span>'
-BADGE_XVB = '<span class="badge badge-purple">XvB</span>'
-BADGE_UNKNOWN = '<span class="badge badge-bad">Unknown</span>'
 
 # Template Caching Mechanism
 _TEMPLATE_CACHE = None
@@ -42,462 +31,6 @@ def get_cached_template():
         logger.error(f"Error loading template: {e}")
     return _TEMPLATE_CACHE or "<h1>Template Error</h1>"
 
-def _get_chart_context(history, shares, range_arg):
-    """Filters historical data based on the selected time range, downsamples for performance, and prepares datasets."""
-    filtered_history = history
-    filtered_shares = shares
-    
-    if range_arg != 'all':
-        target_seconds = 0
-        if range_arg == '1h': target_seconds = 3600
-        elif range_arg == '24h': target_seconds = 86400
-        elif range_arg == '1w': target_seconds = 604800
-        elif range_arg == '1m': target_seconds = 2592000 
-        
-        if target_seconds > 0:
-            cutoff_timestamp = time.time() - target_seconds
-            filtered_history = [x for x in history if x['timestamp'] >= cutoff_timestamp]
-            filtered_shares = [x for x in shares if x['ts'] >= cutoff_timestamp]
-
-    # --- DOWNSAMPLING LOGIC ---
-    # Limits maximum points sent to the frontend to ensure Chart.js performance 
-    # and to dramatically reduce the HTML payload size.
-    MAX_POINTS = 800
-    if len(filtered_history) > MAX_POINTS:
-        chunk_size = len(filtered_history) / MAX_POINTS
-        downsampled = []
-        for i in range(MAX_POINTS):
-            start_idx = int(i * chunk_size)
-            end_idx = int((i + 1) * chunk_size)
-            chunk = filtered_history[start_idx:end_idx]
-            if not chunk:
-                continue
-            
-            # Average the hashrate values over the chunk
-            avg_v = sum(x.get('v', 0) for x in chunk) / len(chunk)
-            avg_vp = sum(x.get('v_p2pool', 0) for x in chunk) / len(chunk)
-            avg_vx = sum(x.get('v_xvb', 0) for x in chunk) / len(chunk)
-            
-            mid_idx = len(chunk) // 2
-            
-            downsampled.append({
-                't': chunk[mid_idx]['t'],
-                'timestamp': chunk[mid_idx]['timestamp'],
-                'v': round(avg_v, 2),
-                'v_p2pool': round(avg_vp, 2),
-                'v_xvb': round(avg_vx, 2)
-            })
-        filtered_history = downsampled
-
-    p2pool_data = []
-    xvb_data = []
-    chart_labels_list = [json.dumps(x['t']) for x in filtered_history]
-
-    for x in filtered_history:
-        v = x.get('v', 0)
-        vp = x.get('v_p2pool', 0)
-        vx = x.get('v_xvb', 0)
-        
-        # Fallback for legacy data: if breakdown is missing, assume P2Pool
-        if vp == 0 and vx == 0 and v > 0:
-            vp = v
-            
-        p2pool_data.append(str(vp))
-        xvb_data.append(str(vx))
-
-    share_y_list = ['null'] * len(filtered_history)
-    share_r_list = ['0'] * len(filtered_history)
-    share_c_list = ['0'] * len(filtered_history)
-    
-    if filtered_history and filtered_shares:
-        hist_ts = [x['timestamp'] for x in filtered_history]
-        share_counts = {}
-
-        for s in filtered_shares:
-            s_ts = s['ts']
-            idx = bisect.bisect_left(hist_ts, s_ts)
-            candidates = []
-            if idx < len(hist_ts): candidates.append(idx)
-            if idx > 0: candidates.append(idx - 1)
-            
-            if candidates:
-                closest_idx = min(candidates, key=lambda i: abs(hist_ts[i] - s_ts))
-                share_counts[closest_idx] = share_counts.get(closest_idx, 0) + 1
-
-        for idx, count in share_counts.items():
-            if idx < len(filtered_history):
-                item = filtered_history[idx]
-                v = item.get('v', 0)
-                
-                # 1. Calculate offset: Lift the triangle 10% above the line value
-                y_pos = v * 1.1 if v > 0 else 100
-                
-                r = min(6 + (count * 3), 15)
-                
-                # 2. Use the OFFSET position (y_pos) instead of the exact line value (v)
-                share_y_list[idx] = str(y_pos)
-                share_r_list[idx] = str(r)
-                share_c_list[idx] = str(count)
-
-    return {
-        'chart_labels': ",".join(chart_labels_list),
-        'chart_data': ",".join([str(x['v']) for x in filtered_history]),
-        'chart_p2pool': ",".join(p2pool_data),
-        'chart_xvb': ",".join(xvb_data),
-        'chart_shares_y': ",".join(share_y_list),
-        'chart_shares_r': ",".join(share_r_list),
-        'chart_shares_c': ",".join(share_c_list),
-        'cls_1h': 'active' if range_arg == '1h' else '',
-        'cls_24h': 'active' if range_arg == '24h' else '',
-        'cls_1w': 'active' if range_arg == '1w' else '',
-        'cls_1m': 'active' if range_arg == '1m' else ''
-    }
-
-def _get_worker_rows(workers):
-    """Generates HTML table rows for worker statistics, including status badges and hashrate metrics."""
-    worker_rows = ""
-    sorted_workers = sorted(workers, key=lambda x: (x['status'] != 'online', x['name']))
-    
-    for worker in sorted_workers:
-        try:
-            status_class = "status-ok" if worker['status'] == 'online' else "status-bad"
-            
-            # Identify and assign pool badge based on port
-            active_pool = worker.get('active_pool', '')
-            pool_badge = BADGE_UNKNOWN
-            if any(p in active_pool for p in ['3333', '37889', '37888', '37890']):
-                pool_badge = BADGE_P2POOL
-            elif any(p in active_pool for p in ['3344', '4247']):
-                pool_badge = BADGE_XVB
-            
-            name_display = f"{html.escape(worker['name'])} {pool_badge}"
-
-            # Add data-sort attributes for client-side sorting
-            uptime_val = worker.get('uptime', 0)
-            h10_val = worker.get('h10', 0)
-            h60_val = worker.get('h60', 0)
-            h15_val = worker.get('h15', 0)
-
-            # Convert IP address to integer for sorting purposes
-            try:
-                ip_parts = [int(part) for part in worker.get('ip', '0.0.0.0').split('.')]
-                ip_sort_val = (ip_parts[0] << 24) + (ip_parts[1] << 16) + (ip_parts[2] << 8) + ip_parts[3]
-            except (ValueError, IndexError, AttributeError):
-                ip_sort_val = 0
-
-            row = f"""
-            <tr class="{status_class}">
-                <td data-sort="{html.escape(worker['name'])}">{name_display}</td>
-                <td data-sort="{ip_sort_val}">{html.escape(worker['ip'])}</td>
-                <td data-sort="{uptime_val}">{format_duration(uptime_val)}</td>
-                <td data-sort="{h10_val}">{format_hashrate(h10_val)}</td>
-                <td data-sort="{h60_val}">{format_hashrate(h60_val)}</td>
-                <td data-sort="{h15_val}">{format_hashrate(h15_val)}</td>
-            </tr>
-            """
-            worker_rows += row
-        except Exception as e:
-            logger.error(f"Error processing worker {worker.get('name', 'unknown')}: {e}")
-            continue
-    return worker_rows
-
-def _get_tari_context(data):
-    """Extracts and formats Tari merge mining metrics for the dashboard."""
-    tari_stats = data.get('tari', {})
-    tari_active = tari_stats.get('active', False)
-    t_addr = tari_stats.get('address', 'Unknown')
-    t_short = t_addr if len(t_addr) <= 16 else f"{t_addr[:8]}...{t_addr[-8:]}"
-    
-    status_val = tari_stats.get('status', 'Waiting...') if tari_active else 'Waiting...'
-    if tari_active:
-        status_val = f'{status_val} <span style="font-size: 1.2em;">✔</span>'
-
-    return {
-        'tari_status': status_val,
-        'tari_status_class': "status-ok" if tari_active else "",
-        'tari_reward': f"{tari_stats.get('reward', 0):.2f} TARI",
-        'tari_height': str(tari_stats.get('height', 0)),
-        'tari_diff': f"{int(tari_stats.get('difficulty', 0)):,}",
-        'tari_wallet': t_addr,
-        'tari_wallet_short': t_short
-    }
-
-def _get_system_context(data):
-    """Extracts and formats system resource metrics (CPU, RAM, Disk, HugePages)."""
-    system = data.get('system', {})
-    
-    # Disk Usage
-    disk_usage = system.get('disk', {})
-    disk_percent = disk_usage.get('percent', 0)
-    disk_fill = "critical" if disk_percent > 90 else "warning" if disk_percent > 70 else ""
-    
-    disk_class = "text-muted"
-    disk_badge = ""
-    if disk_percent > 80:
-        disk_class = "status-bad"
-        disk_badge = '<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">High Usage</span>'
-
-    # Memory Usage
-    mem_usage = system.get('memory', {})
-    mem_percent = mem_usage.get('percent', 0)
-    
-    mem_label_class = "text-muted"
-    mem_val_class = ""
-    mem_badge = ""
-    if mem_percent > 80:
-        mem_label_class = "status-bad"
-        mem_val_class = "status-bad"
-        mem_badge = '<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">High Usage</span>'
-
-    # CPU Usage
-    cpu_str = system.get('cpu_percent', "0.0%")
-    try:
-        cpu_val = float(cpu_str.strip('%'))
-    except ValueError:
-        cpu_val = 0.0
-        
-    load_raw = system.get('load', "0.00 0.00 0.00")
-    load_parts = load_raw.split()
-    load_avg = f"1m: {load_parts[0]} 5m: {load_parts[1]} 15m: {load_parts[2]}" if len(load_parts) == 3 else load_raw
-    
-    cpu_label_class = "text-muted"
-    cpu_val_class = ""
-    cpu_badge = ""
-    if cpu_val > 80:
-        cpu_label_class = "status-bad"
-        cpu_val_class = "status-bad"
-        cpu_badge = '<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">High Usage</span>'
-
-    hugepages_info = system.get('hugepages', ["Disabled", "status-bad", "0/0"])
-    hp_status, hp_class, hp_val = hugepages_info
-
-    return {
-        'hp_status': hp_status,
-        'hp_class': hp_class,
-        'hp_val': hp_val,
-        'disk_used': disk_usage.get('used_gb', 0),
-        'disk_total': disk_usage.get('total_gb', 0),
-        'disk_p': disk_usage.get('percent_str', '0%'),
-        'disk_width': f"{disk_percent}%",
-        'disk_fill_class': disk_fill,
-        'disk_class': disk_class,
-        'disk_badge': disk_badge,
-        'mem_p': mem_usage.get('percent_str', '0%'),
-        'mem_used': f"{mem_usage.get('used_gb', 0):.1f}",
-        'mem_total': f"{mem_usage.get('total_gb', 0):.1f}",
-        'mem_label_class': mem_label_class,
-        'mem_val_class': mem_val_class,
-        'mem_badge': mem_badge,
-        'cpu_load': load_avg,
-        'cpu_percent': cpu_str,
-        'cpu_label_class': cpu_label_class,
-        'cpu_val_class': cpu_val_class,
-        'cpu_badge': cpu_badge,
-    }
-
-def _get_pool_network_context(data):
-    """Extracts and formats P2Pool, Stratum, and Monero Network metrics."""
-    pool_stats = data.get('pool', {})
-    p2p_stats = pool_stats.get('p2p', {})
-    local_pool = pool_stats.get('pool', {})
-    stratum_stats = data.get('stratum', {})
-    network_stats = data.get('network', {})
-
-    net_hash_val = str(network_stats.get('hash', 'N/A'))
-    if len(net_hash_val) > 20:
-        net_hash_val = f"{net_hash_val[:8]}...{net_hash_val[-8:]}"
-
-    s_addr = stratum_stats.get('wallet', 'Unknown')
-    s_short = s_addr if len(s_addr) <= 16 else f"{s_addr[:8]}...{s_addr[-8:]}"
-
-    workers_list = data.get('workers', [])
-    proxy_count = sum(1 for w in workers_list if w.get('status') == 'online')
-
-    # Determine block time based on pool type (Main/Mini=10s, Nano=30s)
-    pool_type = p2p_stats.get('type', 'Main')
-    block_time = 30 if pool_type == 'Nano' else 10
-
-    # Calculate shares in window
-    shares_list = data.get('shares', [])
-    pplns_window = local_pool.get('pplns_window', 2160)
-    window_duration = pplns_window * block_time
-    cutoff = time.time() - window_duration
-    shares_count = sum(1 for s in shares_list if s.get('ts', 0) >= cutoff)
-    shares_display = f"<span class='status-ok'>{shares_count}</span>" if shares_count > 0 else f"<span class='status-bad'>0</span>"
-
-    # Monero node mode: Pruned/Full from config (Issue #32), with the on-disk DB size from
-    # get_info alongside so a config/DB mismatch is visible. Only meaningful for a local node
-    # (we don't probe a remote node's RPC, so its pruning state is unknown to us).
-    monero_sync = data.get('monero_sync', {})
-    db_bytes = monero_sync.get('db_size', 0) or 0
-    if MONERO_NODE_HOST == "172.28.0.26":
-        monero_mode = "Pruned" if MONERO_PRUNE else "Full"
-    else:
-        monero_mode = "Unknown"
-    monero_db_size = f"{db_bytes / 1e9:.1f} GB" if db_bytes > 0 else "—"
-
-    # Compact header badge mirroring the mode. Hidden for a remote node (pruning unknown).
-    if monero_mode == "Pruned":
-        monero_prune_badge = ('<span class="badge badge-outline" '
-                              'title="Monero blockchain is pruned">XMR Pruned</span>')
-    elif monero_mode == "Full":
-        monero_prune_badge = ('<span class="badge badge-outline" '
-                              'title="Monero blockchain is full (not pruned)">XMR Full</span>')
-    else:
-        monero_prune_badge = ''
-
-    return {
-        'strat_h15': format_hashrate(stratum_stats.get('hashrate_15m', 0)),
-        'strat_h1h': format_hashrate(stratum_stats.get('hashrate_1h', 0)),
-        'strat_h24h': format_hashrate(stratum_stats.get('hashrate_24h', 0)),
-        'strat_shares': f"{stratum_stats.get('shares_found',0)} / {stratum_stats.get('shares_failed',0)}",
-        'strat_effort': f"{stratum_stats.get('current_effort', 0):.1f}%",
-        'strat_total_shares': stratum_stats.get('total_stratum_shares', 0),
-        'strat_reward_pct': f"{stratum_stats.get('block_reward_share_percent', 0):.4f}%",
-        'strat_conns': stratum_stats.get('connections', 0),
-        'strat_last_share': format_time_abs(stratum_stats.get('last_share_found_time', 0)),
-        'strat_total_hashes': stratum_stats.get('total_hashes', 0),
-        'strat_wallet': s_addr,
-        'strat_wallet_short': s_short,
-        'proxy_workers': proxy_count,
-        'p2p_type': p2p_stats.get('type', 'Unknown'),
-        'pool_sidechain_height': local_pool.get('sidechain_height', 0),
-        'pool_diff': f"{local_pool.get('difficulty', 0)/1e6:.2f} M",
-        'pool_hr': format_hashrate(local_pool.get('hashrate', 0)),
-        'pool_total_hashes': local_pool.get('total_hashes', 0),
-        'pool_miners': local_pool.get('miners', 0),
-        'pplns_win': f"{local_pool.get('pplns_window', 0)} ({format_duration(local_pool.get('pplns_window', 0) * block_time)})",
-        'pplns_wgt': local_pool.get('pplns_weight', 0),
-        'pool_shares_window': shares_display,
-        'pool_blocks': local_pool.get('blocks_found', 0),
-        'pool_last_blk': format_time_abs(local_pool.get('last_block_ts', 0)),
-        'p2p_peers': f"{p2p_stats.get('out_peers',0)} / {p2p_stats.get('in_peers',0)}",
-        'p2p_uptime': format_duration(p2p_stats.get('uptime', 0)),
-        'net_height': network_stats.get('height', 0),
-        'net_reward': f"{network_stats.get('reward', 0)/1e12:.4f} XMR",
-        'net_diff': f"{network_stats.get('difficulty', 0)/1e9:.2f} G",
-        'net_hash': net_hash_val,
-        'net_ts': format_time_abs(network_stats.get('timestamp', 0)),
-        'monero_mode': monero_mode,
-        'monero_db_size': monero_db_size,
-        'monero_prune_badge': monero_prune_badge,
-    }
-
-def _avg_p2pool_over_window(history, window_seconds):
-    """Time-weighted P2Pool hashrate over the trailing window, from DB history.
-
-    Averages the per-sample ``v_p2pool`` (hashrate attributed to P2Pool) for
-    samples within the window. Samples are written at a fixed cadence
-    (UPDATE_INTERVAL), so a simple mean approximates a time-weighted average.
-    Mirrors the chart's legacy-data fallback: rows predating the p2pool/xvb
-    split (v_p2pool == v_xvb == 0 but v > 0) are counted as P2Pool. (Issue #27)
-    """
-    if not history:
-        return 0.0
-
-    cutoff = time.time() - window_seconds
-    total = 0.0
-    count = 0
-    for x in history:
-        if x.get('timestamp', 0) < cutoff:
-            continue
-        vp = x.get('v_p2pool', 0) or 0
-        vx = x.get('v_xvb', 0) or 0
-        v = x.get('v', 0) or 0
-        if vp == 0 and vx == 0 and v > 0:
-            vp = v
-        total += vp
-        count += 1
-
-    return total / count if count else 0.0
-
-def _get_algo_context(data, state_mgr, history):
-    """Calculates algorithm switching logic, donation tiers, and hashrate averages."""
-    xvb_stats = state_mgr.get_xvb_stats() or {}
-    current_mode = xvb_stats.get('current_mode', 'P2POOL')
-    
-    # Colors
-    c_green = "#238636"
-    c_purple = "#a371f7"
-    c_blue = "#58a6ff"
-    c_muted = "#8b949e"
-
-    # Pool activity coloring: the active pool is colored, the inactive one muted.
-    # Symmetric — P2Pool dims when XvB is active, and vice versa (Issue #27).
-    # Checked most-specific first: "XVB (Split)" contains both "Split" and "XVB".
-    if not ENABLE_XVB:
-        current_mode = "P2POOL (XvB Disabled)"
-        mode_color = c_green
-        p2p_color = c_green
-        xvb_color = c_muted
-    elif "Split" in current_mode:
-        # Split cycle alternates pools within the window — both are active.
-        mode_color = c_blue
-        p2p_color = c_green
-        xvb_color = c_purple
-    elif "XVB" in current_mode:
-        mode_color = c_purple
-        p2p_color = c_muted
-        xvb_color = c_purple
-    else:  # P2POOL
-        mode_color = c_green
-        p2p_color = c_green
-        xvb_color = c_muted
-
-    total_hr_val = data.get('total_live_h15', 0)
-    xvb_1h_val = xvb_stats.get('avg_1h', 0)
-    xvb_24h_val = xvb_stats.get('avg_24h', 0)
-
-    # P2Pool 1h/24h averages from our own DB history: the time-weighted hashrate
-    # actually delivered to P2Pool (v_p2pool), rather than p2pool's noisy stratum
-    # estimate or a total-minus-XvB subtraction. The raw stratum reading is still
-    # shown separately in the "Stratum (15m/1h/24h)" card. (Issue #27)
-    p2p_1h_val = _avg_p2pool_over_window(history, 3600)
-    p2p_24h_val = _avg_p2pool_over_window(history, 86400)
-
-    tiers = state_mgr.get_tiers()
-    # Current tier = what XvB actually credits us (drives qualification).
-    tier_name, _ = get_tier_info(xvb_24h_val, tiers)
-    # Target tier = what the algo aims for, from the configured donation level
-    # (Issue #40 config side). "auto" = highest sustainable; an explicit tier is
-    # honored even if unsustainable, in which case we flag a low-hashrate warning.
-    target_threshold, sustainable = resolve_target_threshold(
-        tiers, total_hr_val, XVB_DONATION_LEVEL, XVB_MAX_DONATION_FRACTION
-    )
-    target_tier_name, _ = get_tier_info(target_threshold, tiers)
-
-    low_hr_badge = ''
-    if (ENABLE_XVB and XVB_DONATION_LEVEL not in ("auto", "highest")
-            and target_threshold > 0 and not sustainable):
-        low_hr_badge = (
-            '<span class="badge badge-warn" style="margin-left: 8px;" '
-            'title="Your hashrate can\'t sustain the selected XvB donation tier; '
-            'donation will fall short of it.">⚠ Hashrate low for tier</span>'
-        )
-
-    if not ENABLE_XVB:
-        tier_name = "Disabled"
-        target_tier_name = "Disabled"
-        low_hr_badge = ''
-
-    return {
-        'mode_name': current_mode,
-        'mode_color': mode_color,
-        'p2p_color': p2p_color,
-        'xvb_color': xvb_color,
-        'total_hr': format_hashrate(total_hr_val),
-        'last_update': format_time_abs(time.time()),
-        'xvb_updated': format_time_abs(xvb_stats.get('last_update', 0)),
-        'p2p_1h': format_hashrate(p2p_1h_val),
-        'p2p_24h': format_hashrate(p2p_24h_val),
-        'xvb_1h': format_hashrate(xvb_1h_val),
-        'xvb_24h': format_hashrate(xvb_24h_val),
-        'tier_name': tier_name,
-        'target_tier_name': target_tier_name,
-        'low_hr_badge': low_hr_badge,
-        'xvb_fail_count': xvb_stats.get('fail_count', 0),
-    }
-
 async def handle_index(request):
     """
     Primary Request Handler: Aggregates all context data and renders the Dashboard HTML.
@@ -506,99 +39,31 @@ async def handle_index(request):
     app = request.app
     data = app['latest_data']
     state_mgr = app['state_manager']
-    
+
     try:
         history = state_mgr.get_history()
         shares = data.get('shares', [])
         range_arg = request.query.get('range', 'all')
-        
-        # Prepare Sync Context
-        monero_sync = data.get('monero_sync', {})
-        tari_sync = data.get('tari_sync', {})
-        
+
         # Use global_sync flag from DataService to trigger dashboard sync mode
         is_syncing = data.get('global_sync', False)
-        
-        # Format Monero Sync Display. Show the checkmark only once we have real data
-        # (target > 0); before the initial heights arrive it's 0/0, which is "waiting",
-        # not "synced", so render a loading indicator rather than a false 100% check.
-        m_pct = monero_sync.get('percent', 0)
-        if monero_sync.get('target', 0) <= 0:
-            m_disp = '…'
-        elif m_pct >= 100:
-            m_disp = '<span class="status-ok" style="font-size: 3.5em; line-height: 1;">✔</span>'
-        else:
-            m_disp = f"{m_pct}%"
 
-        # Format Tari Sync Display (same 0/0 guard as Monero above)
-        t_pct = tari_sync.get('percent', 0)
-        if tari_sync.get('target', 0) <= 0:
-            t_disp = '…'
-        elif t_pct >= 100:
-            t_disp = '<span class="status-ok" style="font-size: 3.5em; line-height: 1;">✔</span>'
-        else:
-            t_disp = f"{t_pct}%"
-        
-        sync_ctx = {
-            'sync_class': 'mode-sync' if is_syncing else '',
-            'page_title': 'Mining Dashboard - Syncing' if is_syncing else 'Mining Dashboard',
-            'sync_percent': m_disp,
-            'sync_percent_val': m_pct,
-            'sync_current': monero_sync.get('current', 0),
-            'sync_target': monero_sync.get('target', 0),
-            'sync_remaining': monero_sync.get('target', 0) - monero_sync.get('current', 0),
-            'tari_sync_percent': t_disp,
-            'tari_sync_percent_val': t_pct,
-            'tari_sync_current': tari_sync.get('current', 0),
-            'tari_sync_target': tari_sync.get('target', 0),
-            'tari_sync_remaining': tari_sync.get('target', 0) - tari_sync.get('current', 0)
-        }
-
-        # Build Contexts
+        # Build Contexts (presentation logic lives in web/views.py)
+        sync_ctx = build_sync_context(
+            data.get('monero_sync', {}), data.get('tari_sync', {}), is_syncing
+        )
         chart_ctx = _get_chart_context(history, shares, range_arg)
         system_ctx = _get_system_context(data)
         pool_net_ctx = _get_pool_network_context(data)
         algo_ctx = _get_algo_context(data, state_mgr, history)
         tari_ctx = _get_tari_context(data)
-        
+
         # Dynamic Components
         worker_rows = _get_worker_rows(data.get('workers', []))
-
-        # Dynamic Header Badges
-        if is_syncing:
-            header_badges = '<span class="badge badge-warn badge-pool">Syncing...</span>'
-        else:
-            m_color = algo_ctx.get('mode_color', '')
-            m_name = algo_ctx.get('mode_name', '')
-            p_type = pool_net_ctx.get('p2p_type', '')
-            header_badges = f'<span class="badge badge-pool" style="background-color: {m_color};">{m_name}</span>'
-            header_badges += f'<span class="badge badge-outline">P2Pool {p_type}</span>'
-            header_badges += algo_ctx.get('low_hr_badge', '')
-
-        # Node-down badges (Issue #31) — shown whenever a node is unreachable, regardless
-        # of sync state, plus a notice when workers have been rejected to fail over.
-        if monero_sync.get('down'):
-            header_badges += '<span class="badge badge-bad badge-pool">monerod DOWN</span>'
-        if tari_sync.get('down'):
-            header_badges += '<span class="badge badge-bad badge-pool">Tari DOWN</span>'
-        if data.get('workers_rejected'):
-            header_badges += '<span class="badge badge-bad badge-pool" title="Workers rejected so they fail over to their backup pools">Workers rejected</span>'
-        # Miner held until the required chain(s) finish their initial sync (Issue #35).
-        if data.get('miner_held'):
-            header_badges += '<span class="badge badge-warn badge-pool" title="p2pool and xmrig-proxy are held until the required chains finish syncing">Miner held (sync)</span>'
-        # Non-blocking Tari (Issue #51): Tari is (re)syncing but we stay in the operational
-        # view — surface it as a top-bar badge instead of the full-screen takeover. Show the
-        # progress percentage once it's known (omitted early on, before a target height, so it
-        # doesn't read a misleading "0%").
-        if data.get('tari_syncing_passive'):
-            t_pct = tari_sync.get('percent', 0)
-            label = f'Tari syncing {t_pct}%' if t_pct > 0 else 'Tari syncing'
-            header_badges += (f'<span class="badge badge-warn badge-pool" '
-                              f'title="Tari is still syncing — merge mining resumes when it catches up; '
-                              f'Monero mining continues">{label}</span>')
+        header_badges = build_header_badges(data, is_syncing, algo_ctx, pool_net_ctx)
 
         template = get_cached_template()
-        
+
         response_html = template.format(
             host_ip=HOST_IP,
             header_badges=header_badges,
@@ -612,7 +77,7 @@ async def handle_index(request):
         )
 
         return web.Response(text=response_html, content_type='text/html')
-        
+
     except Exception:
         # Log the full error server-side; never leak exception details to the browser.
         logger.exception("Error rendering dashboard")
@@ -652,10 +117,10 @@ def create_app(state_manager, latest_data_ref):
     # Pass shared state objects to the app context
     app['state_manager'] = state_manager
     app['latest_data'] = latest_data_ref
-    
+
     app.add_routes([web.get('/', handle_index)])
-    
+
     static_path = os.path.join(os.path.dirname(__file__), "static")
     app.router.add_static('/static', static_path)
-    
+
     return app

--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -1,83 +1,25 @@
 import os
 import logging
 from aiohttp import web
-from mining_dashboard.config.config import HOST_IP
-from mining_dashboard.web.views import (
-    _get_chart_context, _get_system_context, _get_pool_network_context,
-    _get_algo_context, _get_tari_context, _get_worker_rows,
-    build_sync_context, build_header_badges,
-)
+
+from mining_dashboard.web.views import render_dashboard
 
 logger = logging.getLogger("WebServer")
 
-# Absolute path to the HTML template file
-TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "templates", "index.html")
-
-# Template Caching Mechanism
-_TEMPLATE_CACHE = None
-_TEMPLATE_MTIME = 0
-
-def get_cached_template():
-    """Retrieves and caches the HTML template, reloading from disk only if the file has been modified."""
-    global _TEMPLATE_CACHE, _TEMPLATE_MTIME
-    try:
-        mtime = os.path.getmtime(TEMPLATE_PATH)
-        if _TEMPLATE_CACHE is None or mtime > _TEMPLATE_MTIME:
-            with open(TEMPLATE_PATH, 'r') as f:
-                content = f.read()
-            _TEMPLATE_CACHE = content
-            _TEMPLATE_MTIME = mtime
-    except Exception as e:
-        logger.error(f"Error loading template: {e}")
-    return _TEMPLATE_CACHE or "<h1>Template Error</h1>"
 
 async def handle_index(request):
-    """
-    Primary Request Handler: Aggregates all context data and renders the Dashboard HTML.
-    Handles view modes (Sync vs. Dashboard) and time-range filtering.
-    """
+    """Render the dashboard. Pure transport: pull shared state, delegate to the view layer,
+    and turn the result (or a failure) into an HTTP response."""
     app = request.app
     data = app['latest_data']
     state_mgr = app['state_manager']
+    range_arg = request.query.get('range', 'all')
 
     try:
-        history = state_mgr.get_history()
-        shares = data.get('shares', [])
-        range_arg = request.query.get('range', 'all')
-
-        # Use global_sync flag from DataService to trigger dashboard sync mode
-        is_syncing = data.get('global_sync', False)
-
-        # Build Contexts (presentation logic lives in web/views.py)
-        sync_ctx = build_sync_context(
-            data.get('monero_sync', {}), data.get('tari_sync', {}), is_syncing
+        return web.Response(
+            text=render_dashboard(data, state_mgr, range_arg),
+            content_type='text/html',
         )
-        chart_ctx = _get_chart_context(history, shares, range_arg)
-        system_ctx = _get_system_context(data)
-        pool_net_ctx = _get_pool_network_context(data)
-        algo_ctx = _get_algo_context(data, state_mgr, history)
-        tari_ctx = _get_tari_context(data)
-
-        # Dynamic Components
-        worker_rows = _get_worker_rows(data.get('workers', []))
-        header_badges = build_header_badges(data, is_syncing, algo_ctx, pool_net_ctx)
-
-        template = get_cached_template()
-
-        response_html = template.format(
-            host_ip=HOST_IP,
-            header_badges=header_badges,
-            worker_rows=worker_rows,
-            **sync_ctx,
-            **algo_ctx,
-            **system_ctx,
-            **pool_net_ctx,
-            **tari_ctx,
-            **chart_ctx
-        )
-
-        return web.Response(text=response_html, content_type='text/html')
-
     except Exception:
         # Log the full error server-side; never leak exception details to the browser.
         logger.exception("Error rendering dashboard")
@@ -87,6 +29,7 @@ async def handle_index(request):
             status=500,
             content_type='text/html',
         )
+
 
 def _apply_security_headers(response):
     """Baseline hardening headers. CSP is self-only (Chart.js is vendored locally);

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1,0 +1,568 @@
+"""Presentation / view layer for the dashboard.
+
+Pure(-ish) builders that turn the aggregated ``latest_data`` snapshot (and a bit of
+``state_manager`` state) into the flat string maps that ``index.html`` is ``.format()``-ed
+with. Kept out of ``web/server.py`` so the request handler stays a thin shell of routing +
+middleware and this presentation logic is directly unit-testable (Issue #38).
+
+Each ``_get_*_context`` returns a plain ``dict`` whose keys are template placeholders; the
+handler merges them and unpacks into ``template.format(...)``.
+"""
+import time
+import html
+import bisect
+import json
+import logging
+
+from mining_dashboard.config.config import (
+    ENABLE_XVB, XVB_DONATION_LEVEL, XVB_MAX_DONATION_FRACTION,
+    MONERO_PRUNE, MONERO_NODE_HOST,
+)
+from mining_dashboard.helper.utils import (
+    format_hashrate, format_duration, format_time_abs, get_tier_info,
+    resolve_target_threshold,
+)
+
+logger = logging.getLogger("WebViews")
+
+BADGE_P2POOL = '<span class="badge badge-ok">P2Pool</span>'
+BADGE_XVB = '<span class="badge badge-purple">XvB</span>'
+BADGE_UNKNOWN = '<span class="badge badge-bad">Unknown</span>'
+
+
+def _get_chart_context(history, shares, range_arg):
+    """Filters historical data based on the selected time range, downsamples for performance, and prepares datasets."""
+    filtered_history = history
+    filtered_shares = shares
+
+    if range_arg != 'all':
+        target_seconds = 0
+        if range_arg == '1h': target_seconds = 3600
+        elif range_arg == '24h': target_seconds = 86400
+        elif range_arg == '1w': target_seconds = 604800
+        elif range_arg == '1m': target_seconds = 2592000
+
+        if target_seconds > 0:
+            cutoff_timestamp = time.time() - target_seconds
+            filtered_history = [x for x in history if x['timestamp'] >= cutoff_timestamp]
+            filtered_shares = [x for x in shares if x['ts'] >= cutoff_timestamp]
+
+    # --- DOWNSAMPLING LOGIC ---
+    # Limits maximum points sent to the frontend to ensure Chart.js performance
+    # and to dramatically reduce the HTML payload size.
+    MAX_POINTS = 800
+    if len(filtered_history) > MAX_POINTS:
+        chunk_size = len(filtered_history) / MAX_POINTS
+        downsampled = []
+        for i in range(MAX_POINTS):
+            start_idx = int(i * chunk_size)
+            end_idx = int((i + 1) * chunk_size)
+            chunk = filtered_history[start_idx:end_idx]
+            if not chunk:
+                continue
+
+            # Average the hashrate values over the chunk
+            avg_v = sum(x.get('v', 0) for x in chunk) / len(chunk)
+            avg_vp = sum(x.get('v_p2pool', 0) for x in chunk) / len(chunk)
+            avg_vx = sum(x.get('v_xvb', 0) for x in chunk) / len(chunk)
+
+            mid_idx = len(chunk) // 2
+
+            downsampled.append({
+                't': chunk[mid_idx]['t'],
+                'timestamp': chunk[mid_idx]['timestamp'],
+                'v': round(avg_v, 2),
+                'v_p2pool': round(avg_vp, 2),
+                'v_xvb': round(avg_vx, 2)
+            })
+        filtered_history = downsampled
+
+    p2pool_data = []
+    xvb_data = []
+    chart_labels_list = [json.dumps(x['t']) for x in filtered_history]
+
+    for x in filtered_history:
+        v = x.get('v', 0)
+        vp = x.get('v_p2pool', 0)
+        vx = x.get('v_xvb', 0)
+
+        # Fallback for legacy data: if breakdown is missing, assume P2Pool
+        if vp == 0 and vx == 0 and v > 0:
+            vp = v
+
+        p2pool_data.append(str(vp))
+        xvb_data.append(str(vx))
+
+    share_y_list = ['null'] * len(filtered_history)
+    share_r_list = ['0'] * len(filtered_history)
+    share_c_list = ['0'] * len(filtered_history)
+
+    if filtered_history and filtered_shares:
+        hist_ts = [x['timestamp'] for x in filtered_history]
+        share_counts = {}
+
+        for s in filtered_shares:
+            s_ts = s['ts']
+            idx = bisect.bisect_left(hist_ts, s_ts)
+            candidates = []
+            if idx < len(hist_ts): candidates.append(idx)
+            if idx > 0: candidates.append(idx - 1)
+
+            if candidates:
+                closest_idx = min(candidates, key=lambda i: abs(hist_ts[i] - s_ts))
+                share_counts[closest_idx] = share_counts.get(closest_idx, 0) + 1
+
+        for idx, count in share_counts.items():
+            if idx < len(filtered_history):
+                item = filtered_history[idx]
+                v = item.get('v', 0)
+
+                # 1. Calculate offset: Lift the triangle 10% above the line value
+                y_pos = v * 1.1 if v > 0 else 100
+
+                r = min(6 + (count * 3), 15)
+
+                # 2. Use the OFFSET position (y_pos) instead of the exact line value (v)
+                share_y_list[idx] = str(y_pos)
+                share_r_list[idx] = str(r)
+                share_c_list[idx] = str(count)
+
+    return {
+        'chart_labels': ",".join(chart_labels_list),
+        'chart_data': ",".join([str(x['v']) for x in filtered_history]),
+        'chart_p2pool': ",".join(p2pool_data),
+        'chart_xvb': ",".join(xvb_data),
+        'chart_shares_y': ",".join(share_y_list),
+        'chart_shares_r': ",".join(share_r_list),
+        'chart_shares_c': ",".join(share_c_list),
+        'cls_1h': 'active' if range_arg == '1h' else '',
+        'cls_24h': 'active' if range_arg == '24h' else '',
+        'cls_1w': 'active' if range_arg == '1w' else '',
+        'cls_1m': 'active' if range_arg == '1m' else ''
+    }
+
+def _get_worker_rows(workers):
+    """Generates HTML table rows for worker statistics, including status badges and hashrate metrics."""
+    worker_rows = ""
+    sorted_workers = sorted(workers, key=lambda x: (x['status'] != 'online', x['name']))
+
+    for worker in sorted_workers:
+        try:
+            status_class = "status-ok" if worker['status'] == 'online' else "status-bad"
+
+            # Identify and assign pool badge based on port
+            active_pool = worker.get('active_pool', '')
+            pool_badge = BADGE_UNKNOWN
+            if any(p in active_pool for p in ['3333', '37889', '37888', '37890']):
+                pool_badge = BADGE_P2POOL
+            elif any(p in active_pool for p in ['3344', '4247']):
+                pool_badge = BADGE_XVB
+
+            name_display = f"{html.escape(worker['name'])} {pool_badge}"
+
+            # Add data-sort attributes for client-side sorting
+            uptime_val = worker.get('uptime', 0)
+            h10_val = worker.get('h10', 0)
+            h60_val = worker.get('h60', 0)
+            h15_val = worker.get('h15', 0)
+
+            # Convert IP address to integer for sorting purposes
+            try:
+                ip_parts = [int(part) for part in worker.get('ip', '0.0.0.0').split('.')]
+                ip_sort_val = (ip_parts[0] << 24) + (ip_parts[1] << 16) + (ip_parts[2] << 8) + ip_parts[3]
+            except (ValueError, IndexError, AttributeError):
+                ip_sort_val = 0
+
+            row = f"""
+            <tr class="{status_class}">
+                <td data-sort="{html.escape(worker['name'])}">{name_display}</td>
+                <td data-sort="{ip_sort_val}">{html.escape(worker['ip'])}</td>
+                <td data-sort="{uptime_val}">{format_duration(uptime_val)}</td>
+                <td data-sort="{h10_val}">{format_hashrate(h10_val)}</td>
+                <td data-sort="{h60_val}">{format_hashrate(h60_val)}</td>
+                <td data-sort="{h15_val}">{format_hashrate(h15_val)}</td>
+            </tr>
+            """
+            worker_rows += row
+        except Exception as e:
+            logger.error(f"Error processing worker {worker.get('name', 'unknown')}: {e}")
+            continue
+    return worker_rows
+
+def _get_tari_context(data):
+    """Extracts and formats Tari merge mining metrics for the dashboard."""
+    tari_stats = data.get('tari', {})
+    tari_active = tari_stats.get('active', False)
+    t_addr = tari_stats.get('address', 'Unknown')
+    t_short = t_addr if len(t_addr) <= 16 else f"{t_addr[:8]}...{t_addr[-8:]}"
+
+    status_val = tari_stats.get('status', 'Waiting...') if tari_active else 'Waiting...'
+    if tari_active:
+        status_val = f'{status_val} <span style="font-size: 1.2em;">✔</span>'
+
+    return {
+        'tari_status': status_val,
+        'tari_status_class': "status-ok" if tari_active else "",
+        'tari_reward': f"{tari_stats.get('reward', 0):.2f} TARI",
+        'tari_height': str(tari_stats.get('height', 0)),
+        'tari_diff': f"{int(tari_stats.get('difficulty', 0)):,}",
+        'tari_wallet': t_addr,
+        'tari_wallet_short': t_short
+    }
+
+def _get_system_context(data):
+    """Extracts and formats system resource metrics (CPU, RAM, Disk, HugePages)."""
+    system = data.get('system', {})
+
+    # Disk Usage
+    disk_usage = system.get('disk', {})
+    disk_percent = disk_usage.get('percent', 0)
+    disk_fill = "critical" if disk_percent > 90 else "warning" if disk_percent > 70 else ""
+
+    disk_class = "text-muted"
+    disk_badge = ""
+    if disk_percent > 80:
+        disk_class = "status-bad"
+        disk_badge = '<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">High Usage</span>'
+
+    # Memory Usage
+    mem_usage = system.get('memory', {})
+    mem_percent = mem_usage.get('percent', 0)
+
+    mem_label_class = "text-muted"
+    mem_val_class = ""
+    mem_badge = ""
+    if mem_percent > 80:
+        mem_label_class = "status-bad"
+        mem_val_class = "status-bad"
+        mem_badge = '<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">High Usage</span>'
+
+    # CPU Usage
+    cpu_str = system.get('cpu_percent', "0.0%")
+    try:
+        cpu_val = float(cpu_str.strip('%'))
+    except ValueError:
+        cpu_val = 0.0
+
+    load_raw = system.get('load', "0.00 0.00 0.00")
+    load_parts = load_raw.split()
+    load_avg = f"1m: {load_parts[0]} 5m: {load_parts[1]} 15m: {load_parts[2]}" if len(load_parts) == 3 else load_raw
+
+    cpu_label_class = "text-muted"
+    cpu_val_class = ""
+    cpu_badge = ""
+    if cpu_val > 80:
+        cpu_label_class = "status-bad"
+        cpu_val_class = "status-bad"
+        cpu_badge = '<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">High Usage</span>'
+
+    hugepages_info = system.get('hugepages', ["Disabled", "status-bad", "0/0"])
+    hp_status, hp_class, hp_val = hugepages_info
+
+    return {
+        'hp_status': hp_status,
+        'hp_class': hp_class,
+        'hp_val': hp_val,
+        'disk_used': disk_usage.get('used_gb', 0),
+        'disk_total': disk_usage.get('total_gb', 0),
+        'disk_p': disk_usage.get('percent_str', '0%'),
+        'disk_width': f"{disk_percent}%",
+        'disk_fill_class': disk_fill,
+        'disk_class': disk_class,
+        'disk_badge': disk_badge,
+        'mem_p': mem_usage.get('percent_str', '0%'),
+        'mem_used': f"{mem_usage.get('used_gb', 0):.1f}",
+        'mem_total': f"{mem_usage.get('total_gb', 0):.1f}",
+        'mem_label_class': mem_label_class,
+        'mem_val_class': mem_val_class,
+        'mem_badge': mem_badge,
+        'cpu_load': load_avg,
+        'cpu_percent': cpu_str,
+        'cpu_label_class': cpu_label_class,
+        'cpu_val_class': cpu_val_class,
+        'cpu_badge': cpu_badge,
+    }
+
+def _get_pool_network_context(data):
+    """Extracts and formats P2Pool, Stratum, and Monero Network metrics."""
+    pool_stats = data.get('pool', {})
+    p2p_stats = pool_stats.get('p2p', {})
+    local_pool = pool_stats.get('pool', {})
+    stratum_stats = data.get('stratum', {})
+    network_stats = data.get('network', {})
+
+    net_hash_val = str(network_stats.get('hash', 'N/A'))
+    if len(net_hash_val) > 20:
+        net_hash_val = f"{net_hash_val[:8]}...{net_hash_val[-8:]}"
+
+    s_addr = stratum_stats.get('wallet', 'Unknown')
+    s_short = s_addr if len(s_addr) <= 16 else f"{s_addr[:8]}...{s_addr[-8:]}"
+
+    workers_list = data.get('workers', [])
+    proxy_count = sum(1 for w in workers_list if w.get('status') == 'online')
+
+    # Determine block time based on pool type (Main/Mini=10s, Nano=30s)
+    pool_type = p2p_stats.get('type', 'Main')
+    block_time = 30 if pool_type == 'Nano' else 10
+
+    # Calculate shares in window
+    shares_list = data.get('shares', [])
+    pplns_window = local_pool.get('pplns_window', 2160)
+    window_duration = pplns_window * block_time
+    cutoff = time.time() - window_duration
+    shares_count = sum(1 for s in shares_list if s.get('ts', 0) >= cutoff)
+    shares_display = f"<span class='status-ok'>{shares_count}</span>" if shares_count > 0 else f"<span class='status-bad'>0</span>"
+
+    # Monero node mode: Pruned/Full from config (Issue #32), with the on-disk DB size from
+    # get_info alongside so a config/DB mismatch is visible. Only meaningful for a local node
+    # (we don't probe a remote node's RPC, so its pruning state is unknown to us).
+    monero_sync = data.get('monero_sync', {})
+    db_bytes = monero_sync.get('db_size', 0) or 0
+    if MONERO_NODE_HOST == "172.28.0.26":
+        monero_mode = "Pruned" if MONERO_PRUNE else "Full"
+    else:
+        monero_mode = "Unknown"
+    monero_db_size = f"{db_bytes / 1e9:.1f} GB" if db_bytes > 0 else "—"
+
+    # Compact header badge mirroring the mode. Hidden for a remote node (pruning unknown).
+    if monero_mode == "Pruned":
+        monero_prune_badge = ('<span class="badge badge-outline" '
+                              'title="Monero blockchain is pruned">XMR Pruned</span>')
+    elif monero_mode == "Full":
+        monero_prune_badge = ('<span class="badge badge-outline" '
+                              'title="Monero blockchain is full (not pruned)">XMR Full</span>')
+    else:
+        monero_prune_badge = ''
+
+    return {
+        'strat_h15': format_hashrate(stratum_stats.get('hashrate_15m', 0)),
+        'strat_h1h': format_hashrate(stratum_stats.get('hashrate_1h', 0)),
+        'strat_h24h': format_hashrate(stratum_stats.get('hashrate_24h', 0)),
+        'strat_shares': f"{stratum_stats.get('shares_found',0)} / {stratum_stats.get('shares_failed',0)}",
+        'strat_effort': f"{stratum_stats.get('current_effort', 0):.1f}%",
+        'strat_total_shares': stratum_stats.get('total_stratum_shares', 0),
+        'strat_reward_pct': f"{stratum_stats.get('block_reward_share_percent', 0):.4f}%",
+        'strat_conns': stratum_stats.get('connections', 0),
+        'strat_last_share': format_time_abs(stratum_stats.get('last_share_found_time', 0)),
+        'strat_total_hashes': stratum_stats.get('total_hashes', 0),
+        'strat_wallet': s_addr,
+        'strat_wallet_short': s_short,
+        'proxy_workers': proxy_count,
+        'p2p_type': p2p_stats.get('type', 'Unknown'),
+        'pool_sidechain_height': local_pool.get('sidechain_height', 0),
+        'pool_diff': f"{local_pool.get('difficulty', 0)/1e6:.2f} M",
+        'pool_hr': format_hashrate(local_pool.get('hashrate', 0)),
+        'pool_total_hashes': local_pool.get('total_hashes', 0),
+        'pool_miners': local_pool.get('miners', 0),
+        'pplns_win': f"{local_pool.get('pplns_window', 0)} ({format_duration(local_pool.get('pplns_window', 0) * block_time)})",
+        'pplns_wgt': local_pool.get('pplns_weight', 0),
+        'pool_shares_window': shares_display,
+        'pool_blocks': local_pool.get('blocks_found', 0),
+        'pool_last_blk': format_time_abs(local_pool.get('last_block_ts', 0)),
+        'p2p_peers': f"{p2p_stats.get('out_peers',0)} / {p2p_stats.get('in_peers',0)}",
+        'p2p_uptime': format_duration(p2p_stats.get('uptime', 0)),
+        'net_height': network_stats.get('height', 0),
+        'net_reward': f"{network_stats.get('reward', 0)/1e12:.4f} XMR",
+        'net_diff': f"{network_stats.get('difficulty', 0)/1e9:.2f} G",
+        'net_hash': net_hash_val,
+        'net_ts': format_time_abs(network_stats.get('timestamp', 0)),
+        'monero_mode': monero_mode,
+        'monero_db_size': monero_db_size,
+        'monero_prune_badge': monero_prune_badge,
+    }
+
+def _avg_p2pool_over_window(history, window_seconds):
+    """Time-weighted P2Pool hashrate over the trailing window, from DB history.
+
+    Averages the per-sample ``v_p2pool`` (hashrate attributed to P2Pool) for
+    samples within the window. Samples are written at a fixed cadence
+    (UPDATE_INTERVAL), so a simple mean approximates a time-weighted average.
+    Mirrors the chart's legacy-data fallback: rows predating the p2pool/xvb
+    split (v_p2pool == v_xvb == 0 but v > 0) are counted as P2Pool. (Issue #27)
+    """
+    if not history:
+        return 0.0
+
+    cutoff = time.time() - window_seconds
+    total = 0.0
+    count = 0
+    for x in history:
+        if x.get('timestamp', 0) < cutoff:
+            continue
+        vp = x.get('v_p2pool', 0) or 0
+        vx = x.get('v_xvb', 0) or 0
+        v = x.get('v', 0) or 0
+        if vp == 0 and vx == 0 and v > 0:
+            vp = v
+        total += vp
+        count += 1
+
+    return total / count if count else 0.0
+
+def _get_algo_context(data, state_mgr, history):
+    """Calculates algorithm switching logic, donation tiers, and hashrate averages."""
+    xvb_stats = state_mgr.get_xvb_stats() or {}
+    current_mode = xvb_stats.get('current_mode', 'P2POOL')
+
+    # Colors
+    c_green = "#238636"
+    c_purple = "#a371f7"
+    c_blue = "#58a6ff"
+    c_muted = "#8b949e"
+
+    # Pool activity coloring: the active pool is colored, the inactive one muted.
+    # Symmetric — P2Pool dims when XvB is active, and vice versa (Issue #27).
+    # Checked most-specific first: "XVB (Split)" contains both "Split" and "XVB".
+    if not ENABLE_XVB:
+        current_mode = "P2POOL (XvB Disabled)"
+        mode_color = c_green
+        p2p_color = c_green
+        xvb_color = c_muted
+    elif "Split" in current_mode:
+        # Split cycle alternates pools within the window — both are active.
+        mode_color = c_blue
+        p2p_color = c_green
+        xvb_color = c_purple
+    elif "XVB" in current_mode:
+        mode_color = c_purple
+        p2p_color = c_muted
+        xvb_color = c_purple
+    else:  # P2POOL
+        mode_color = c_green
+        p2p_color = c_green
+        xvb_color = c_muted
+
+    total_hr_val = data.get('total_live_h15', 0)
+    xvb_1h_val = xvb_stats.get('avg_1h', 0)
+    xvb_24h_val = xvb_stats.get('avg_24h', 0)
+
+    # P2Pool 1h/24h averages from our own DB history: the time-weighted hashrate
+    # actually delivered to P2Pool (v_p2pool), rather than p2pool's noisy stratum
+    # estimate or a total-minus-XvB subtraction. The raw stratum reading is still
+    # shown separately in the "Stratum (15m/1h/24h)" card. (Issue #27)
+    p2p_1h_val = _avg_p2pool_over_window(history, 3600)
+    p2p_24h_val = _avg_p2pool_over_window(history, 86400)
+
+    tiers = state_mgr.get_tiers()
+    # Current tier = what XvB actually credits us (drives qualification).
+    tier_name, _ = get_tier_info(xvb_24h_val, tiers)
+    # Target tier = what the algo aims for, from the configured donation level
+    # (Issue #40 config side). "auto" = highest sustainable; an explicit tier is
+    # honored even if unsustainable, in which case we flag a low-hashrate warning.
+    target_threshold, sustainable = resolve_target_threshold(
+        tiers, total_hr_val, XVB_DONATION_LEVEL, XVB_MAX_DONATION_FRACTION
+    )
+    target_tier_name, _ = get_tier_info(target_threshold, tiers)
+
+    low_hr_badge = ''
+    if (ENABLE_XVB and XVB_DONATION_LEVEL not in ("auto", "highest")
+            and target_threshold > 0 and not sustainable):
+        low_hr_badge = (
+            '<span class="badge badge-warn" style="margin-left: 8px;" '
+            'title="Your hashrate can\'t sustain the selected XvB donation tier; '
+            'donation will fall short of it.">⚠ Hashrate low for tier</span>'
+        )
+
+    if not ENABLE_XVB:
+        tier_name = "Disabled"
+        target_tier_name = "Disabled"
+        low_hr_badge = ''
+
+    return {
+        'mode_name': current_mode,
+        'mode_color': mode_color,
+        'p2p_color': p2p_color,
+        'xvb_color': xvb_color,
+        'total_hr': format_hashrate(total_hr_val),
+        'last_update': format_time_abs(time.time()),
+        'xvb_updated': format_time_abs(xvb_stats.get('last_update', 0)),
+        'p2p_1h': format_hashrate(p2p_1h_val),
+        'p2p_24h': format_hashrate(p2p_24h_val),
+        'xvb_1h': format_hashrate(xvb_1h_val),
+        'xvb_24h': format_hashrate(xvb_24h_val),
+        'tier_name': tier_name,
+        'target_tier_name': target_tier_name,
+        'low_hr_badge': low_hr_badge,
+        'xvb_fail_count': xvb_stats.get('fail_count', 0),
+    }
+
+
+def build_sync_context(monero_sync, tari_sync, is_syncing):
+    """Builds the sync-mode template fields (Monero + Tari progress).
+
+    Shows the checkmark only once real data has arrived (target > 0); before the initial
+    heights are known it's 0/0, which is "waiting" — render a loading indicator rather than
+    a false 100% check.
+    """
+    # Format Monero Sync Display.
+    m_pct = monero_sync.get('percent', 0)
+    if monero_sync.get('target', 0) <= 0:
+        m_disp = '…'
+    elif m_pct >= 100:
+        m_disp = '<span class="status-ok" style="font-size: 3.5em; line-height: 1;">✔</span>'
+    else:
+        m_disp = f"{m_pct}%"
+
+    # Format Tari Sync Display (same 0/0 guard as Monero above)
+    t_pct = tari_sync.get('percent', 0)
+    if tari_sync.get('target', 0) <= 0:
+        t_disp = '…'
+    elif t_pct >= 100:
+        t_disp = '<span class="status-ok" style="font-size: 3.5em; line-height: 1;">✔</span>'
+    else:
+        t_disp = f"{t_pct}%"
+
+    return {
+        'sync_class': 'mode-sync' if is_syncing else '',
+        'page_title': 'Mining Dashboard - Syncing' if is_syncing else 'Mining Dashboard',
+        'sync_percent': m_disp,
+        'sync_percent_val': m_pct,
+        'sync_current': monero_sync.get('current', 0),
+        'sync_target': monero_sync.get('target', 0),
+        'sync_remaining': monero_sync.get('target', 0) - monero_sync.get('current', 0),
+        'tari_sync_percent': t_disp,
+        'tari_sync_percent_val': t_pct,
+        'tari_sync_current': tari_sync.get('current', 0),
+        'tari_sync_target': tari_sync.get('target', 0),
+        'tari_sync_remaining': tari_sync.get('target', 0) - tari_sync.get('current', 0)
+    }
+
+
+def build_header_badges(data, is_syncing, algo_ctx, pool_net_ctx):
+    """Builds the top-bar status badges (mode/pool, node-down, sync-hold, passive-Tari)."""
+    monero_sync = data.get('monero_sync', {})
+    tari_sync = data.get('tari_sync', {})
+
+    if is_syncing:
+        header_badges = '<span class="badge badge-warn badge-pool">Syncing...</span>'
+    else:
+        m_color = algo_ctx.get('mode_color', '')
+        m_name = algo_ctx.get('mode_name', '')
+        p_type = pool_net_ctx.get('p2p_type', '')
+        header_badges = f'<span class="badge badge-pool" style="background-color: {m_color};">{m_name}</span>'
+        header_badges += f'<span class="badge badge-outline">P2Pool {p_type}</span>'
+        header_badges += algo_ctx.get('low_hr_badge', '')
+
+    # Node-down badges (Issue #31) — shown whenever a node is unreachable, regardless
+    # of sync state, plus a notice when workers have been rejected to fail over.
+    if monero_sync.get('down'):
+        header_badges += '<span class="badge badge-bad badge-pool">monerod DOWN</span>'
+    if tari_sync.get('down'):
+        header_badges += '<span class="badge badge-bad badge-pool">Tari DOWN</span>'
+    if data.get('workers_rejected'):
+        header_badges += '<span class="badge badge-bad badge-pool" title="Workers rejected so they fail over to their backup pools">Workers rejected</span>'
+    # Miner held until the required chain(s) finish their initial sync (Issue #35).
+    if data.get('miner_held'):
+        header_badges += '<span class="badge badge-warn badge-pool" title="p2pool and xmrig-proxy are held until the required chains finish syncing">Miner held (sync)</span>'
+    # Non-blocking Tari (Issue #51): Tari is (re)syncing but we stay in the operational
+    # view — surface it as a top-bar badge instead of the full-screen takeover. Show the
+    # progress percentage once it's known (omitted early on, before a target height, so it
+    # doesn't read a misleading "0%").
+    if data.get('tari_syncing_passive'):
+        t_pct = tari_sync.get('percent', 0)
+        label = f'Tari syncing {t_pct}%' if t_pct > 0 else 'Tari syncing'
+        header_badges += (f'<span class="badge badge-warn badge-pool" '
+                          f'title="Tari is still syncing — merge mining resumes when it catches up; '
+                          f'Monero mining continues">{label}</span>')
+
+    return header_badges

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1,21 +1,24 @@
 """Presentation / view layer for the dashboard.
 
-Pure(-ish) builders that turn the aggregated ``latest_data`` snapshot (and a bit of
-``state_manager`` state) into the flat string maps that ``index.html`` is ``.format()``-ed
-with. Kept out of ``web/server.py`` so the request handler stays a thin shell of routing +
-middleware and this presentation logic is directly unit-testable (Issue #38).
+Turns the aggregated ``latest_data`` snapshot (plus a little ``state_manager`` state) into
+the flat string map that ``index.html`` is ``str.format()``-ed with, and renders it.
 
-Each ``_get_*_context`` returns a plain ``dict`` whose keys are template placeholders; the
-handler merges them and unpacks into ``template.format(...)``.
+Each dashboard section has a frozen ``*Context`` dataclass whose fields ARE that section's
+template placeholders — so the template contract is explicit and discoverable, and a
+forgotten field fails loudly at construction (a ``TypeError`` here) instead of silently
+surviving until a render-time ``KeyError`` in the 500 handler (Issue #38). ``render_dashboard``
+is the single assembly point; ``server.py`` stays pure transport (routing + middleware).
 """
+import os
 import time
 import html
 import bisect
 import json
 import logging
+from dataclasses import dataclass, asdict
 
 from mining_dashboard.config.config import (
-    ENABLE_XVB, XVB_DONATION_LEVEL, XVB_MAX_DONATION_FRACTION,
+    HOST_IP, ENABLE_XVB, XVB_DONATION_LEVEL, XVB_MAX_DONATION_FRACTION,
     MONERO_PRUNE, MONERO_NODE_HOST,
 )
 from mining_dashboard.helper.utils import (
@@ -29,53 +32,168 @@ BADGE_P2POOL = '<span class="badge badge-ok">P2Pool</span>'
 BADGE_XVB = '<span class="badge badge-purple">XvB</span>'
 BADGE_UNKNOWN = '<span class="badge badge-bad">Unknown</span>'
 
+# Mode colours: the active pool is coloured, the inactive one muted (Issue #27).
+_C_GREEN = "#238636"
+_C_PURPLE = "#a371f7"
+_C_BLUE = "#58a6ff"
+_C_MUTED = "#8b949e"
 
-def _get_chart_context(history, shares, range_arg):
-    """Filters historical data based on the selected time range, downsamples for performance, and prepares datasets."""
+# Only a local monerod's pruning state is knowable to us; a remote node isn't probed.
+_LOCAL_MONERO_HOST = "172.28.0.26"
+
+# Cap on chart points sent to the frontend — keeps Chart.js responsive and the HTML small.
+_MAX_CHART_POINTS = 800
+
+# Nano sidechain blocks are 30s; Main/Mini are 10s. Drives PPLNS-window durations.
+_BLOCK_TIME_NANO = 30
+_BLOCK_TIME_DEFAULT = 10
+
+
+# --------------------------------------------------------------------------------------
+# Template-bound context blocks. Field name == template placeholder.
+# --------------------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SyncContext:
+    sync_class: str
+    page_title: str
+    sync_percent: str
+    sync_percent_val: int
+    sync_current: int
+    sync_target: int
+    sync_remaining: int
+    tari_sync_percent: str
+    tari_sync_percent_val: int
+    tari_sync_current: int
+    tari_sync_target: int
+    tari_sync_remaining: int
+
+
+@dataclass(frozen=True)
+class ChartContext:
+    chart_labels: str
+    chart_p2pool: str
+    chart_xvb: str
+    chart_shares_y: str
+    chart_shares_r: str
+    chart_shares_c: str
+    cls_1h: str
+    cls_24h: str
+    cls_1w: str
+    cls_1m: str
+
+
+@dataclass(frozen=True)
+class SystemContext:
+    hp_status: str
+    hp_class: str
+    hp_val: str
+    disk_used: float
+    disk_total: float
+    disk_p: str
+    disk_width: str
+    disk_fill_class: str
+    disk_class: str
+    disk_badge: str
+    mem_p: str
+    mem_used: str
+    mem_total: str
+    mem_label_class: str
+    mem_val_class: str
+    mem_badge: str
+    cpu_load: str
+    cpu_percent: str
+    cpu_label_class: str
+    cpu_val_class: str
+    cpu_badge: str
+
+
+@dataclass(frozen=True)
+class PoolNetworkContext:
+    strat_h15: str
+    strat_h1h: str
+    strat_h24h: str
+    strat_shares: str
+    strat_effort: str
+    strat_total_shares: int
+    strat_reward_pct: str
+    strat_conns: int
+    strat_last_share: str
+    strat_total_hashes: int
+    strat_wallet: str
+    strat_wallet_short: str
+    proxy_workers: int
+    p2p_type: str
+    pool_sidechain_height: int
+    pool_diff: str
+    pool_hr: str
+    pool_total_hashes: int
+    pool_miners: int
+    pplns_win: str
+    pplns_wgt: int
+    pool_shares_window: str
+    pool_blocks: int
+    pool_last_blk: str
+    p2p_peers: str
+    p2p_uptime: str
+    net_height: int
+    net_reward: str
+    net_diff: str
+    net_hash: str
+    net_ts: str
+    monero_mode: str
+    monero_db_size: str
+    monero_prune_badge: str
+
+
+@dataclass(frozen=True)
+class AlgoContext:
+    mode_name: str
+    mode_color: str
+    p2p_color: str
+    xvb_color: str
+    total_hr: str
+    last_update: str
+    xvb_updated: str
+    p2p_1h: str
+    p2p_24h: str
+    xvb_1h: str
+    xvb_24h: str
+    tier_name: str
+    target_tier_name: str
+    low_hr_badge: str
+    xvb_fail_count: int
+
+
+@dataclass(frozen=True)
+class TariContext:
+    tari_status: str
+    tari_status_class: str
+    tari_reward: str
+    tari_height: str
+    tari_diff: str
+    tari_wallet: str
+    tari_wallet_short: str
+
+
+# --------------------------------------------------------------------------------------
+# Builders: raw snapshot -> context block.
+# --------------------------------------------------------------------------------------
+
+def build_chart_context(history, shares, range_arg):
+    """Filters history to the selected range, downsamples for performance, and builds the
+    Chart.js datasets (P2Pool/XvB hashrate series + share-found markers)."""
     filtered_history = history
     filtered_shares = shares
 
     if range_arg != 'all':
-        target_seconds = 0
-        if range_arg == '1h': target_seconds = 3600
-        elif range_arg == '24h': target_seconds = 86400
-        elif range_arg == '1w': target_seconds = 604800
-        elif range_arg == '1m': target_seconds = 2592000
-
+        target_seconds = {'1h': 3600, '24h': 86400, '1w': 604800, '1m': 2592000}.get(range_arg, 0)
         if target_seconds > 0:
             cutoff_timestamp = time.time() - target_seconds
             filtered_history = [x for x in history if x['timestamp'] >= cutoff_timestamp]
             filtered_shares = [x for x in shares if x['ts'] >= cutoff_timestamp]
 
-    # --- DOWNSAMPLING LOGIC ---
-    # Limits maximum points sent to the frontend to ensure Chart.js performance
-    # and to dramatically reduce the HTML payload size.
-    MAX_POINTS = 800
-    if len(filtered_history) > MAX_POINTS:
-        chunk_size = len(filtered_history) / MAX_POINTS
-        downsampled = []
-        for i in range(MAX_POINTS):
-            start_idx = int(i * chunk_size)
-            end_idx = int((i + 1) * chunk_size)
-            chunk = filtered_history[start_idx:end_idx]
-            if not chunk:
-                continue
-
-            # Average the hashrate values over the chunk
-            avg_v = sum(x.get('v', 0) for x in chunk) / len(chunk)
-            avg_vp = sum(x.get('v_p2pool', 0) for x in chunk) / len(chunk)
-            avg_vx = sum(x.get('v_xvb', 0) for x in chunk) / len(chunk)
-
-            mid_idx = len(chunk) // 2
-
-            downsampled.append({
-                't': chunk[mid_idx]['t'],
-                'timestamp': chunk[mid_idx]['timestamp'],
-                'v': round(avg_v, 2),
-                'v_p2pool': round(avg_vp, 2),
-                'v_xvb': round(avg_vx, 2)
-            })
-        filtered_history = downsampled
+    filtered_history = _downsample_history(filtered_history)
 
     p2pool_data = []
     xvb_data = []
@@ -85,63 +203,85 @@ def _get_chart_context(history, shares, range_arg):
         v = x.get('v', 0)
         vp = x.get('v_p2pool', 0)
         vx = x.get('v_xvb', 0)
-
-        # Fallback for legacy data: if breakdown is missing, assume P2Pool
+        # Fallback for legacy data: if breakdown is missing, assume P2Pool.
         if vp == 0 and vx == 0 and v > 0:
             vp = v
-
         p2pool_data.append(str(vp))
         xvb_data.append(str(vx))
 
+    share_y_list, share_r_list, share_c_list = _build_share_markers(filtered_history, filtered_shares)
+
+    return ChartContext(
+        chart_labels=",".join(chart_labels_list),
+        chart_p2pool=",".join(p2pool_data),
+        chart_xvb=",".join(xvb_data),
+        chart_shares_y=",".join(share_y_list),
+        chart_shares_r=",".join(share_r_list),
+        chart_shares_c=",".join(share_c_list),
+        cls_1h='active' if range_arg == '1h' else '',
+        cls_24h='active' if range_arg == '24h' else '',
+        cls_1w='active' if range_arg == '1w' else '',
+        cls_1m='active' if range_arg == '1m' else '',
+    )
+
+
+def _downsample_history(filtered_history):
+    """Bucket-averages history down to ``_MAX_CHART_POINTS`` to cap the HTML payload size."""
+    if len(filtered_history) <= _MAX_CHART_POINTS:
+        return filtered_history
+
+    chunk_size = len(filtered_history) / _MAX_CHART_POINTS
+    downsampled = []
+    for i in range(_MAX_CHART_POINTS):
+        chunk = filtered_history[int(i * chunk_size):int((i + 1) * chunk_size)]
+        if not chunk:
+            continue
+        mid = chunk[len(chunk) // 2]
+        downsampled.append({
+            't': mid['t'],
+            'timestamp': mid['timestamp'],
+            'v': round(sum(x.get('v', 0) for x in chunk) / len(chunk), 2),
+            'v_p2pool': round(sum(x.get('v_p2pool', 0) for x in chunk) / len(chunk), 2),
+            'v_xvb': round(sum(x.get('v_xvb', 0) for x in chunk) / len(chunk), 2),
+        })
+    return downsampled
+
+
+def _build_share_markers(filtered_history, filtered_shares):
+    """Bucket each share onto its nearest history sample, returning the per-point marker
+    arrays (y-offset, radius, count) as parallel string lists."""
     share_y_list = ['null'] * len(filtered_history)
     share_r_list = ['0'] * len(filtered_history)
     share_c_list = ['0'] * len(filtered_history)
 
-    if filtered_history and filtered_shares:
-        hist_ts = [x['timestamp'] for x in filtered_history]
-        share_counts = {}
+    if not (filtered_history and filtered_shares):
+        return share_y_list, share_r_list, share_c_list
 
-        for s in filtered_shares:
-            s_ts = s['ts']
-            idx = bisect.bisect_left(hist_ts, s_ts)
-            candidates = []
-            if idx < len(hist_ts): candidates.append(idx)
-            if idx > 0: candidates.append(idx - 1)
+    hist_ts = [x['timestamp'] for x in filtered_history]
+    share_counts = {}
+    for s in filtered_shares:
+        s_ts = s['ts']
+        idx = bisect.bisect_left(hist_ts, s_ts)
+        candidates = []
+        if idx < len(hist_ts): candidates.append(idx)
+        if idx > 0: candidates.append(idx - 1)
+        if candidates:
+            closest_idx = min(candidates, key=lambda i: abs(hist_ts[i] - s_ts))
+            share_counts[closest_idx] = share_counts.get(closest_idx, 0) + 1
 
-            if candidates:
-                closest_idx = min(candidates, key=lambda i: abs(hist_ts[i] - s_ts))
-                share_counts[closest_idx] = share_counts.get(closest_idx, 0) + 1
+    for idx, count in share_counts.items():
+        if idx < len(filtered_history):
+            v = filtered_history[idx].get('v', 0)
+            # Lift the marker 10% above the line so it doesn't sit on the curve; floor to
+            # 100 for zero-hashrate samples so it stays visible.
+            share_y_list[idx] = str(v * 1.1 if v > 0 else 100)
+            share_r_list[idx] = str(min(6 + (count * 3), 15))
+            share_c_list[idx] = str(count)
 
-        for idx, count in share_counts.items():
-            if idx < len(filtered_history):
-                item = filtered_history[idx]
-                v = item.get('v', 0)
+    return share_y_list, share_r_list, share_c_list
 
-                # 1. Calculate offset: Lift the triangle 10% above the line value
-                y_pos = v * 1.1 if v > 0 else 100
 
-                r = min(6 + (count * 3), 15)
-
-                # 2. Use the OFFSET position (y_pos) instead of the exact line value (v)
-                share_y_list[idx] = str(y_pos)
-                share_r_list[idx] = str(r)
-                share_c_list[idx] = str(count)
-
-    return {
-        'chart_labels': ",".join(chart_labels_list),
-        'chart_data': ",".join([str(x['v']) for x in filtered_history]),
-        'chart_p2pool': ",".join(p2pool_data),
-        'chart_xvb': ",".join(xvb_data),
-        'chart_shares_y': ",".join(share_y_list),
-        'chart_shares_r': ",".join(share_r_list),
-        'chart_shares_c': ",".join(share_c_list),
-        'cls_1h': 'active' if range_arg == '1h' else '',
-        'cls_24h': 'active' if range_arg == '24h' else '',
-        'cls_1w': 'active' if range_arg == '1w' else '',
-        'cls_1m': 'active' if range_arg == '1m' else ''
-    }
-
-def _get_worker_rows(workers):
+def build_worker_rows(workers):
     """Generates HTML table rows for worker statistics, including status badges and hashrate metrics."""
     worker_rows = ""
     sorted_workers = sorted(workers, key=lambda x: (x['status'] != 'online', x['name']))
@@ -160,20 +300,13 @@ def _get_worker_rows(workers):
 
             name_display = f"{html.escape(worker['name'])} {pool_badge}"
 
-            # Add data-sort attributes for client-side sorting
             uptime_val = worker.get('uptime', 0)
             h10_val = worker.get('h10', 0)
             h60_val = worker.get('h60', 0)
             h15_val = worker.get('h15', 0)
+            ip_sort_val = _ip_to_sort_int(worker.get('ip', '0.0.0.0'))
 
-            # Convert IP address to integer for sorting purposes
-            try:
-                ip_parts = [int(part) for part in worker.get('ip', '0.0.0.0').split('.')]
-                ip_sort_val = (ip_parts[0] << 24) + (ip_parts[1] << 16) + (ip_parts[2] << 8) + ip_parts[3]
-            except (ValueError, IndexError, AttributeError):
-                ip_sort_val = 0
-
-            row = f"""
+            worker_rows += f"""
             <tr class="{status_class}">
                 <td data-sort="{html.escape(worker['name'])}">{name_display}</td>
                 <td data-sort="{ip_sort_val}">{html.escape(worker['ip'])}</td>
@@ -183,107 +316,115 @@ def _get_worker_rows(workers):
                 <td data-sort="{h15_val}">{format_hashrate(h15_val)}</td>
             </tr>
             """
-            worker_rows += row
         except Exception as e:
             logger.error(f"Error processing worker {worker.get('name', 'unknown')}: {e}")
             continue
     return worker_rows
 
-def _get_tari_context(data):
+
+def _ip_to_sort_int(ip):
+    """Pack a dotted-quad IP into an int for client-side numeric sorting; 0 on malformed input."""
+    try:
+        a, b, c, d = (int(part) for part in ip.split('.'))
+        return (a << 24) + (b << 16) + (c << 8) + d
+    except (ValueError, IndexError, AttributeError):
+        return 0
+
+
+def build_tari_context(data):
     """Extracts and formats Tari merge mining metrics for the dashboard."""
     tari_stats = data.get('tari', {})
     tari_active = tari_stats.get('active', False)
     t_addr = tari_stats.get('address', 'Unknown')
-    t_short = t_addr if len(t_addr) <= 16 else f"{t_addr[:8]}...{t_addr[-8:]}"
 
     status_val = tari_stats.get('status', 'Waiting...') if tari_active else 'Waiting...'
     if tari_active:
         status_val = f'{status_val} <span style="font-size: 1.2em;">✔</span>'
 
-    return {
-        'tari_status': status_val,
-        'tari_status_class': "status-ok" if tari_active else "",
-        'tari_reward': f"{tari_stats.get('reward', 0):.2f} TARI",
-        'tari_height': str(tari_stats.get('height', 0)),
-        'tari_diff': f"{int(tari_stats.get('difficulty', 0)):,}",
-        'tari_wallet': t_addr,
-        'tari_wallet_short': t_short
-    }
+    return TariContext(
+        tari_status=status_val,
+        tari_status_class="status-ok" if tari_active else "",
+        tari_reward=f"{tari_stats.get('reward', 0):.2f} TARI",
+        tari_height=str(tari_stats.get('height', 0)),
+        tari_diff=f"{int(tari_stats.get('difficulty', 0)):,}",
+        tari_wallet=t_addr,
+        tari_wallet_short=_shorten(t_addr),
+    )
 
-def _get_system_context(data):
+
+def _shorten(addr, keep=8, threshold=16):
+    """Elide a long address to ``head...tail`` for compact display; short ones pass through."""
+    return addr if len(addr) <= threshold else f"{addr[:keep]}...{addr[-keep:]}"
+
+
+def _usage_flag(percent, threshold=80, label="High Usage"):
+    """Return the (status class, badge HTML) pair for a resource gauge over ``threshold``."""
+    if percent > threshold:
+        badge = (f'<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">'
+                 f'{label}</span>')
+        return "status-bad", badge
+    return "", ""
+
+
+def build_system_context(data):
     """Extracts and formats system resource metrics (CPU, RAM, Disk, HugePages)."""
     system = data.get('system', {})
 
-    # Disk Usage
+    # Disk
     disk_usage = system.get('disk', {})
     disk_percent = disk_usage.get('percent', 0)
     disk_fill = "critical" if disk_percent > 90 else "warning" if disk_percent > 70 else ""
+    disk_status, disk_badge = _usage_flag(disk_percent)
+    disk_class = disk_status or "text-muted"
 
-    disk_class = "text-muted"
-    disk_badge = ""
-    if disk_percent > 80:
-        disk_class = "status-bad"
-        disk_badge = '<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">High Usage</span>'
-
-    # Memory Usage
+    # Memory
     mem_usage = system.get('memory', {})
     mem_percent = mem_usage.get('percent', 0)
+    mem_status, mem_badge = _usage_flag(mem_percent)
+    mem_label_class = mem_status or "text-muted"
 
-    mem_label_class = "text-muted"
-    mem_val_class = ""
-    mem_badge = ""
-    if mem_percent > 80:
-        mem_label_class = "status-bad"
-        mem_val_class = "status-bad"
-        mem_badge = '<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">High Usage</span>'
-
-    # CPU Usage
+    # CPU
     cpu_str = system.get('cpu_percent', "0.0%")
     try:
         cpu_val = float(cpu_str.strip('%'))
     except ValueError:
         cpu_val = 0.0
+    cpu_status, cpu_badge = _usage_flag(cpu_val)
+    cpu_label_class = cpu_status or "text-muted"
 
     load_raw = system.get('load', "0.00 0.00 0.00")
     load_parts = load_raw.split()
-    load_avg = f"1m: {load_parts[0]} 5m: {load_parts[1]} 15m: {load_parts[2]}" if len(load_parts) == 3 else load_raw
+    load_avg = (f"1m: {load_parts[0]} 5m: {load_parts[1]} 15m: {load_parts[2]}"
+                if len(load_parts) == 3 else load_raw)
 
-    cpu_label_class = "text-muted"
-    cpu_val_class = ""
-    cpu_badge = ""
-    if cpu_val > 80:
-        cpu_label_class = "status-bad"
-        cpu_val_class = "status-bad"
-        cpu_badge = '<span class="badge badge-bad" style="margin-left:5px; margin-right:5px;">High Usage</span>'
+    hp_status, hp_class, hp_val = system.get('hugepages', ["Disabled", "status-bad", "0/0"])
 
-    hugepages_info = system.get('hugepages', ["Disabled", "status-bad", "0/0"])
-    hp_status, hp_class, hp_val = hugepages_info
+    return SystemContext(
+        hp_status=hp_status,
+        hp_class=hp_class,
+        hp_val=hp_val,
+        disk_used=disk_usage.get('used_gb', 0),
+        disk_total=disk_usage.get('total_gb', 0),
+        disk_p=disk_usage.get('percent_str', '0%'),
+        disk_width=f"{disk_percent}%",
+        disk_fill_class=disk_fill,
+        disk_class=disk_class,
+        disk_badge=disk_badge,
+        mem_p=mem_usage.get('percent_str', '0%'),
+        mem_used=f"{mem_usage.get('used_gb', 0):.1f}",
+        mem_total=f"{mem_usage.get('total_gb', 0):.1f}",
+        mem_label_class=mem_label_class,
+        mem_val_class=mem_status,
+        mem_badge=mem_badge,
+        cpu_load=load_avg,
+        cpu_percent=cpu_str,
+        cpu_label_class=cpu_label_class,
+        cpu_val_class=cpu_status,
+        cpu_badge=cpu_badge,
+    )
 
-    return {
-        'hp_status': hp_status,
-        'hp_class': hp_class,
-        'hp_val': hp_val,
-        'disk_used': disk_usage.get('used_gb', 0),
-        'disk_total': disk_usage.get('total_gb', 0),
-        'disk_p': disk_usage.get('percent_str', '0%'),
-        'disk_width': f"{disk_percent}%",
-        'disk_fill_class': disk_fill,
-        'disk_class': disk_class,
-        'disk_badge': disk_badge,
-        'mem_p': mem_usage.get('percent_str', '0%'),
-        'mem_used': f"{mem_usage.get('used_gb', 0):.1f}",
-        'mem_total': f"{mem_usage.get('total_gb', 0):.1f}",
-        'mem_label_class': mem_label_class,
-        'mem_val_class': mem_val_class,
-        'mem_badge': mem_badge,
-        'cpu_load': load_avg,
-        'cpu_percent': cpu_str,
-        'cpu_label_class': cpu_label_class,
-        'cpu_val_class': cpu_val_class,
-        'cpu_badge': cpu_badge,
-    }
 
-def _get_pool_network_context(data):
+def build_pool_network_context(data):
     """Extracts and formats P2Pool, Stratum, and Monero Network metrics."""
     pool_stats = data.get('pool', {})
     p2p_stats = pool_stats.get('p2p', {})
@@ -291,94 +432,94 @@ def _get_pool_network_context(data):
     stratum_stats = data.get('stratum', {})
     network_stats = data.get('network', {})
 
-    net_hash_val = str(network_stats.get('hash', 'N/A'))
-    if len(net_hash_val) > 20:
-        net_hash_val = f"{net_hash_val[:8]}...{net_hash_val[-8:]}"
-
     s_addr = stratum_stats.get('wallet', 'Unknown')
-    s_short = s_addr if len(s_addr) <= 16 else f"{s_addr[:8]}...{s_addr[-8:]}"
 
     workers_list = data.get('workers', [])
     proxy_count = sum(1 for w in workers_list if w.get('status') == 'online')
 
-    # Determine block time based on pool type (Main/Mini=10s, Nano=30s)
     pool_type = p2p_stats.get('type', 'Main')
-    block_time = 30 if pool_type == 'Nano' else 10
+    block_time = _BLOCK_TIME_NANO if pool_type == 'Nano' else _BLOCK_TIME_DEFAULT
 
-    # Calculate shares in window
+    # Shares within the PPLNS window
     shares_list = data.get('shares', [])
     pplns_window = local_pool.get('pplns_window', 2160)
-    window_duration = pplns_window * block_time
-    cutoff = time.time() - window_duration
+    cutoff = time.time() - pplns_window * block_time
     shares_count = sum(1 for s in shares_list if s.get('ts', 0) >= cutoff)
-    shares_display = f"<span class='status-ok'>{shares_count}</span>" if shares_count > 0 else f"<span class='status-bad'>0</span>"
+    cls = 'status-ok' if shares_count > 0 else 'status-bad'
+    shares_display = f"<span class='{cls}'>{shares_count}</span>"
 
-    # Monero node mode: Pruned/Full from config (Issue #32), with the on-disk DB size from
-    # get_info alongside so a config/DB mismatch is visible. Only meaningful for a local node
-    # (we don't probe a remote node's RPC, so its pruning state is unknown to us).
-    monero_sync = data.get('monero_sync', {})
+    monero_mode, monero_db_size, monero_prune_badge = _monero_panel(data.get('monero_sync', {}))
+
+    return PoolNetworkContext(
+        strat_h15=format_hashrate(stratum_stats.get('hashrate_15m', 0)),
+        strat_h1h=format_hashrate(stratum_stats.get('hashrate_1h', 0)),
+        strat_h24h=format_hashrate(stratum_stats.get('hashrate_24h', 0)),
+        strat_shares=f"{stratum_stats.get('shares_found',0)} / {stratum_stats.get('shares_failed',0)}",
+        strat_effort=f"{stratum_stats.get('current_effort', 0):.1f}%",
+        strat_total_shares=stratum_stats.get('total_stratum_shares', 0),
+        strat_reward_pct=f"{stratum_stats.get('block_reward_share_percent', 0):.4f}%",
+        strat_conns=stratum_stats.get('connections', 0),
+        strat_last_share=format_time_abs(stratum_stats.get('last_share_found_time', 0)),
+        strat_total_hashes=stratum_stats.get('total_hashes', 0),
+        strat_wallet=s_addr,
+        strat_wallet_short=_shorten(s_addr),
+        proxy_workers=proxy_count,
+        p2p_type=p2p_stats.get('type', 'Unknown'),
+        pool_sidechain_height=local_pool.get('sidechain_height', 0),
+        pool_diff=f"{local_pool.get('difficulty', 0)/1e6:.2f} M",
+        pool_hr=format_hashrate(local_pool.get('hashrate', 0)),
+        pool_total_hashes=local_pool.get('total_hashes', 0),
+        pool_miners=local_pool.get('miners', 0),
+        pplns_win=f"{local_pool.get('pplns_window', 0)} ({format_duration(local_pool.get('pplns_window', 0) * block_time)})",
+        pplns_wgt=local_pool.get('pplns_weight', 0),
+        pool_shares_window=shares_display,
+        pool_blocks=local_pool.get('blocks_found', 0),
+        pool_last_blk=format_time_abs(local_pool.get('last_block_ts', 0)),
+        p2p_peers=f"{p2p_stats.get('out_peers',0)} / {p2p_stats.get('in_peers',0)}",
+        p2p_uptime=format_duration(p2p_stats.get('uptime', 0)),
+        net_height=network_stats.get('height', 0),
+        net_reward=f"{network_stats.get('reward', 0)/1e12:.4f} XMR",
+        net_diff=f"{network_stats.get('difficulty', 0)/1e9:.2f} G",
+        net_hash=_shorten(str(network_stats.get('hash', 'N/A')), threshold=20),
+        net_ts=format_time_abs(network_stats.get('timestamp', 0)),
+        monero_mode=monero_mode,
+        monero_db_size=monero_db_size,
+        monero_prune_badge=monero_prune_badge,
+    )
+
+
+def _monero_panel(monero_sync):
+    """Monero node mode label, on-disk DB size, and header badge (Issue #32).
+
+    Pruned/Full comes from config; the DB size from get_info sits alongside so a config/DB
+    mismatch is visible. Only meaningful for a local node — a remote node's pruning state
+    isn't something we probe, so it reads 'Unknown' with no badge.
+    """
     db_bytes = monero_sync.get('db_size', 0) or 0
-    if MONERO_NODE_HOST == "172.28.0.26":
-        monero_mode = "Pruned" if MONERO_PRUNE else "Full"
+    if MONERO_NODE_HOST == _LOCAL_MONERO_HOST:
+        mode = "Pruned" if MONERO_PRUNE else "Full"
     else:
-        monero_mode = "Unknown"
-    monero_db_size = f"{db_bytes / 1e9:.1f} GB" if db_bytes > 0 else "—"
+        mode = "Unknown"
+    db_size = f"{db_bytes / 1e9:.1f} GB" if db_bytes > 0 else "—"
 
-    # Compact header badge mirroring the mode. Hidden for a remote node (pruning unknown).
-    if monero_mode == "Pruned":
-        monero_prune_badge = ('<span class="badge badge-outline" '
-                              'title="Monero blockchain is pruned">XMR Pruned</span>')
-    elif monero_mode == "Full":
-        monero_prune_badge = ('<span class="badge badge-outline" '
-                              'title="Monero blockchain is full (not pruned)">XMR Full</span>')
+    if mode == "Pruned":
+        badge = ('<span class="badge badge-outline" '
+                 'title="Monero blockchain is pruned">XMR Pruned</span>')
+    elif mode == "Full":
+        badge = ('<span class="badge badge-outline" '
+                 'title="Monero blockchain is full (not pruned)">XMR Full</span>')
     else:
-        monero_prune_badge = ''
+        badge = ''
+    return mode, db_size, badge
 
-    return {
-        'strat_h15': format_hashrate(stratum_stats.get('hashrate_15m', 0)),
-        'strat_h1h': format_hashrate(stratum_stats.get('hashrate_1h', 0)),
-        'strat_h24h': format_hashrate(stratum_stats.get('hashrate_24h', 0)),
-        'strat_shares': f"{stratum_stats.get('shares_found',0)} / {stratum_stats.get('shares_failed',0)}",
-        'strat_effort': f"{stratum_stats.get('current_effort', 0):.1f}%",
-        'strat_total_shares': stratum_stats.get('total_stratum_shares', 0),
-        'strat_reward_pct': f"{stratum_stats.get('block_reward_share_percent', 0):.4f}%",
-        'strat_conns': stratum_stats.get('connections', 0),
-        'strat_last_share': format_time_abs(stratum_stats.get('last_share_found_time', 0)),
-        'strat_total_hashes': stratum_stats.get('total_hashes', 0),
-        'strat_wallet': s_addr,
-        'strat_wallet_short': s_short,
-        'proxy_workers': proxy_count,
-        'p2p_type': p2p_stats.get('type', 'Unknown'),
-        'pool_sidechain_height': local_pool.get('sidechain_height', 0),
-        'pool_diff': f"{local_pool.get('difficulty', 0)/1e6:.2f} M",
-        'pool_hr': format_hashrate(local_pool.get('hashrate', 0)),
-        'pool_total_hashes': local_pool.get('total_hashes', 0),
-        'pool_miners': local_pool.get('miners', 0),
-        'pplns_win': f"{local_pool.get('pplns_window', 0)} ({format_duration(local_pool.get('pplns_window', 0) * block_time)})",
-        'pplns_wgt': local_pool.get('pplns_weight', 0),
-        'pool_shares_window': shares_display,
-        'pool_blocks': local_pool.get('blocks_found', 0),
-        'pool_last_blk': format_time_abs(local_pool.get('last_block_ts', 0)),
-        'p2p_peers': f"{p2p_stats.get('out_peers',0)} / {p2p_stats.get('in_peers',0)}",
-        'p2p_uptime': format_duration(p2p_stats.get('uptime', 0)),
-        'net_height': network_stats.get('height', 0),
-        'net_reward': f"{network_stats.get('reward', 0)/1e12:.4f} XMR",
-        'net_diff': f"{network_stats.get('difficulty', 0)/1e9:.2f} G",
-        'net_hash': net_hash_val,
-        'net_ts': format_time_abs(network_stats.get('timestamp', 0)),
-        'monero_mode': monero_mode,
-        'monero_db_size': monero_db_size,
-        'monero_prune_badge': monero_prune_badge,
-    }
 
 def _avg_p2pool_over_window(history, window_seconds):
     """Time-weighted P2Pool hashrate over the trailing window, from DB history.
 
-    Averages the per-sample ``v_p2pool`` (hashrate attributed to P2Pool) for
-    samples within the window. Samples are written at a fixed cadence
-    (UPDATE_INTERVAL), so a simple mean approximates a time-weighted average.
-    Mirrors the chart's legacy-data fallback: rows predating the p2pool/xvb
-    split (v_p2pool == v_xvb == 0 but v > 0) are counted as P2Pool. (Issue #27)
+    Averages the per-sample ``v_p2pool`` (hashrate attributed to P2Pool) for samples within
+    the window. Samples are written at a fixed cadence (UPDATE_INTERVAL), so a simple mean
+    approximates a time-weighted average. Mirrors the chart's legacy-data fallback: rows
+    predating the p2pool/xvb split (v_p2pool == v_xvb == 0 but v > 0) count as P2Pool. (Issue #27)
     """
     if not history:
         return 0.0
@@ -399,56 +540,47 @@ def _avg_p2pool_over_window(history, window_seconds):
 
     return total / count if count else 0.0
 
-def _get_algo_context(data, state_mgr, history):
+
+def _mode_colors(current_mode):
+    """Resolve (mode_color, p2p_color, xvb_color) from the algo mode string.
+
+    The active pool is coloured, the inactive one muted — symmetric between P2Pool and XvB
+    (Issue #27). Checked most-specific first: "XVB (Split)" contains both "Split" and "XVB".
+    """
+    if "Split" in current_mode:
+        # Split cycle alternates pools within the window — both are active.
+        return _C_BLUE, _C_GREEN, _C_PURPLE
+    if "XVB" in current_mode:
+        return _C_PURPLE, _C_MUTED, _C_PURPLE
+    return _C_GREEN, _C_GREEN, _C_MUTED  # P2POOL
+
+
+def build_algo_context(data, state_mgr, history):
     """Calculates algorithm switching logic, donation tiers, and hashrate averages."""
     xvb_stats = state_mgr.get_xvb_stats() or {}
     current_mode = xvb_stats.get('current_mode', 'P2POOL')
 
-    # Colors
-    c_green = "#238636"
-    c_purple = "#a371f7"
-    c_blue = "#58a6ff"
-    c_muted = "#8b949e"
-
-    # Pool activity coloring: the active pool is colored, the inactive one muted.
-    # Symmetric — P2Pool dims when XvB is active, and vice versa (Issue #27).
-    # Checked most-specific first: "XVB (Split)" contains both "Split" and "XVB".
     if not ENABLE_XVB:
         current_mode = "P2POOL (XvB Disabled)"
-        mode_color = c_green
-        p2p_color = c_green
-        xvb_color = c_muted
-    elif "Split" in current_mode:
-        # Split cycle alternates pools within the window — both are active.
-        mode_color = c_blue
-        p2p_color = c_green
-        xvb_color = c_purple
-    elif "XVB" in current_mode:
-        mode_color = c_purple
-        p2p_color = c_muted
-        xvb_color = c_purple
-    else:  # P2POOL
-        mode_color = c_green
-        p2p_color = c_green
-        xvb_color = c_muted
+    mode_color, p2p_color, xvb_color = _mode_colors(
+        "P2POOL" if not ENABLE_XVB else current_mode
+    )
 
     total_hr_val = data.get('total_live_h15', 0)
-    xvb_1h_val = xvb_stats.get('avg_1h', 0)
     xvb_24h_val = xvb_stats.get('avg_24h', 0)
 
-    # P2Pool 1h/24h averages from our own DB history: the time-weighted hashrate
-    # actually delivered to P2Pool (v_p2pool), rather than p2pool's noisy stratum
-    # estimate or a total-minus-XvB subtraction. The raw stratum reading is still
-    # shown separately in the "Stratum (15m/1h/24h)" card. (Issue #27)
+    # P2Pool 1h/24h averages from our own DB history: the time-weighted hashrate actually
+    # delivered to P2Pool (v_p2pool), rather than p2pool's noisy stratum estimate or a
+    # total-minus-XvB subtraction. The raw stratum reading is shown separately. (Issue #27)
     p2p_1h_val = _avg_p2pool_over_window(history, 3600)
     p2p_24h_val = _avg_p2pool_over_window(history, 86400)
 
     tiers = state_mgr.get_tiers()
     # Current tier = what XvB actually credits us (drives qualification).
     tier_name, _ = get_tier_info(xvb_24h_val, tiers)
-    # Target tier = what the algo aims for, from the configured donation level
-    # (Issue #40 config side). "auto" = highest sustainable; an explicit tier is
-    # honored even if unsustainable, in which case we flag a low-hashrate warning.
+    # Target tier = what the algo aims for, from the configured donation level (Issue #40).
+    # "auto" = highest sustainable; an explicit tier is honored even if unsustainable, in
+    # which case we flag a low-hashrate warning.
     target_threshold, sustainable = resolve_target_threshold(
         tiers, total_hr_val, XVB_DONATION_LEVEL, XVB_MAX_DONATION_FRACTION
     )
@@ -468,101 +600,148 @@ def _get_algo_context(data, state_mgr, history):
         target_tier_name = "Disabled"
         low_hr_badge = ''
 
-    return {
-        'mode_name': current_mode,
-        'mode_color': mode_color,
-        'p2p_color': p2p_color,
-        'xvb_color': xvb_color,
-        'total_hr': format_hashrate(total_hr_val),
-        'last_update': format_time_abs(time.time()),
-        'xvb_updated': format_time_abs(xvb_stats.get('last_update', 0)),
-        'p2p_1h': format_hashrate(p2p_1h_val),
-        'p2p_24h': format_hashrate(p2p_24h_val),
-        'xvb_1h': format_hashrate(xvb_1h_val),
-        'xvb_24h': format_hashrate(xvb_24h_val),
-        'tier_name': tier_name,
-        'target_tier_name': target_tier_name,
-        'low_hr_badge': low_hr_badge,
-        'xvb_fail_count': xvb_stats.get('fail_count', 0),
-    }
+    return AlgoContext(
+        mode_name=current_mode,
+        mode_color=mode_color,
+        p2p_color=p2p_color,
+        xvb_color=xvb_color,
+        total_hr=format_hashrate(total_hr_val),
+        last_update=format_time_abs(time.time()),
+        xvb_updated=format_time_abs(xvb_stats.get('last_update', 0)),
+        p2p_1h=format_hashrate(p2p_1h_val),
+        p2p_24h=format_hashrate(p2p_24h_val),
+        xvb_1h=format_hashrate(xvb_stats.get('avg_1h', 0)),
+        xvb_24h=format_hashrate(xvb_24h_val),
+        tier_name=tier_name,
+        target_tier_name=target_tier_name,
+        low_hr_badge=low_hr_badge,
+        xvb_fail_count=xvb_stats.get('fail_count', 0),
+    )
+
+
+def _sync_display(sync):
+    """Render one chain's sync progress: a loading ellipsis until real data arrives
+    (target > 0), a checkmark at 100%, else the raw percentage."""
+    pct = sync.get('percent', 0)
+    if sync.get('target', 0) <= 0:
+        return '…'
+    if pct >= 100:
+        return '<span class="status-ok" style="font-size: 3.5em; line-height: 1;">✔</span>'
+    return f"{pct}%"
 
 
 def build_sync_context(monero_sync, tari_sync, is_syncing):
-    """Builds the sync-mode template fields (Monero + Tari progress).
-
-    Shows the checkmark only once real data has arrived (target > 0); before the initial
-    heights are known it's 0/0, which is "waiting" — render a loading indicator rather than
-    a false 100% check.
-    """
-    # Format Monero Sync Display.
-    m_pct = monero_sync.get('percent', 0)
-    if monero_sync.get('target', 0) <= 0:
-        m_disp = '…'
-    elif m_pct >= 100:
-        m_disp = '<span class="status-ok" style="font-size: 3.5em; line-height: 1;">✔</span>'
-    else:
-        m_disp = f"{m_pct}%"
-
-    # Format Tari Sync Display (same 0/0 guard as Monero above)
-    t_pct = tari_sync.get('percent', 0)
-    if tari_sync.get('target', 0) <= 0:
-        t_disp = '…'
-    elif t_pct >= 100:
-        t_disp = '<span class="status-ok" style="font-size: 3.5em; line-height: 1;">✔</span>'
-    else:
-        t_disp = f"{t_pct}%"
-
-    return {
-        'sync_class': 'mode-sync' if is_syncing else '',
-        'page_title': 'Mining Dashboard - Syncing' if is_syncing else 'Mining Dashboard',
-        'sync_percent': m_disp,
-        'sync_percent_val': m_pct,
-        'sync_current': monero_sync.get('current', 0),
-        'sync_target': monero_sync.get('target', 0),
-        'sync_remaining': monero_sync.get('target', 0) - monero_sync.get('current', 0),
-        'tari_sync_percent': t_disp,
-        'tari_sync_percent_val': t_pct,
-        'tari_sync_current': tari_sync.get('current', 0),
-        'tari_sync_target': tari_sync.get('target', 0),
-        'tari_sync_remaining': tari_sync.get('target', 0) - tari_sync.get('current', 0)
-    }
+    """Builds the sync-mode template fields (Monero + Tari progress)."""
+    return SyncContext(
+        sync_class='mode-sync' if is_syncing else '',
+        page_title='Mining Dashboard - Syncing' if is_syncing else 'Mining Dashboard',
+        sync_percent=_sync_display(monero_sync),
+        sync_percent_val=monero_sync.get('percent', 0),
+        sync_current=monero_sync.get('current', 0),
+        sync_target=monero_sync.get('target', 0),
+        sync_remaining=monero_sync.get('target', 0) - monero_sync.get('current', 0),
+        tari_sync_percent=_sync_display(tari_sync),
+        tari_sync_percent_val=tari_sync.get('percent', 0),
+        tari_sync_current=tari_sync.get('current', 0),
+        tari_sync_target=tari_sync.get('target', 0),
+        tari_sync_remaining=tari_sync.get('target', 0) - tari_sync.get('current', 0),
+    )
 
 
-def build_header_badges(data, is_syncing, algo_ctx, pool_net_ctx):
+def _badge(cls, text, title=None):
+    title_attr = f' title="{title}"' if title else ''
+    return f'<span class="{cls}"{title_attr}>{text}</span>'
+
+
+def build_header_badges(data, is_syncing, algo, pool_net):
     """Builds the top-bar status badges (mode/pool, node-down, sync-hold, passive-Tari)."""
     monero_sync = data.get('monero_sync', {})
     tari_sync = data.get('tari_sync', {})
 
+    badges = []
     if is_syncing:
-        header_badges = '<span class="badge badge-warn badge-pool">Syncing...</span>'
+        badges.append(_badge("badge badge-warn badge-pool", "Syncing..."))
     else:
-        m_color = algo_ctx.get('mode_color', '')
-        m_name = algo_ctx.get('mode_name', '')
-        p_type = pool_net_ctx.get('p2p_type', '')
-        header_badges = f'<span class="badge badge-pool" style="background-color: {m_color};">{m_name}</span>'
-        header_badges += f'<span class="badge badge-outline">P2Pool {p_type}</span>'
-        header_badges += algo_ctx.get('low_hr_badge', '')
+        badges.append(f'<span class="badge badge-pool" style="background-color: '
+                      f'{algo.mode_color};">{algo.mode_name}</span>')
+        badges.append(_badge("badge badge-outline", f"P2Pool {pool_net.p2p_type}"))
+        if algo.low_hr_badge:
+            badges.append(algo.low_hr_badge)
 
-    # Node-down badges (Issue #31) — shown whenever a node is unreachable, regardless
-    # of sync state, plus a notice when workers have been rejected to fail over.
+    # Node-down badges (Issue #31) — shown whenever a node is unreachable, regardless of
+    # sync state, plus a notice when workers have been rejected to fail over.
     if monero_sync.get('down'):
-        header_badges += '<span class="badge badge-bad badge-pool">monerod DOWN</span>'
+        badges.append(_badge("badge badge-bad badge-pool", "monerod DOWN"))
     if tari_sync.get('down'):
-        header_badges += '<span class="badge badge-bad badge-pool">Tari DOWN</span>'
+        badges.append(_badge("badge badge-bad badge-pool", "Tari DOWN"))
     if data.get('workers_rejected'):
-        header_badges += '<span class="badge badge-bad badge-pool" title="Workers rejected so they fail over to their backup pools">Workers rejected</span>'
+        badges.append(_badge("badge badge-bad badge-pool", "Workers rejected",
+                             "Workers rejected so they fail over to their backup pools"))
     # Miner held until the required chain(s) finish their initial sync (Issue #35).
     if data.get('miner_held'):
-        header_badges += '<span class="badge badge-warn badge-pool" title="p2pool and xmrig-proxy are held until the required chains finish syncing">Miner held (sync)</span>'
-    # Non-blocking Tari (Issue #51): Tari is (re)syncing but we stay in the operational
-    # view — surface it as a top-bar badge instead of the full-screen takeover. Show the
-    # progress percentage once it's known (omitted early on, before a target height, so it
-    # doesn't read a misleading "0%").
+        badges.append(_badge("badge badge-warn badge-pool", "Miner held (sync)",
+                             "p2pool and xmrig-proxy are held until the required chains finish syncing"))
+    # Non-blocking Tari (Issue #51): Tari is (re)syncing but we stay in the operational view
+    # — surface it as a top-bar badge instead of the full-screen takeover. Show the progress
+    # percentage once known (omitted early, before a target height, so it isn't a stale "0%").
     if data.get('tari_syncing_passive'):
         t_pct = tari_sync.get('percent', 0)
         label = f'Tari syncing {t_pct}%' if t_pct > 0 else 'Tari syncing'
-        header_badges += (f'<span class="badge badge-warn badge-pool" '
-                          f'title="Tari is still syncing — merge mining resumes when it catches up; '
-                          f'Monero mining continues">{label}</span>')
+        badges.append(_badge(
+            "badge badge-warn badge-pool", label,
+            "Tari is still syncing — merge mining resumes when it catches up; Monero mining continues"))
 
-    return header_badges
+    return "".join(badges)
+
+
+# --------------------------------------------------------------------------------------
+# Template loading + render assembly.
+# --------------------------------------------------------------------------------------
+
+TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "templates", "index.html")
+_TEMPLATE_CACHE = None
+_TEMPLATE_MTIME = 0
+
+
+def get_cached_template():
+    """Retrieves and caches the HTML template, reloading from disk only if it has changed."""
+    global _TEMPLATE_CACHE, _TEMPLATE_MTIME
+    try:
+        mtime = os.path.getmtime(TEMPLATE_PATH)
+        if _TEMPLATE_CACHE is None or mtime > _TEMPLATE_MTIME:
+            with open(TEMPLATE_PATH, 'r') as f:
+                _TEMPLATE_CACHE = f.read()
+            _TEMPLATE_MTIME = mtime
+    except Exception as e:
+        logger.error(f"Error loading template: {e}")
+    return _TEMPLATE_CACHE or "<h1>Template Error</h1>"
+
+
+def render_dashboard(data, state_mgr, range_arg):
+    """Assemble every context block and render the dashboard HTML.
+
+    The single place the template contract is satisfied: each block's dataclass fields are
+    flattened into the ``str.format`` kwargs, alongside the host IP, worker rows, and header
+    badges. May raise (e.g. ``state_mgr.get_history`` failing) — the caller wraps this and
+    returns a sanitized 500.
+    """
+    history = state_mgr.get_history()
+    is_syncing = data.get('global_sync', False)
+
+    sync = build_sync_context(data.get('monero_sync', {}), data.get('tari_sync', {}), is_syncing)
+    chart = build_chart_context(history, data.get('shares', []), range_arg)
+    system = build_system_context(data)
+    pool_net = build_pool_network_context(data)
+    algo = build_algo_context(data, state_mgr, history)
+    tari = build_tari_context(data)
+
+    fields = {}
+    for block in (sync, chart, system, pool_net, algo, tari):
+        fields.update(asdict(block))
+    fields.update(
+        host_ip=HOST_IP,
+        worker_rows=build_worker_rows(data.get('workers', [])),
+        header_badges=build_header_badges(data, is_syncing, algo, pool_net),
+    )
+
+    return get_cached_template().format(**fields)

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -717,13 +717,15 @@ def get_cached_template():
     return _TEMPLATE_CACHE or "<h1>Template Error</h1>"
 
 
-def render_dashboard(data, state_mgr, range_arg):
-    """Assemble every context block and render the dashboard HTML.
+def build_view_model(data, state_mgr, range_arg):
+    """Assemble every context block into the flat field map the dashboard needs.
 
-    The single place the template contract is satisfied: each block's dataclass fields are
-    flattened into the ``str.format`` kwargs, alongside the host IP, worker rows, and header
-    badges. May raise (e.g. ``state_mgr.get_history`` failing) — the caller wraps this and
-    returns a sanitized 500.
+    Each block's dataclass fields are flattened into a single dict, alongside the host IP,
+    pre-rendered worker rows, and header badges. The values are all JSON-serializable
+    primitives/strings — so this is the single source of truth for both the HTML render
+    (``render_dashboard``) and a future ``fetch()`` partial/JSON endpoint (Issue #30),
+    without either re-deriving the other's data. May raise (e.g. ``state_mgr.get_history``
+    failing) — callers wrap this and return a sanitized 500.
     """
     history = state_mgr.get_history()
     is_syncing = data.get('global_sync', False)
@@ -743,5 +745,9 @@ def render_dashboard(data, state_mgr, range_arg):
         worker_rows=build_worker_rows(data.get('workers', [])),
         header_badges=build_header_badges(data, is_syncing, algo, pool_net),
     )
+    return fields
 
-    return get_cached_template().format(**fields)
+
+def render_dashboard(data, state_mgr, range_arg):
+    """Render the dashboard HTML — the one place the template contract is satisfied."""
+    return get_cached_template().format(**build_view_model(data, state_mgr, range_arg))

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock, AsyncMock, patch
 import pytest
 
 import mining_dashboard.service.data_service as ds_mod
-from mining_dashboard.service.data_service import DataService
+from mining_dashboard.service.data_service import (
+    DataService, _normalize_proxy_workers, _merge_direct_stats, _aggregate_hashrate,
+)
 
 
 class _FakeClientSession:
@@ -28,6 +30,120 @@ def _make_service():
     svc.docker_control.stop = AsyncMock(return_value=True)
     svc.docker_control.start = AsyncMock(return_value=True)
     return svc, state_manager, proxy_client
+
+
+class TestNormalizeProxyWorkers:
+    """The two xmrig-proxy /workers payload shapes -> a uniform worker list (Issue #39)."""
+
+    def test_list_format_online(self):
+        # 6.x list: idx2=connections (1 -> online), idx8=1.0 kH/s, idx9=2.0 kH/s.
+        row = ["rig1", "10.0.0.1", 1, 0, 0, 0, 0, 0, 1.0, 2.0, 0, 0, 0]
+        [w] = _normalize_proxy_workers({"workers": [row]})
+        assert w["name"] == "rig1"
+        assert w["ip"] == "10.0.0.1"
+        assert w["status"] == "online"
+        assert w["h10"] == 1000 and w["h60"] == 1000  # idx8 kH/s -> H/s
+        assert w["h15"] == 2000                         # idx9 kH/s -> H/s
+        assert w["uptime"] == 0                          # idx7 (last share ms) == 0
+
+    def test_list_format_offline_when_no_connections(self):
+        # A worker still listed by the proxy but with 0 connections is a stopped miner.
+        row = ["rig1", "10.0.0.1", 0, 0, 0, 0, 0, 0, 1.0, 2.0, 0, 0, 0]
+        [w] = _normalize_proxy_workers({"workers": [row]})
+        assert w["status"] == "offline"
+
+    def test_list_format_uptime_estimate_from_last_share(self):
+        # idx7 = last share timestamp (ms) -> a non-negative "seconds since last share".
+        row = ["rig1", "10.0.0.1", 1, 0, 0, 0, 0, 1_000, 1.0, 2.0, 0, 0, 0]
+        [w] = _normalize_proxy_workers({"workers": [row]})
+        assert isinstance(w["uptime"], int)
+        assert w["uptime"] > 0
+
+    def test_short_list_row_is_skipped(self):
+        # Fewer than 13 fields isn't the 6.x shape -> ignored rather than mis-parsed.
+        assert _normalize_proxy_workers({"workers": [["rig1", "10.0.0.1", 1]]}) == []
+
+    def test_legacy_dict_format(self):
+        row = {"id": "old", "ip": "1.2.3.4", "hashrate": [100, 200, 300], "uptime": 50}
+        [w] = _normalize_proxy_workers({"workers": [row]})
+        assert w["name"] == "old"
+        assert w["status"] == "online"
+        assert (w["h10"], w["h60"], w["h15"]) == (100, 200, 300)
+        assert w["uptime"] == 50
+
+    def test_legacy_dict_defaults(self):
+        [w] = _normalize_proxy_workers({"workers": [{}]})
+        assert w["name"] == "Unknown"
+        assert w["ip"] == "0.0.0.0"
+        assert (w["h10"], w["h60"], w["h15"]) == (0, 0, 0)
+
+    def test_missing_payload_returns_empty(self):
+        assert _normalize_proxy_workers(None) == []
+        assert _normalize_proxy_workers({}) == []
+        assert _normalize_proxy_workers({"nope": 1}) == []
+
+
+class TestMergeDirectStats:
+    """Augment proxy workers with direct-API stats; kind-based scaling + keep-online (#39/#28)."""
+
+    def _worker(self):
+        return {"name": "rig", "ip": "10.0.0.1", "status": "online",
+                "h10": 1, "h60": 2, "h15": 3, "uptime": 0}
+
+    def test_proxy_kind_scales_khs_to_hs(self):
+        extra = {"kind": "proxy", "uptime": 120, "hashrate": {"total": [1, 2, 3]}}
+        [w] = _merge_direct_stats([self._worker()], [extra], "3333")
+        assert (w["h10"], w["h60"], w["h15"]) == (1000, 2000, 3000)
+        assert w["uptime"] == 120
+        assert w["active_pool"] == "3333"
+
+    def test_xmrig_kind_not_scaled(self):
+        extra = {"uptime": 99, "hashrate": {"total": [10, 20, 30]}}
+        [w] = _merge_direct_stats([self._worker()], [extra], "3344")
+        assert (w["h10"], w["h60"], w["h15"]) == (10, 20, 30)
+        assert w["active_pool"] == "3344"
+
+    def test_unreachable_direct_api_keeps_proxy_values_online(self):
+        # Falsy extra_stats -> keep proxy-derived hashrate/uptime and stay online (#28).
+        w0 = self._worker()
+        [w] = _merge_direct_stats([w0], [{}], "3333")
+        assert w["status"] == "online"
+        assert (w["h10"], w["h60"], w["h15"]) == (1, 2, 3)  # untouched
+        assert w["active_pool"] == "3333"
+
+    def test_short_hashrate_total_ignored(self):
+        # A <3-entry total isn't applied; uptime still updates and active_pool is tagged.
+        extra = {"uptime": 7, "hashrate": {"total": [5, 6]}}
+        [w] = _merge_direct_stats([self._worker()], [extra], "3333")
+        assert (w["h10"], w["h60"], w["h15"]) == (1, 2, 3)
+        assert w["uptime"] == 7
+
+
+class TestAggregateHashrate:
+    """Total live hashrate, priority 15m > 60s > 10s, online-only (Issue #39)."""
+
+    def test_prefers_h15(self):
+        workers = [{"status": "online", "h15": 2000, "h60": 1000, "h10": 500}]
+        assert _aggregate_hashrate(workers) == (2000, 500)
+
+    def test_falls_back_to_h60_then_h10(self):
+        workers = [
+            {"status": "online", "h15": 0, "h60": 1500, "h10": 500},  # uses h60
+            {"status": "online", "h15": 0, "h60": 0, "h10": 700},     # uses h10
+        ]
+        total_h15, total_h10 = _aggregate_hashrate(workers)
+        assert total_h15 == 1500 + 700
+        assert total_h10 == 500 + 700
+
+    def test_offline_excluded(self):
+        workers = [
+            {"status": "online", "h15": 1000, "h10": 100},
+            {"status": "offline", "h15": 9999, "h10": 9999},
+        ]
+        assert _aggregate_hashrate(workers) == (1000, 100)
+
+    def test_empty(self):
+        assert _aggregate_hashrate([]) == (0, 0)
 
 
 class TestInit:

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -5,6 +5,7 @@ import pytest
 import mining_dashboard.service.data_service as ds_mod
 from mining_dashboard.service.data_service import (
     DataService, _normalize_proxy_workers, _merge_direct_stats, _aggregate_hashrate,
+    _parse_proxy_list_worker, _parse_legacy_dict_worker,
 )
 
 
@@ -30,6 +31,29 @@ def _make_service():
     svc.docker_control.stop = AsyncMock(return_value=True)
     svc.docker_control.start = AsyncMock(return_value=True)
     return svc, state_manager, proxy_client
+
+
+class TestProxyWorkerParsers:
+    """The per-shape row parsers used by _normalize_proxy_workers (Issue #39)."""
+
+    def test_parse_list_row_named_fields(self):
+        # idx2=connections, idx8=1m kH/s, idx9=10m kH/s, idx7=last share ms.
+        row = ["rig", "10.0.0.1", 1, 0, 0, 0, 0, 0, 1.0, 2.0, 0, 0, 0]
+        w = _parse_proxy_list_worker(row)
+        assert w == {"name": "rig", "ip": "10.0.0.1", "status": "online",
+                     "h10": 1000, "h60": 1000, "h15": 2000, "uptime": 0}
+
+    def test_parse_list_row_offline_and_uptime(self):
+        row = ["rig", "10.0.0.1", 0, 0, 0, 0, 0, 1_000, 1.0, 2.0, 0, 0, 0]
+        w = _parse_proxy_list_worker(row)
+        assert w["status"] == "offline"
+        assert w["uptime"] > 0  # derived from the last-share timestamp
+
+    def test_parse_legacy_dict_row(self):
+        w = _parse_legacy_dict_worker({"id": "old", "ip": "1.2.3.4",
+                                       "hashrate": [10, 20, 30], "uptime": 5})
+        assert w == {"name": "old", "ip": "1.2.3.4", "status": "online",
+                     "h10": 10, "h60": 20, "h15": 30, "uptime": 5}
 
 
 class TestNormalizeProxyWorkers:

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -2,10 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-import mining_dashboard.web.server as server
-from mining_dashboard.web.server import (
-    create_app, get_cached_template, _apply_security_headers,
-)
+from mining_dashboard.web.server import create_app, _apply_security_headers
 from mining_dashboard.service.storage_service import StateManager
 
 
@@ -115,16 +112,7 @@ class TestErrorHandling:
         assert "X-Frame-Options" in resp.headers  # headers still applied
 
 
-class TestHelpers:
-    def test_get_cached_template_returns_str(self):
-        assert isinstance(get_cached_template(), str)
-        assert len(get_cached_template()) > 0
-
-    def test_template_error_fallback(self, monkeypatch):
-        server._TEMPLATE_CACHE = None
-        monkeypatch.setattr(server.os.path, "getmtime", lambda p: (_ for _ in ()).throw(OSError()))
-        assert get_cached_template() == "<h1>Template Error</h1>"
-
+class TestSecurityHeaders:
     def test_apply_security_headers(self):
         resp = MagicMock()
         resp.headers = {}

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -1,12 +1,10 @@
-import time
 from unittest.mock import MagicMock
 
 import pytest
 
 import mining_dashboard.web.server as server
 from mining_dashboard.web.server import (
-    create_app, _get_chart_context, get_cached_template, _apply_security_headers,
-    _get_pool_network_context,
+    create_app, get_cached_template, _apply_security_headers,
 )
 from mining_dashboard.service.storage_service import StateManager
 
@@ -117,121 +115,6 @@ class TestErrorHandling:
         assert "X-Frame-Options" in resp.headers  # headers still applied
 
 
-class TestChartContext:
-    def _history(self, n, base_ts):
-        return [{"timestamp": base_ts + i, "v": i, "v_p2pool": 0, "v_xvb": 0,
-                 "t": "x"} for i in range(n)]
-
-    def test_range_filtering(self):
-        now = time.time()
-        history = [{"timestamp": now - 7200, "v": 1, "v_p2pool": 0, "v_xvb": 0, "t": "x"},
-                   {"timestamp": now - 60, "v": 2, "v_p2pool": 0, "v_xvb": 0, "t": "x"}]
-        ctx_all = _get_chart_context(history, [], "all")
-        ctx_1h = _get_chart_context(history, [], "1h")
-        # both return a context dict; 1h filtering drops the 2h-old point from the payload
-        assert isinstance(ctx_all, dict) and isinstance(ctx_1h, dict)
-
-    def test_downsampling_caps_points(self):
-        now = time.time()
-        big = self._history(2000, now - 2000)
-        ctx = _get_chart_context(big, [], "all")
-        assert isinstance(ctx, dict)
-
-
-class TestAvgP2poolOverWindow:
-    def test_empty_history_returns_zero(self):
-        assert server._avg_p2pool_over_window([], 3600) == 0.0
-
-    def test_averages_v_p2pool_in_window(self):
-        now = time.time()
-        history = [
-            {"timestamp": now - 30, "v": 1000, "v_p2pool": 1000, "v_xvb": 0},
-            {"timestamp": now - 60, "v": 500, "v_p2pool": 500, "v_xvb": 0},
-        ]
-        assert server._avg_p2pool_over_window(history, 3600) == 750.0
-
-    def test_excludes_samples_outside_window(self):
-        now = time.time()
-        history = [
-            {"timestamp": now - 30, "v": 1000, "v_p2pool": 1000, "v_xvb": 0},
-            {"timestamp": now - 7200, "v": 200, "v_p2pool": 200, "v_xvb": 0},
-        ]
-        assert server._avg_p2pool_over_window(history, 3600) == 1000.0
-
-    def test_legacy_rows_count_as_p2pool(self):
-        now = time.time()
-        history = [{"timestamp": now - 30, "v": 800, "v_p2pool": 0, "v_xvb": 0}]
-        assert server._avg_p2pool_over_window(history, 3600) == 800.0
-
-    def test_xvb_samples_drag_average_down(self):
-        # Time spent donating to XvB reduces the P2Pool average (v_p2pool == 0 then).
-        now = time.time()
-        history = [
-            {"timestamp": now - 30, "v": 1000, "v_p2pool": 1000, "v_xvb": 0},
-            {"timestamp": now - 60, "v": 1000, "v_p2pool": 0, "v_xvb": 1000},
-        ]
-        assert server._avg_p2pool_over_window(history, 3600) == 500.0
-
-
-class TestAlgoContextColors:
-    MUTED = "#8b949e"
-
-    def _ctx(self, mode):
-        sm = StateManager(db_path=":memory:")
-        sm.update_xvb_stats(mode=mode)
-        try:
-            return server._get_algo_context({"total_live_h15": 100000}, sm, [])
-        finally:
-            sm.close()
-
-    def test_p2pool_mode_grays_xvb(self):
-        ctx = self._ctx("P2POOL")
-        assert ctx["xvb_color"] == self.MUTED
-        assert ctx["p2p_color"] != self.MUTED
-
-    def test_xvb_mode_grays_p2pool(self):
-        ctx = self._ctx("XVB")
-        assert ctx["p2p_color"] == self.MUTED
-        assert ctx["xvb_color"] != self.MUTED
-
-    def test_split_mode_both_active(self):
-        ctx = self._ctx("XVB (Split)")
-        assert ctx["p2p_color"] != self.MUTED
-        assert ctx["xvb_color"] != self.MUTED
-
-    def test_xvb_disabled_grays_xvb(self, monkeypatch):
-        monkeypatch.setattr(server, "ENABLE_XVB", False)
-        ctx = self._ctx("XVB")
-        assert ctx["xvb_color"] == self.MUTED
-        assert "Disabled" in ctx["mode_name"]
-
-
-class TestLowHashrateWarning:
-    def _ctx(self, monkeypatch, level, total_hr):
-        monkeypatch.setattr(server, "XVB_DONATION_LEVEL", level)
-        sm = StateManager(db_path=":memory:")
-        sm.update_xvb_stats(mode="P2POOL")
-        try:
-            return server._get_algo_context({"total_live_h15": total_hr}, sm, [])
-        finally:
-            sm.close()
-
-    def test_warns_when_selected_tier_unsustainable(self, monkeypatch):
-        # 50k can't sustain Mega (1M) -> warning badge.
-        ctx = self._ctx(monkeypatch, "mega", 50_000)
-        assert ctx["low_hr_badge"]
-
-    def test_no_warning_for_auto(self, monkeypatch):
-        # auto only ever targets a sustainable tier -> no warning.
-        ctx = self._ctx(monkeypatch, "auto", 50_000)
-        assert ctx["low_hr_badge"] == ""
-
-    def test_no_warning_when_sustainable(self, monkeypatch):
-        # 50k easily sustains Donor (1k) -> no warning.
-        ctx = self._ctx(monkeypatch, "donor", 50_000)
-        assert ctx["low_hr_badge"] == ""
-
-
 class TestHelpers:
     def test_get_cached_template_returns_str(self):
         assert isinstance(get_cached_template(), str)
@@ -248,38 +131,3 @@ class TestHelpers:
         _apply_security_headers(resp)
         for h in SECURITY_HEADERS:
             assert h in resp.headers
-
-
-class TestMoneroMode:
-    """Pruned/Full label + DB size in the Monero panel (Issue #32)."""
-
-    def _ctx(self, db_size=0):
-        return _get_pool_network_context({"monero_sync": {"db_size": db_size}})
-
-    def test_local_pruned(self, monkeypatch):
-        monkeypatch.setattr(server, "MONERO_NODE_HOST", "172.28.0.26")
-        monkeypatch.setattr(server, "MONERO_PRUNE", True)
-        ctx = self._ctx(db_size=85_000_000_000)
-        assert ctx["monero_mode"] == "Pruned"
-        assert ctx["monero_db_size"] == "85.0 GB"
-        assert "XMR Pruned" in ctx["monero_prune_badge"]
-
-    def test_local_full(self, monkeypatch):
-        monkeypatch.setattr(server, "MONERO_NODE_HOST", "172.28.0.26")
-        monkeypatch.setattr(server, "MONERO_PRUNE", False)
-        ctx = self._ctx()
-        assert ctx["monero_mode"] == "Full"
-        assert "XMR Full" in ctx["monero_prune_badge"]
-
-    def test_remote_unknown(self, monkeypatch):
-        # A remote node's pruning state isn't something we probe — no badge.
-        monkeypatch.setattr(server, "MONERO_NODE_HOST", "10.0.0.9")
-        monkeypatch.setattr(server, "MONERO_PRUNE", True)
-        ctx = self._ctx()
-        assert ctx["monero_mode"] == "Unknown"
-        assert ctx["monero_prune_badge"] == ""
-
-    def test_db_size_dash_when_unknown(self, monkeypatch):
-        monkeypatch.setattr(server, "MONERO_NODE_HOST", "172.28.0.26")
-        monkeypatch.setattr(server, "MONERO_PRUNE", True)
-        assert self._ctx(db_size=0)["monero_db_size"] == "—"

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -6,12 +6,14 @@ no request — which is the whole point of having pulled them out of the request
 """
 import time
 
+import json
+
 import mining_dashboard.web.views as views
 from mining_dashboard.web.views import (
     build_chart_context, build_pool_network_context, build_worker_rows,
     build_tari_context, build_system_context, build_algo_context,
     build_sync_context, build_header_badges, get_cached_template, render_dashboard,
-    AlgoContext, PoolNetworkContext,
+    build_view_model, AlgoContext, PoolNetworkContext,
 )
 from mining_dashboard.service.storage_service import StateManager
 
@@ -438,3 +440,29 @@ class TestRenderDashboard:
         import pytest
         with pytest.raises(RuntimeError):
             render_dashboard({"workers": []}, bad_sm, "all")
+
+
+class TestViewModel:
+    """The assembled field map (shared by the HTML render and a future #30 JSON endpoint)."""
+
+    def _vm(self):
+        sm = StateManager(db_path=":memory:")
+        data = {
+            "shares": [], "workers": [], "global_sync": False,
+            "monero_sync": {"percent": 100, "current": 10, "target": 10},
+            "tari_sync": {"percent": 50, "current": 5, "target": 10},
+        }
+        try:
+            return build_view_model(data, sm, "all")
+        finally:
+            sm.close()
+
+    def test_contains_all_template_fields(self):
+        vm = self._vm()
+        for key in ("host_ip", "worker_rows", "header_badges", "total_hr",
+                    "sync_percent", "mode_name", "tari_status"):
+            assert key in vm
+
+    def test_is_json_serializable(self):
+        # #30 will serve this map over fetch() — every value must be JSON-encodable.
+        json.dumps(self._vm())

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -1,14 +1,17 @@
 """Unit tests for the dashboard presentation layer (mining_dashboard/web/views.py).
 
-These exercise the context builders in isolation — no aiohttp app, no request — which is
-the whole point of having pulled them out of the request handler (Issue #38).
+These exercise the context builders and the render assembly in isolation — no aiohttp app,
+no request — which is the whole point of having pulled them out of the request handler
+(Issue #38). Builders return frozen ``*Context`` dataclasses; tests read their attributes.
 """
 import time
 
 import mining_dashboard.web.views as views
 from mining_dashboard.web.views import (
-    _get_chart_context, _get_pool_network_context, _get_worker_rows,
-    _get_tari_context, _get_system_context, build_sync_context, build_header_badges,
+    build_chart_context, build_pool_network_context, build_worker_rows,
+    build_tari_context, build_system_context, build_algo_context,
+    build_sync_context, build_header_badges, get_cached_template, render_dashboard,
+    AlgoContext, PoolNetworkContext,
 )
 from mining_dashboard.service.storage_service import StateManager
 
@@ -22,41 +25,34 @@ class TestChartContext:
         now = time.time()
         history = [{"timestamp": now - 7200, "v": 1, "v_p2pool": 0, "v_xvb": 0, "t": "x"},
                    {"timestamp": now - 60, "v": 2, "v_p2pool": 0, "v_xvb": 0, "t": "x"}]
-        ctx_all = _get_chart_context(history, [], "all")
-        ctx_1h = _get_chart_context(history, [], "1h")
-        # both return a context dict; 1h filtering drops the 2h-old point from the payload
-        assert isinstance(ctx_all, dict) and isinstance(ctx_1h, dict)
-        assert ctx_1h["cls_1h"] == "active"
+        ctx_1h = build_chart_context(history, [], "1h")
+        assert ctx_1h.cls_1h == "active"
+        # 1h filtering drops the 2h-old point -> one label remains.
+        assert len(ctx_1h.chart_labels.split(",")) == 1
 
     def test_downsampling_caps_points(self):
         now = time.time()
         big = self._history(2000, now - 2000)
-        ctx = _get_chart_context(big, [], "all")
-        # Downsampled to <= 800 comma-separated points.
-        assert isinstance(ctx, dict)
-        assert len(ctx["chart_data"].split(",")) <= 800
+        ctx = build_chart_context(big, [], "all")
+        assert len(ctx.chart_p2pool.split(",")) <= 800
 
     def test_shares_mapped_to_nearest_history_point(self):
-        # Each share is bucketed onto the closest history sample; the marker count/radius/
-        # offset arrays line up with the history points (covers the share-overlay branch).
         history = [
             {"timestamp": 1000, "v": 500, "v_p2pool": 500, "v_xvb": 0, "t": "a"},
             {"timestamp": 1060, "v": 600, "v_p2pool": 600, "v_xvb": 0, "t": "b"},
         ]
         shares = [{"ts": 1005}, {"ts": 1058}]
-        ctx = _get_chart_context(history, shares, "all")
-        assert ctx["chart_shares_c"] == "1,1"
+        ctx = build_chart_context(history, shares, "all")
+        assert ctx.chart_shares_c == "1,1"
         # y offset is lifted 10% above the line value (500 -> 550.0, 600 -> 660.0).
-        assert ctx["chart_shares_y"] == "550.0,660.0"
-        assert ctx["chart_shares_r"] == "9,9"
+        assert ctx.chart_shares_y == "550.0,660.0"
+        assert ctx.chart_shares_r == "9,9"
 
     def test_share_offset_floor_when_value_zero(self):
-        # A share landing on a zero-hashrate sample is floored to y=100 so the marker stays
-        # visible instead of sitting on the axis.
         history = [{"timestamp": 1000, "v": 0, "v_p2pool": 0, "v_xvb": 0, "t": "a"}]
-        ctx = _get_chart_context(history, [{"ts": 1000}], "all")
-        assert ctx["chart_shares_y"] == "100"
-        assert ctx["chart_shares_c"] == "1"
+        ctx = build_chart_context(history, [{"ts": 1000}], "all")
+        assert ctx.chart_shares_y == "100"
+        assert ctx.chart_shares_c == "1"
 
 
 class TestAvgP2poolOverWindow:
@@ -101,31 +97,31 @@ class TestAlgoContextColors:
         sm = StateManager(db_path=":memory:")
         sm.update_xvb_stats(mode=mode)
         try:
-            return views._get_algo_context({"total_live_h15": 100000}, sm, [])
+            return build_algo_context({"total_live_h15": 100000}, sm, [])
         finally:
             sm.close()
 
     def test_p2pool_mode_grays_xvb(self):
         ctx = self._ctx("P2POOL")
-        assert ctx["xvb_color"] == self.MUTED
-        assert ctx["p2p_color"] != self.MUTED
+        assert ctx.xvb_color == self.MUTED
+        assert ctx.p2p_color != self.MUTED
 
     def test_xvb_mode_grays_p2pool(self):
         ctx = self._ctx("XVB")
-        assert ctx["p2p_color"] == self.MUTED
-        assert ctx["xvb_color"] != self.MUTED
+        assert ctx.p2p_color == self.MUTED
+        assert ctx.xvb_color != self.MUTED
 
     def test_split_mode_both_active(self):
         ctx = self._ctx("XVB (Split)")
-        assert ctx["p2p_color"] != self.MUTED
-        assert ctx["xvb_color"] != self.MUTED
+        assert ctx.p2p_color != self.MUTED
+        assert ctx.xvb_color != self.MUTED
 
     def test_xvb_disabled_grays_xvb(self, monkeypatch):
         monkeypatch.setattr(views, "ENABLE_XVB", False)
         ctx = self._ctx("XVB")
-        assert ctx["xvb_color"] == self.MUTED
-        assert "Disabled" in ctx["mode_name"]
-        assert ctx["tier_name"] == "Disabled"
+        assert ctx.xvb_color == self.MUTED
+        assert "Disabled" in ctx.mode_name
+        assert ctx.tier_name == "Disabled"
 
 
 class TestLowHashrateWarning:
@@ -134,110 +130,116 @@ class TestLowHashrateWarning:
         sm = StateManager(db_path=":memory:")
         sm.update_xvb_stats(mode="P2POOL")
         try:
-            return views._get_algo_context({"total_live_h15": total_hr}, sm, [])
+            return build_algo_context({"total_live_h15": total_hr}, sm, [])
         finally:
             sm.close()
 
     def test_warns_when_selected_tier_unsustainable(self, monkeypatch):
         # 50k can't sustain Mega (1M) -> warning badge.
         ctx = self._ctx(monkeypatch, "mega", 50_000)
-        assert ctx["low_hr_badge"]
+        assert ctx.low_hr_badge
 
     def test_no_warning_for_auto(self, monkeypatch):
-        # auto only ever targets a sustainable tier -> no warning.
         ctx = self._ctx(monkeypatch, "auto", 50_000)
-        assert ctx["low_hr_badge"] == ""
+        assert ctx.low_hr_badge == ""
 
     def test_no_warning_when_sustainable(self, monkeypatch):
-        # 50k easily sustains Donor (1k) -> no warning.
         ctx = self._ctx(monkeypatch, "donor", 50_000)
-        assert ctx["low_hr_badge"] == ""
+        assert ctx.low_hr_badge == ""
 
 
 class TestMoneroMode:
     """Pruned/Full label + DB size in the Monero panel (Issue #32)."""
 
     def _ctx(self, db_size=0):
-        return _get_pool_network_context({"monero_sync": {"db_size": db_size}})
+        return build_pool_network_context({"monero_sync": {"db_size": db_size}})
 
     def test_local_pruned(self, monkeypatch):
         monkeypatch.setattr(views, "MONERO_NODE_HOST", "172.28.0.26")
         monkeypatch.setattr(views, "MONERO_PRUNE", True)
         ctx = self._ctx(db_size=85_000_000_000)
-        assert ctx["monero_mode"] == "Pruned"
-        assert ctx["monero_db_size"] == "85.0 GB"
-        assert "XMR Pruned" in ctx["monero_prune_badge"]
+        assert ctx.monero_mode == "Pruned"
+        assert ctx.monero_db_size == "85.0 GB"
+        assert "XMR Pruned" in ctx.monero_prune_badge
 
     def test_local_full(self, monkeypatch):
         monkeypatch.setattr(views, "MONERO_NODE_HOST", "172.28.0.26")
         monkeypatch.setattr(views, "MONERO_PRUNE", False)
         ctx = self._ctx()
-        assert ctx["monero_mode"] == "Full"
-        assert "XMR Full" in ctx["monero_prune_badge"]
+        assert ctx.monero_mode == "Full"
+        assert "XMR Full" in ctx.monero_prune_badge
 
     def test_remote_unknown(self, monkeypatch):
-        # A remote node's pruning state isn't something we probe — no badge.
         monkeypatch.setattr(views, "MONERO_NODE_HOST", "10.0.0.9")
         monkeypatch.setattr(views, "MONERO_PRUNE", True)
         ctx = self._ctx()
-        assert ctx["monero_mode"] == "Unknown"
-        assert ctx["monero_prune_badge"] == ""
+        assert ctx.monero_mode == "Unknown"
+        assert ctx.monero_prune_badge == ""
 
     def test_db_size_dash_when_unknown(self, monkeypatch):
         monkeypatch.setattr(views, "MONERO_NODE_HOST", "172.28.0.26")
         monkeypatch.setattr(views, "MONERO_PRUNE", True)
-        assert self._ctx(db_size=0)["monero_db_size"] == "—"
+        assert self._ctx(db_size=0).monero_db_size == "—"
+
+    def test_shares_window_counts_recent_only(self):
+        now = time.time()
+        data = {
+            "pool": {"pool": {"pplns_window": 10}},  # 10 blocks * 10s = 100s window
+            "shares": [{"ts": now - 5}, {"ts": now - 50}, {"ts": now - 10_000}],
+        }
+        ctx = build_pool_network_context(data)
+        assert "status-ok" in ctx.pool_shares_window  # 2 recent shares -> ok styling
+        assert ">2<" in ctx.pool_shares_window
 
 
 class TestWorkerRows:
     """HTML table rows for the worker list (badges, sorting, escaping)."""
 
     def test_online_p2pool_worker_rendered(self):
-        rows = _get_worker_rows([
+        rows = build_worker_rows([
             {"name": "rig1", "ip": "10.0.0.1", "status": "online",
              "active_pool": "3333", "uptime": 60, "h10": 1000, "h60": 1000, "h15": 1000},
         ])
         assert "rig1" in rows
         assert "status-ok" in rows
-        assert ">P2Pool<" in rows  # P2Pool badge for a 3333 (p2pool) port
+        assert ">P2Pool<" in rows
 
     def test_offline_worker_marked_bad(self):
-        rows = _get_worker_rows([
-            {"name": "rig2", "ip": "10.0.0.2", "status": "offline",
-             "active_pool": "3333"},
+        rows = build_worker_rows([
+            {"name": "rig2", "ip": "10.0.0.2", "status": "offline", "active_pool": "3333"},
         ])
         assert "status-bad" in rows
 
     def test_xvb_badge_for_xvb_port(self):
-        rows = _get_worker_rows([
+        rows = build_worker_rows([
             {"name": "rig3", "ip": "10.0.0.3", "status": "online", "active_pool": "3344"},
         ])
         assert ">XvB<" in rows
 
     def test_unknown_badge_when_no_active_pool(self):
-        rows = _get_worker_rows([
+        rows = build_worker_rows([
             {"name": "rig4", "ip": "10.0.0.4", "status": "online", "active_pool": ""},
         ])
         assert ">Unknown<" in rows
 
     def test_worker_name_is_html_escaped(self):
-        rows = _get_worker_rows([
+        rows = build_worker_rows([
             {"name": "<script>", "ip": "10.0.0.5", "status": "online", "active_pool": "3333"},
         ])
         assert "<script>" not in rows
         assert "&lt;script&gt;" in rows
 
     def test_online_sorted_before_offline(self):
-        rows = _get_worker_rows([
+        rows = build_worker_rows([
             {"name": "zzz", "ip": "10.0.0.9", "status": "offline", "active_pool": "3333"},
             {"name": "aaa", "ip": "10.0.0.1", "status": "online", "active_pool": "3333"},
         ])
-        assert rows.index("aaa") < rows.index("zzz")  # online (aaa) comes first
+        assert rows.index("aaa") < rows.index("zzz")
 
     def test_malformed_worker_is_skipped(self):
-        # A worker missing 'ip' raises inside the row build and is skipped (the good one
-        # still renders) rather than blowing up the whole table.
-        rows = _get_worker_rows([
+        # A worker missing 'ip' raises inside the row build and is skipped; the good one
+        # still renders rather than blowing up the whole table.
+        rows = build_worker_rows([
             {"name": "good", "ip": "10.0.0.1", "status": "online", "active_pool": "3333"},
             {"name": "skipme", "status": "online", "active_pool": "3333"},  # no 'ip'
         ])
@@ -245,8 +247,7 @@ class TestWorkerRows:
         assert "skipme" not in rows
 
     def test_bad_ip_sorts_to_zero(self):
-        # A non-numeric IP can't be packed into a sort int -> falls back to 0, still renders.
-        rows = _get_worker_rows([
+        rows = build_worker_rows([
             {"name": "rig", "ip": "not-an-ip", "status": "online", "active_pool": "3333"},
         ])
         assert 'data-sort="0"' in rows
@@ -254,109 +255,122 @@ class TestWorkerRows:
 
 class TestTariContext:
     def test_active_tari_shows_checkmark(self):
-        ctx = _get_tari_context({"tari": {
+        ctx = build_tari_context({"tari": {
             "active": True, "status": "Mining", "reward": 12.5, "height": 42,
             "difficulty": 1234567, "address": "addr",
         }})
-        assert "✔" in ctx["tari_status"]
-        assert ctx["tari_status_class"] == "status-ok"
-        assert ctx["tari_reward"] == "12.50 TARI"
-        assert ctx["tari_height"] == "42"
-        assert ctx["tari_diff"] == "1,234,567"  # thousands separators
+        assert "✔" in ctx.tari_status
+        assert ctx.tari_status_class == "status-ok"
+        assert ctx.tari_reward == "12.50 TARI"
+        assert ctx.tari_height == "42"
+        assert ctx.tari_diff == "1,234,567"
 
     def test_inactive_tari_waiting(self):
-        ctx = _get_tari_context({"tari": {"active": False}})
-        assert ctx["tari_status"] == "Waiting..."
-        assert ctx["tari_status_class"] == ""
+        ctx = build_tari_context({"tari": {"active": False}})
+        assert ctx.tari_status == "Waiting..."
+        assert ctx.tari_status_class == ""
 
     def test_long_wallet_is_shortened(self):
         addr = "T" * 40
-        ctx = _get_tari_context({"tari": {"active": True, "address": addr}})
-        assert ctx["tari_wallet"] == addr            # full kept
-        assert "..." in ctx["tari_wallet_short"]      # short elided
-        assert len(ctx["tari_wallet_short"]) < len(addr)
+        ctx = build_tari_context({"tari": {"active": True, "address": addr}})
+        assert ctx.tari_wallet == addr
+        assert "..." in ctx.tari_wallet_short
+        assert len(ctx.tari_wallet_short) < len(addr)
 
     def test_missing_tari_block_uses_defaults(self):
-        ctx = _get_tari_context({})
-        assert ctx["tari_status"] == "Waiting..."
-        assert ctx["tari_wallet"] == "Unknown"
+        ctx = build_tari_context({})
+        assert ctx.tari_status == "Waiting..."
+        assert ctx.tari_wallet == "Unknown"
 
 
 class TestSystemContext:
     def test_high_usage_flags_badges(self):
-        ctx = _get_system_context({"system": {
+        ctx = build_system_context({"system": {
             "disk": {"percent": 95, "used_gb": 90, "total_gb": 100, "percent_str": "95%"},
             "memory": {"percent": 85, "used_gb": 13, "total_gb": 16, "percent_str": "85%"},
             "cpu_percent": "90.0%",
             "load": "0.5 0.4 0.3",
             "hugepages": ["Enabled", "status-ok", "1555/3072"],
         }})
-        assert ctx["disk_fill_class"] == "critical"   # > 90
-        assert ctx["disk_class"] == "status-bad"
-        assert "High Usage" in ctx["disk_badge"]
-        assert "High Usage" in ctx["mem_badge"]
-        assert "High Usage" in ctx["cpu_badge"]
-        assert ctx["cpu_load"] == "1m: 0.5 5m: 0.4 15m: 0.3"
-        assert ctx["hp_status"] == "Enabled"
+        assert ctx.disk_fill_class == "critical"   # > 90
+        assert ctx.disk_class == "status-bad"
+        assert "High Usage" in ctx.disk_badge
+        assert "High Usage" in ctx.mem_badge
+        assert "High Usage" in ctx.cpu_badge
+        assert ctx.cpu_load == "1m: 0.5 5m: 0.4 15m: 0.3"
+        assert ctx.hp_status == "Enabled"
 
     def test_warning_fill_between_70_and_90(self):
-        ctx = _get_system_context({"system": {"disk": {"percent": 75}}})
-        assert ctx["disk_fill_class"] == "warning"
+        ctx = build_system_context({"system": {"disk": {"percent": 75}}})
+        assert ctx.disk_fill_class == "warning"
 
     def test_unparseable_cpu_defaults_to_zero(self):
-        # A non-numeric cpu string must not raise; it degrades to 0% (no High-Usage badge).
-        ctx = _get_system_context({"system": {"cpu_percent": "n/a"}})
-        assert ctx["cpu_badge"] == ""
-        assert ctx["cpu_label_class"] == "text-muted"
+        ctx = build_system_context({"system": {"cpu_percent": "n/a"}})
+        assert ctx.cpu_badge == ""
+        assert ctx.cpu_label_class == "text-muted"
 
     def test_empty_system_uses_hugepages_default(self):
-        ctx = _get_system_context({})
-        assert ctx["hp_status"] == "Disabled"
-        assert ctx["hp_val"] == "0/0"
+        ctx = build_system_context({})
+        assert ctx.hp_status == "Disabled"
+        assert ctx.hp_val == "0/0"
 
 
 class TestSyncContext:
     def test_loading_when_no_target(self):
         ctx = build_sync_context({"percent": 0, "target": 0}, {"percent": 0, "target": 0}, False)
-        assert ctx["sync_percent"] == "…"
-        assert ctx["tari_sync_percent"] == "…"
-        assert ctx["sync_class"] == ""
-        assert ctx["page_title"] == "Mining Dashboard"
+        assert ctx.sync_percent == "…"
+        assert ctx.tari_sync_percent == "…"
+        assert ctx.sync_class == ""
+        assert ctx.page_title == "Mining Dashboard"
 
     def test_checkmark_at_full_sync(self):
         ctx = build_sync_context({"percent": 100, "target": 10, "current": 10},
                                  {"percent": 100, "target": 5, "current": 5}, False)
-        assert "✔" in ctx["sync_percent"]
-        assert "✔" in ctx["tari_sync_percent"]
+        assert "✔" in ctx.sync_percent
+        assert "✔" in ctx.tari_sync_percent
 
     def test_percent_and_remaining_mid_sync(self):
         ctx = build_sync_context({"percent": 42, "target": 100, "current": 42},
                                  {"percent": 10, "target": 100, "current": 10}, True)
-        assert ctx["sync_percent"] == "42%"
-        assert ctx["sync_remaining"] == 58
-        assert ctx["sync_class"] == "mode-sync"
-        assert ctx["page_title"] == "Mining Dashboard - Syncing"
+        assert ctx.sync_percent == "42%"
+        assert ctx.sync_remaining == 58
+        assert ctx.sync_class == "mode-sync"
+        assert ctx.page_title == "Mining Dashboard - Syncing"
+
+
+def _algo(**over):
+    """Build a full AlgoContext with placeholder values, overriding only what a test cares about."""
+    fields = {f: "" for f in AlgoContext.__dataclass_fields__}
+    fields["xvb_fail_count"] = 0
+    fields.update(mode_color="#238636", mode_name="P2POOL", low_hr_badge="")
+    fields.update(over)
+    return AlgoContext(**fields)
+
+
+def _pool(**over):
+    fields = {f: "" for f in PoolNetworkContext.__dataclass_fields__}
+    for int_field in ("strat_total_shares", "strat_conns", "strat_total_hashes", "proxy_workers",
+                      "pool_sidechain_height", "pool_total_hashes", "pool_miners", "pplns_wgt",
+                      "pool_blocks", "net_height"):
+        fields[int_field] = 0
+    fields.update(p2p_type="Main")
+    fields.update(over)
+    return PoolNetworkContext(**fields)
 
 
 class TestHeaderBadges:
-    def _algo(self, **over):
-        base = {"mode_color": "#238636", "mode_name": "P2POOL", "low_hr_badge": ""}
-        base.update(over)
-        return base
-
     def test_syncing_shows_syncing_badge_only(self):
-        out = build_header_badges({}, True, self._algo(), {"p2p_type": "Main"})
+        out = build_header_badges({}, True, _algo(), _pool())
         assert "Syncing..." in out
         assert "P2POOL" not in out  # mode badge suppressed during sync
 
     def test_operational_shows_mode_and_pool_type(self):
-        out = build_header_badges({}, False, self._algo(), {"p2p_type": "Mini"})
+        out = build_header_badges({}, False, _algo(), _pool(p2p_type="Mini"))
         assert "P2POOL" in out
         assert "P2Pool Mini" in out
 
     def test_low_hashrate_badge_appended(self):
-        out = build_header_badges({}, False, self._algo(low_hr_badge="<b>LOW</b>"),
-                                  {"p2p_type": "Main"})
+        out = build_header_badges({}, False, _algo(low_hr_badge="<b>LOW</b>"), _pool())
         assert "<b>LOW</b>" in out
 
     def test_node_down_and_rejected_badges(self):
@@ -364,22 +378,63 @@ class TestHeaderBadges:
             "monero_sync": {"down": True}, "tari_sync": {"down": True},
             "workers_rejected": True,
         }
-        out = build_header_badges(data, False, self._algo(), {"p2p_type": "Main"})
+        out = build_header_badges(data, False, _algo(), _pool())
         assert "monerod DOWN" in out
         assert "Tari DOWN" in out
         assert "Workers rejected" in out
 
     def test_miner_held_badge(self):
-        out = build_header_badges({"miner_held": True}, True, self._algo(), {})
+        out = build_header_badges({"miner_held": True}, True, _algo(), _pool())
         assert "Miner held (sync)" in out
 
     def test_passive_tari_badge_with_and_without_percent(self):
         with_pct = build_header_badges(
             {"tari_syncing_passive": True, "tari_sync": {"percent": 42}},
-            False, self._algo(), {"p2p_type": "Main"})
+            False, _algo(), _pool())
         assert "Tari syncing 42%" in with_pct
 
         no_pct = build_header_badges(
             {"tari_syncing_passive": True, "tari_sync": {"percent": 0}},
-            False, self._algo(), {"p2p_type": "Main"})
+            False, _algo(), _pool())
         assert "Tari syncing<" in no_pct  # bare label, no percentage
+
+
+class TestTemplateCache:
+    def test_get_cached_template_returns_str(self):
+        assert isinstance(get_cached_template(), str)
+        assert len(get_cached_template()) > 0
+
+    def test_template_error_fallback(self, monkeypatch):
+        views._TEMPLATE_CACHE = None
+        monkeypatch.setattr(views.os.path, "getmtime",
+                            lambda p: (_ for _ in ()).throw(OSError()))
+        assert get_cached_template() == "<h1>Template Error</h1>"
+
+
+class TestRenderDashboard:
+    """End-to-end render: every context block must satisfy the template contract."""
+
+    def test_renders_full_html(self):
+        sm = StateManager(db_path=":memory:")
+        data = {
+            "shares": [], "workers": [], "global_sync": False,
+            "monero_sync": {"percent": 100, "current": 10, "target": 10},
+            "tari_sync": {"percent": 50, "current": 5, "target": 10},
+        }
+        try:
+            html = render_dashboard(data, sm, "all")
+        finally:
+            sm.close()
+        assert html.startswith("<!DOCTYPE html>") or "<html" in html
+        # No unresolved placeholders should remain in the rendered page.
+        assert "{header_badges}" not in html
+        assert "{total_hr}" not in html
+
+    def test_propagates_state_errors(self):
+        # render_dashboard does not swallow errors; the handler is responsible for the 500.
+        from unittest.mock import MagicMock
+        bad_sm = MagicMock()
+        bad_sm.get_history.side_effect = RuntimeError("boom")
+        import pytest
+        with pytest.raises(RuntimeError):
+            render_dashboard({"workers": []}, bad_sm, "all")

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -1,0 +1,385 @@
+"""Unit tests for the dashboard presentation layer (mining_dashboard/web/views.py).
+
+These exercise the context builders in isolation — no aiohttp app, no request — which is
+the whole point of having pulled them out of the request handler (Issue #38).
+"""
+import time
+
+import mining_dashboard.web.views as views
+from mining_dashboard.web.views import (
+    _get_chart_context, _get_pool_network_context, _get_worker_rows,
+    _get_tari_context, _get_system_context, build_sync_context, build_header_badges,
+)
+from mining_dashboard.service.storage_service import StateManager
+
+
+class TestChartContext:
+    def _history(self, n, base_ts):
+        return [{"timestamp": base_ts + i, "v": i, "v_p2pool": 0, "v_xvb": 0,
+                 "t": "x"} for i in range(n)]
+
+    def test_range_filtering(self):
+        now = time.time()
+        history = [{"timestamp": now - 7200, "v": 1, "v_p2pool": 0, "v_xvb": 0, "t": "x"},
+                   {"timestamp": now - 60, "v": 2, "v_p2pool": 0, "v_xvb": 0, "t": "x"}]
+        ctx_all = _get_chart_context(history, [], "all")
+        ctx_1h = _get_chart_context(history, [], "1h")
+        # both return a context dict; 1h filtering drops the 2h-old point from the payload
+        assert isinstance(ctx_all, dict) and isinstance(ctx_1h, dict)
+        assert ctx_1h["cls_1h"] == "active"
+
+    def test_downsampling_caps_points(self):
+        now = time.time()
+        big = self._history(2000, now - 2000)
+        ctx = _get_chart_context(big, [], "all")
+        # Downsampled to <= 800 comma-separated points.
+        assert isinstance(ctx, dict)
+        assert len(ctx["chart_data"].split(",")) <= 800
+
+    def test_shares_mapped_to_nearest_history_point(self):
+        # Each share is bucketed onto the closest history sample; the marker count/radius/
+        # offset arrays line up with the history points (covers the share-overlay branch).
+        history = [
+            {"timestamp": 1000, "v": 500, "v_p2pool": 500, "v_xvb": 0, "t": "a"},
+            {"timestamp": 1060, "v": 600, "v_p2pool": 600, "v_xvb": 0, "t": "b"},
+        ]
+        shares = [{"ts": 1005}, {"ts": 1058}]
+        ctx = _get_chart_context(history, shares, "all")
+        assert ctx["chart_shares_c"] == "1,1"
+        # y offset is lifted 10% above the line value (500 -> 550.0, 600 -> 660.0).
+        assert ctx["chart_shares_y"] == "550.0,660.0"
+        assert ctx["chart_shares_r"] == "9,9"
+
+    def test_share_offset_floor_when_value_zero(self):
+        # A share landing on a zero-hashrate sample is floored to y=100 so the marker stays
+        # visible instead of sitting on the axis.
+        history = [{"timestamp": 1000, "v": 0, "v_p2pool": 0, "v_xvb": 0, "t": "a"}]
+        ctx = _get_chart_context(history, [{"ts": 1000}], "all")
+        assert ctx["chart_shares_y"] == "100"
+        assert ctx["chart_shares_c"] == "1"
+
+
+class TestAvgP2poolOverWindow:
+    def test_empty_history_returns_zero(self):
+        assert views._avg_p2pool_over_window([], 3600) == 0.0
+
+    def test_averages_v_p2pool_in_window(self):
+        now = time.time()
+        history = [
+            {"timestamp": now - 30, "v": 1000, "v_p2pool": 1000, "v_xvb": 0},
+            {"timestamp": now - 60, "v": 500, "v_p2pool": 500, "v_xvb": 0},
+        ]
+        assert views._avg_p2pool_over_window(history, 3600) == 750.0
+
+    def test_excludes_samples_outside_window(self):
+        now = time.time()
+        history = [
+            {"timestamp": now - 30, "v": 1000, "v_p2pool": 1000, "v_xvb": 0},
+            {"timestamp": now - 7200, "v": 200, "v_p2pool": 200, "v_xvb": 0},
+        ]
+        assert views._avg_p2pool_over_window(history, 3600) == 1000.0
+
+    def test_legacy_rows_count_as_p2pool(self):
+        now = time.time()
+        history = [{"timestamp": now - 30, "v": 800, "v_p2pool": 0, "v_xvb": 0}]
+        assert views._avg_p2pool_over_window(history, 3600) == 800.0
+
+    def test_xvb_samples_drag_average_down(self):
+        # Time spent donating to XvB reduces the P2Pool average (v_p2pool == 0 then).
+        now = time.time()
+        history = [
+            {"timestamp": now - 30, "v": 1000, "v_p2pool": 1000, "v_xvb": 0},
+            {"timestamp": now - 60, "v": 1000, "v_p2pool": 0, "v_xvb": 1000},
+        ]
+        assert views._avg_p2pool_over_window(history, 3600) == 500.0
+
+
+class TestAlgoContextColors:
+    MUTED = "#8b949e"
+
+    def _ctx(self, mode):
+        sm = StateManager(db_path=":memory:")
+        sm.update_xvb_stats(mode=mode)
+        try:
+            return views._get_algo_context({"total_live_h15": 100000}, sm, [])
+        finally:
+            sm.close()
+
+    def test_p2pool_mode_grays_xvb(self):
+        ctx = self._ctx("P2POOL")
+        assert ctx["xvb_color"] == self.MUTED
+        assert ctx["p2p_color"] != self.MUTED
+
+    def test_xvb_mode_grays_p2pool(self):
+        ctx = self._ctx("XVB")
+        assert ctx["p2p_color"] == self.MUTED
+        assert ctx["xvb_color"] != self.MUTED
+
+    def test_split_mode_both_active(self):
+        ctx = self._ctx("XVB (Split)")
+        assert ctx["p2p_color"] != self.MUTED
+        assert ctx["xvb_color"] != self.MUTED
+
+    def test_xvb_disabled_grays_xvb(self, monkeypatch):
+        monkeypatch.setattr(views, "ENABLE_XVB", False)
+        ctx = self._ctx("XVB")
+        assert ctx["xvb_color"] == self.MUTED
+        assert "Disabled" in ctx["mode_name"]
+        assert ctx["tier_name"] == "Disabled"
+
+
+class TestLowHashrateWarning:
+    def _ctx(self, monkeypatch, level, total_hr):
+        monkeypatch.setattr(views, "XVB_DONATION_LEVEL", level)
+        sm = StateManager(db_path=":memory:")
+        sm.update_xvb_stats(mode="P2POOL")
+        try:
+            return views._get_algo_context({"total_live_h15": total_hr}, sm, [])
+        finally:
+            sm.close()
+
+    def test_warns_when_selected_tier_unsustainable(self, monkeypatch):
+        # 50k can't sustain Mega (1M) -> warning badge.
+        ctx = self._ctx(monkeypatch, "mega", 50_000)
+        assert ctx["low_hr_badge"]
+
+    def test_no_warning_for_auto(self, monkeypatch):
+        # auto only ever targets a sustainable tier -> no warning.
+        ctx = self._ctx(monkeypatch, "auto", 50_000)
+        assert ctx["low_hr_badge"] == ""
+
+    def test_no_warning_when_sustainable(self, monkeypatch):
+        # 50k easily sustains Donor (1k) -> no warning.
+        ctx = self._ctx(monkeypatch, "donor", 50_000)
+        assert ctx["low_hr_badge"] == ""
+
+
+class TestMoneroMode:
+    """Pruned/Full label + DB size in the Monero panel (Issue #32)."""
+
+    def _ctx(self, db_size=0):
+        return _get_pool_network_context({"monero_sync": {"db_size": db_size}})
+
+    def test_local_pruned(self, monkeypatch):
+        monkeypatch.setattr(views, "MONERO_NODE_HOST", "172.28.0.26")
+        monkeypatch.setattr(views, "MONERO_PRUNE", True)
+        ctx = self._ctx(db_size=85_000_000_000)
+        assert ctx["monero_mode"] == "Pruned"
+        assert ctx["monero_db_size"] == "85.0 GB"
+        assert "XMR Pruned" in ctx["monero_prune_badge"]
+
+    def test_local_full(self, monkeypatch):
+        monkeypatch.setattr(views, "MONERO_NODE_HOST", "172.28.0.26")
+        monkeypatch.setattr(views, "MONERO_PRUNE", False)
+        ctx = self._ctx()
+        assert ctx["monero_mode"] == "Full"
+        assert "XMR Full" in ctx["monero_prune_badge"]
+
+    def test_remote_unknown(self, monkeypatch):
+        # A remote node's pruning state isn't something we probe — no badge.
+        monkeypatch.setattr(views, "MONERO_NODE_HOST", "10.0.0.9")
+        monkeypatch.setattr(views, "MONERO_PRUNE", True)
+        ctx = self._ctx()
+        assert ctx["monero_mode"] == "Unknown"
+        assert ctx["monero_prune_badge"] == ""
+
+    def test_db_size_dash_when_unknown(self, monkeypatch):
+        monkeypatch.setattr(views, "MONERO_NODE_HOST", "172.28.0.26")
+        monkeypatch.setattr(views, "MONERO_PRUNE", True)
+        assert self._ctx(db_size=0)["monero_db_size"] == "—"
+
+
+class TestWorkerRows:
+    """HTML table rows for the worker list (badges, sorting, escaping)."""
+
+    def test_online_p2pool_worker_rendered(self):
+        rows = _get_worker_rows([
+            {"name": "rig1", "ip": "10.0.0.1", "status": "online",
+             "active_pool": "3333", "uptime": 60, "h10": 1000, "h60": 1000, "h15": 1000},
+        ])
+        assert "rig1" in rows
+        assert "status-ok" in rows
+        assert ">P2Pool<" in rows  # P2Pool badge for a 3333 (p2pool) port
+
+    def test_offline_worker_marked_bad(self):
+        rows = _get_worker_rows([
+            {"name": "rig2", "ip": "10.0.0.2", "status": "offline",
+             "active_pool": "3333"},
+        ])
+        assert "status-bad" in rows
+
+    def test_xvb_badge_for_xvb_port(self):
+        rows = _get_worker_rows([
+            {"name": "rig3", "ip": "10.0.0.3", "status": "online", "active_pool": "3344"},
+        ])
+        assert ">XvB<" in rows
+
+    def test_unknown_badge_when_no_active_pool(self):
+        rows = _get_worker_rows([
+            {"name": "rig4", "ip": "10.0.0.4", "status": "online", "active_pool": ""},
+        ])
+        assert ">Unknown<" in rows
+
+    def test_worker_name_is_html_escaped(self):
+        rows = _get_worker_rows([
+            {"name": "<script>", "ip": "10.0.0.5", "status": "online", "active_pool": "3333"},
+        ])
+        assert "<script>" not in rows
+        assert "&lt;script&gt;" in rows
+
+    def test_online_sorted_before_offline(self):
+        rows = _get_worker_rows([
+            {"name": "zzz", "ip": "10.0.0.9", "status": "offline", "active_pool": "3333"},
+            {"name": "aaa", "ip": "10.0.0.1", "status": "online", "active_pool": "3333"},
+        ])
+        assert rows.index("aaa") < rows.index("zzz")  # online (aaa) comes first
+
+    def test_malformed_worker_is_skipped(self):
+        # A worker missing 'ip' raises inside the row build and is skipped (the good one
+        # still renders) rather than blowing up the whole table.
+        rows = _get_worker_rows([
+            {"name": "good", "ip": "10.0.0.1", "status": "online", "active_pool": "3333"},
+            {"name": "skipme", "status": "online", "active_pool": "3333"},  # no 'ip'
+        ])
+        assert 'data-sort="good"' in rows
+        assert "skipme" not in rows
+
+    def test_bad_ip_sorts_to_zero(self):
+        # A non-numeric IP can't be packed into a sort int -> falls back to 0, still renders.
+        rows = _get_worker_rows([
+            {"name": "rig", "ip": "not-an-ip", "status": "online", "active_pool": "3333"},
+        ])
+        assert 'data-sort="0"' in rows
+
+
+class TestTariContext:
+    def test_active_tari_shows_checkmark(self):
+        ctx = _get_tari_context({"tari": {
+            "active": True, "status": "Mining", "reward": 12.5, "height": 42,
+            "difficulty": 1234567, "address": "addr",
+        }})
+        assert "✔" in ctx["tari_status"]
+        assert ctx["tari_status_class"] == "status-ok"
+        assert ctx["tari_reward"] == "12.50 TARI"
+        assert ctx["tari_height"] == "42"
+        assert ctx["tari_diff"] == "1,234,567"  # thousands separators
+
+    def test_inactive_tari_waiting(self):
+        ctx = _get_tari_context({"tari": {"active": False}})
+        assert ctx["tari_status"] == "Waiting..."
+        assert ctx["tari_status_class"] == ""
+
+    def test_long_wallet_is_shortened(self):
+        addr = "T" * 40
+        ctx = _get_tari_context({"tari": {"active": True, "address": addr}})
+        assert ctx["tari_wallet"] == addr            # full kept
+        assert "..." in ctx["tari_wallet_short"]      # short elided
+        assert len(ctx["tari_wallet_short"]) < len(addr)
+
+    def test_missing_tari_block_uses_defaults(self):
+        ctx = _get_tari_context({})
+        assert ctx["tari_status"] == "Waiting..."
+        assert ctx["tari_wallet"] == "Unknown"
+
+
+class TestSystemContext:
+    def test_high_usage_flags_badges(self):
+        ctx = _get_system_context({"system": {
+            "disk": {"percent": 95, "used_gb": 90, "total_gb": 100, "percent_str": "95%"},
+            "memory": {"percent": 85, "used_gb": 13, "total_gb": 16, "percent_str": "85%"},
+            "cpu_percent": "90.0%",
+            "load": "0.5 0.4 0.3",
+            "hugepages": ["Enabled", "status-ok", "1555/3072"],
+        }})
+        assert ctx["disk_fill_class"] == "critical"   # > 90
+        assert ctx["disk_class"] == "status-bad"
+        assert "High Usage" in ctx["disk_badge"]
+        assert "High Usage" in ctx["mem_badge"]
+        assert "High Usage" in ctx["cpu_badge"]
+        assert ctx["cpu_load"] == "1m: 0.5 5m: 0.4 15m: 0.3"
+        assert ctx["hp_status"] == "Enabled"
+
+    def test_warning_fill_between_70_and_90(self):
+        ctx = _get_system_context({"system": {"disk": {"percent": 75}}})
+        assert ctx["disk_fill_class"] == "warning"
+
+    def test_unparseable_cpu_defaults_to_zero(self):
+        # A non-numeric cpu string must not raise; it degrades to 0% (no High-Usage badge).
+        ctx = _get_system_context({"system": {"cpu_percent": "n/a"}})
+        assert ctx["cpu_badge"] == ""
+        assert ctx["cpu_label_class"] == "text-muted"
+
+    def test_empty_system_uses_hugepages_default(self):
+        ctx = _get_system_context({})
+        assert ctx["hp_status"] == "Disabled"
+        assert ctx["hp_val"] == "0/0"
+
+
+class TestSyncContext:
+    def test_loading_when_no_target(self):
+        ctx = build_sync_context({"percent": 0, "target": 0}, {"percent": 0, "target": 0}, False)
+        assert ctx["sync_percent"] == "…"
+        assert ctx["tari_sync_percent"] == "…"
+        assert ctx["sync_class"] == ""
+        assert ctx["page_title"] == "Mining Dashboard"
+
+    def test_checkmark_at_full_sync(self):
+        ctx = build_sync_context({"percent": 100, "target": 10, "current": 10},
+                                 {"percent": 100, "target": 5, "current": 5}, False)
+        assert "✔" in ctx["sync_percent"]
+        assert "✔" in ctx["tari_sync_percent"]
+
+    def test_percent_and_remaining_mid_sync(self):
+        ctx = build_sync_context({"percent": 42, "target": 100, "current": 42},
+                                 {"percent": 10, "target": 100, "current": 10}, True)
+        assert ctx["sync_percent"] == "42%"
+        assert ctx["sync_remaining"] == 58
+        assert ctx["sync_class"] == "mode-sync"
+        assert ctx["page_title"] == "Mining Dashboard - Syncing"
+
+
+class TestHeaderBadges:
+    def _algo(self, **over):
+        base = {"mode_color": "#238636", "mode_name": "P2POOL", "low_hr_badge": ""}
+        base.update(over)
+        return base
+
+    def test_syncing_shows_syncing_badge_only(self):
+        out = build_header_badges({}, True, self._algo(), {"p2p_type": "Main"})
+        assert "Syncing..." in out
+        assert "P2POOL" not in out  # mode badge suppressed during sync
+
+    def test_operational_shows_mode_and_pool_type(self):
+        out = build_header_badges({}, False, self._algo(), {"p2p_type": "Mini"})
+        assert "P2POOL" in out
+        assert "P2Pool Mini" in out
+
+    def test_low_hashrate_badge_appended(self):
+        out = build_header_badges({}, False, self._algo(low_hr_badge="<b>LOW</b>"),
+                                  {"p2p_type": "Main"})
+        assert "<b>LOW</b>" in out
+
+    def test_node_down_and_rejected_badges(self):
+        data = {
+            "monero_sync": {"down": True}, "tari_sync": {"down": True},
+            "workers_rejected": True,
+        }
+        out = build_header_badges(data, False, self._algo(), {"p2p_type": "Main"})
+        assert "monerod DOWN" in out
+        assert "Tari DOWN" in out
+        assert "Workers rejected" in out
+
+    def test_miner_held_badge(self):
+        out = build_header_badges({"miner_held": True}, True, self._algo(), {})
+        assert "Miner held (sync)" in out
+
+    def test_passive_tari_badge_with_and_without_percent(self):
+        with_pct = build_header_badges(
+            {"tari_syncing_passive": True, "tari_sync": {"percent": 42}},
+            False, self._algo(), {"p2p_type": "Main"})
+        assert "Tari syncing 42%" in with_pct
+
+        no_pct = build_header_badges(
+            {"tari_syncing_passive": True, "tari_sync": {"percent": 0}},
+            False, self._algo(), {"p2p_type": "Main"})
+        assert "Tari syncing<" in no_pct  # bare label, no percentage


### PR DESCRIPTION
Closes #38
Closes #39

Refactor of the dashboard view layer (#38) and the `data_service` worker pipeline (#39). Done in two passes so the diff is reviewable commit-by-commit: a safe verbatim extraction first, then the deeper structural refactor the issues actually called for. **No intended behavior change** beyond removing one dead template key (`chart_data`).

> The #30 partial-update feature is stacked on top of this branch as a separate PR (#62), so this PR stays a pure refactor.

## #38 — typed view layer + thin transport
- **`mining_dashboard/web/views.py`** owns rendering. Each dashboard section is a **frozen `*Context` dataclass** whose fields *are* its template placeholders — explicit contract, and a forgotten field fails at construction (`TypeError`) instead of as a render-time `KeyError` in the 500 handler.
- **`render_dashboard()`** renders; **`build_view_model()`** assembles the flat field map (JSON-serializable — the seam #30/#45/#61 can reuse). The template cache moved here too.
- **`server.py` is pure transport** (~35 lines): routing, security-headers middleware, thin `handle_index`. Security-headers + template-cache behavior unchanged.
- Builders renamed `build_*_context` with focused helpers; dead `chart_data` dropped (verified the produced field set exactly matches the template's placeholder set, including format-spec fields like `{disk_used:.1f}`).

## #39 — named payload fields + per-shape parsers
- Three pure helpers: `_normalize_proxy_workers`, `_merge_direct_stats`, `_aggregate_hashrate`; `run()` reads as orchestration (fetch → normalize → merge → aggregate → I/O).
- xmrig-proxy 6.x magic indices (`w[2]`, `w[7]`, `w[8]`, `w[9]`) replaced with named constants (`_PX_*`, `_KHS_TO_HS`); `_normalize_proxy_workers` dispatches to `_parse_proxy_list_worker` / `_parse_legacy_dict_worker`.

## Tests & coverage
- `tests/web/test_views.py` exercises the builders by attribute, plus a `render_dashboard` end-to-end test (no unresolved `{placeholders}`) and a `build_view_model` JSON-serializability test; template-cache tests live here. `test_server.py` keeps route/error/middleware tests. `test_data_service.py` adds direct parser tests.
- **262 tests pass** (216 on `main`). Coverage: `web/server.py` 94%, `web/views.py` 99%, `service/data_service.py` 95%.

> Behavior-risk-tolerant refactor to be **manually tested** after merge. The only deliberate output change is the removal of the unused `chart_data` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
