### PR TITLE
CI: use preinstalled shellcheck instead of apt-get update (closes #64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      # shellcheck is preinstalled on ubuntu-* runners, so we invoke it directly.
+      # Avoid `apt-get update`, which refreshes every configured source (incl.
+      # unrelated third-party mirrors like dl.google.com) and intermittently fails
+      # the job when one is briefly out of sync — see issue #64.
       - name: Lint stack.sh and test scripts
         # Gate on warnings+errors (real issues); info-level style nits vary by shellcheck version.
         run: shellcheck --severity=warning stack.sh tests/stack/run.sh tests/stack/test_compose.sh


### PR DESCRIPTION
## Problem

The **Shell tests (shellcheck + stack.sh suite)** job intermittently failed at the *Install shellcheck* step, before any linting ran (e.g. on #62, a dashboard-only PR):

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz
   File has unexpected size (1214 != 1200). Mirror sync in progress? [IP: 192.178.155.136 443]
##[error]Process completed with exit code 100.
```

`sudo apt-get update` refreshes **every** configured apt source on the GitHub-hosted runner — including third-party repos the workflow doesn't use (`dl.google.com/linux/chrome-stable`, Microsoft, etc.). When one of those mirrors is briefly out of sync, `apt-get update` exits non-zero and fails the job, even though `shellcheck` lives in the Ubuntu archive and is unaffected. Re-running fixes it — a transient infra flake, not a code issue.

## Fix

`shellcheck` is **preinstalled on `ubuntu-*` GitHub-hosted runners**, so the install step is unnecessary. Drop it and invoke `shellcheck` directly — no `apt-get update` over third-party mirrors at all (issue #64, option 1).

```diff
-      - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      # shellcheck is preinstalled on ubuntu-* runners, so we invoke it directly.
+      # Avoid `apt-get update`, which refreshes every configured source ...
```

### Why not a dedicated action (ludeeus/reviewdog)?

Those actions are popular but **auto-discover** shell scripts. This repo deliberately lints only 3 files (`stack.sh`, `tests/stack/run.sh`, `tests/stack/test_compose.sh`) while leaving 6 others (worker scripts, Docker entrypoints) unlinted. Adopting an auto-discovering action would silently expand the lint to all 9 scripts — scope creep beyond this issue, with a real chance of newly failing CI. Keeping the explicit invocation preserves current behavior exactly.

## Verification

- `shellcheck --severity=warning stack.sh tests/stack/run.sh tests/stack/test_compose.sh` passes locally (shellcheck 0.11.0).
- The lint command and `bash tests/stack/run.sh` steps are unchanged.

## Acceptance (from #64)

- ✅ A transient mirror blip on an unrelated apt repo no longer fails the Shell tests job.
- ✅ shellcheck still runs against `stack.sh`, `tests/stack/run.sh`, and `tests/stack/test_compose.sh`.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)