### PR TITLE
Dashboard: light/dark/auto theme toggle, persisted (closes #43)

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/chart.mjs
+++ b/build/dashboard/mining_dashboard/web/static/chart.mjs
@@ -13,6 +13,27 @@ import { fmtTimestamp } from './logic.mjs';
 
 const RANGES = [['1h', '1 Hr'], ['24h', '24 Hr'], ['1w', '1 Wk'], ['1m', '1 Mo']];
 
+// Append an 8-bit alpha to a #rrggbb hex (Chart.js accepts #rrggbbaa). Non-hex values pass
+// through opaque, so a future palette change can't break the fills.
+const withAlpha = (hex, aa) => (/^#[0-9a-fA-F]{6}$/.test(hex) ? hex + aa : hex);
+
+// The chart's colours, read from the active theme's CSS variables (Issue #43) so the chart
+// matches light/dark/auto. Re-read on every sync() so a theme switch recolours it in place.
+function paletteColors() {
+    const cs = getComputedStyle(document.documentElement);
+    const v = (name, fallback) => cs.getPropertyValue(name).trim() || fallback;
+    const accent = v('--accent', '#58a6ff');
+    const purple = v('--purple', '#a371f7');
+    return {
+        accent, purple,
+        accentFill: withAlpha(accent, '1a'),   // ≈ 0.1 alpha
+        purpleFill: withAlpha(purple, '33'),   // ≈ 0.2 alpha
+        shares: v('--bad', '#da3633'),
+        grid: v('--border', '#30363d'),
+        ticks: v('--text-muted', '#8b949e'),
+    };
+}
+
 export class ChartCard extends Component {
     constructor(props) {
         super(props);
@@ -31,16 +52,17 @@ export class ChartCard extends Component {
         if (!canvas || typeof Chart === 'undefined') return;
         const d = this.props.chart;
         this.shareCounts = d.shares.map((s) => s.c);
+        const c = paletteColors();
         const self = this;
         this.chart = new Chart(canvas, {
             type: 'line',
             data: {
                 datasets: [
-                    { label: 'P2Pool', data: d.p2pool, borderColor: '#58a6ff', tension: 0.3, fill: true,
-                      backgroundColor: 'rgba(88,166,255,0.1)', pointRadius: 0, pointHitRadius: 20 },
-                    { label: 'XvB', data: d.xvb, borderColor: '#a371f7', tension: 0.3, fill: true,
-                      backgroundColor: 'rgba(163, 113, 247, 0.2)', pointRadius: 0, pointHitRadius: 20 },
-                    { label: 'Shares', data: d.shares, borderColor: '#FF0000', backgroundColor: '#FF0000',
+                    { label: 'P2Pool', data: d.p2pool, borderColor: c.accent, tension: 0.3, fill: true,
+                      backgroundColor: c.accentFill, pointRadius: 0, pointHitRadius: 20 },
+                    { label: 'XvB', data: d.xvb, borderColor: c.purple, tension: 0.3, fill: true,
+                      backgroundColor: c.purpleFill, pointRadius: 0, pointHitRadius: 20 },
+                    { label: 'Shares', data: d.shares, borderColor: c.shares, backgroundColor: c.shares,
                       pointStyle: 'triangle', rotation: 180, pointRadius: d.shares.map((s) => s.r),
                       pointHoverRadius: 15, pointHitRadius: 100, showLine: false },
                 ],
@@ -64,9 +86,9 @@ export class ChartCard extends Component {
                 },
                 scales: {
                     // Linear x positions points by real elapsed time (gaps occupy proportional
-                    // space); axis hidden as before. y unchanged.
+                    // space); axis hidden as before. y grid/ticks follow the theme.
                     x: { type: 'linear', display: false },
-                    y: { stacked: false, grid: { color: '#30363d' }, ticks: { color: '#8b949e' } },
+                    y: { stacked: false, grid: { color: c.grid }, ticks: { color: c.ticks } },
                 },
             },
         });
@@ -75,11 +97,15 @@ export class ChartCard extends Component {
     sync() {
         if (!this.chart) { this.create(); return; }
         const d = this.props.chart;
+        const c = paletteColors();   // re-read so a theme switch recolours in place
         this.shareCounts = d.shares.map((s) => s.c);
-        this.chart.data.datasets[0].data = d.p2pool;
-        this.chart.data.datasets[1].data = d.xvb;
-        this.chart.data.datasets[2].data = d.shares;
-        this.chart.data.datasets[2].pointRadius = d.shares.map((s) => s.r);
+        const ds = this.chart.data.datasets;
+        ds[0].data = d.p2pool; ds[0].borderColor = c.accent; ds[0].backgroundColor = c.accentFill;
+        ds[1].data = d.xvb;    ds[1].borderColor = c.purple; ds[1].backgroundColor = c.purpleFill;
+        ds[2].data = d.shares; ds[2].borderColor = c.shares; ds[2].backgroundColor = c.shares;
+        ds[2].pointRadius = d.shares.map((s) => s.r);
+        this.chart.options.scales.y.grid.color = c.grid;
+        this.chart.options.scales.y.ticks.color = c.ticks;
         this.chart.update();
         this.chart.resize();
     }

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -4,7 +4,7 @@
 // classes — it does no number formatting or business logic of its own.
 import { Component, Fragment, html } from './preact.mjs';
 import { ChartCard } from './chart.mjs';
-import { WORKER_COLUMNS, sortWorkers } from './logic.mjs';
+import { WORKER_COLUMNS, sortWorkers, THEME_ORDER, THEME_LABELS } from './logic.mjs';
 
 // Palette token -> text-colour class (defined in dashboard.css).
 const cVar = (v) => 'c-' + v;
@@ -37,6 +37,35 @@ const Badges = ({ badges }) => html`
 
 const HighUsage = ({ level }) =>
     level === 'high' ? html`<span class="badge badge-bad mx-1">High Usage</span>` : null;
+
+// Theme icons (Issue #43) — minimal Lucide-style line glyphs drawn with currentColor, so they
+// pick up the segment's text colour (muted → full on hover/active). Inline SVG keeps them crisp
+// at any DPI and needs no extra asset or CSP allowance.
+const svgIcon = (body) => html`
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor"
+         stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${body}</svg>`;
+const THEME_ICON = {
+    light: () => svgIcon(html`<circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />`),
+    auto: () => svgIcon(html`<rect x="2" y="3" width="20" height="14" rx="2" /><path d="M8 21h8M12 17v4" />`),
+    dark: () => svgIcon(html`<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />`),
+};
+
+// Fixed bottom-right segmented control to pick light / auto / dark (Issue #43). Icon-only and
+// visually quiet, with the active segment raised; the order/labels come from logic.mjs. Rendered
+// in every app state (loading / sync / dashboard) so it's always reachable; the choice is
+// persisted by the onTheme handler in dashboard.js.
+const ThemeSwitcher = ({ theme, onTheme }) => {
+    const current = theme || 'auto';
+    return html`
+    <div class="theme-switcher" role="group" aria-label="Theme">
+        ${THEME_ORDER.map((id) => html`
+            <button type="button" class=${'theme-seg' + (id === current ? ' active' : '')}
+                    title=${'Theme: ' + THEME_LABELS[id]} aria-label=${THEME_LABELS[id]}
+                    aria-pressed=${id === current} onClick=${() => onTheme(id)}>
+                ${THEME_ICON[id]()}
+            </button>`)}
+    </div>`;
+};
 
 // --- Top bar -------------------------------------------------------------------------
 
@@ -300,9 +329,14 @@ function DashboardView({ state, ui, onRange, onSort, onView }) {
 
 // --- Root ----------------------------------------------------------------------------
 
-export function App({ state, connected, ui, onRange, onSort, onView }) {
+export function App({ state, connected, ui, onRange, onSort, onView, onTheme }) {
+    // The theme toggle is fixed-position and always available, even before the first data load.
+    const switcher = html`<${ThemeSwitcher} theme=${ui.theme} onTheme=${onTheme} />`;
     if (!state) {
-        return html`<div class="loading">${connected ? 'Connecting to the dashboard…' : 'Cannot reach the dashboard.'}</div>`;
+        return html`<${Fragment}>
+            <div class="loading">${connected ? 'Connecting to the dashboard…' : 'Cannot reach the dashboard.'}</div>
+            ${switcher}
+        <//>`;
     }
     return html`<${Fragment}>
         <${Header} state=${state} />
@@ -310,5 +344,6 @@ export function App({ state, connected, ui, onRange, onSort, onView }) {
         ${state.syncing
             ? html`<${SyncView} sync=${state.sync} />`
             : html`<${DashboardView} state=${state} ui=${ui} onRange=${onRange} onSort=${onSort} onView=${onView} />`}
+        ${switcher}
     <//>`;
 }

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -6,12 +6,45 @@
  * (palette colours, gauges) or set at runtime via the CSSOM in dashboard.js (the gauge
  * fill %, which can't be a fixed class). Nothing here is templated — it's static CSS. */
 
-:root {
+/* ---- Theme palettes (Issue #43) -------------------------------------------------------
+ * Three modes, selected by a `data-theme` attribute on <html> — set by theme-init.js before
+ * the first paint and updated by dashboard.js on toggle, persisted in localStorage:
+ *   - "dark"          explicit dark
+ *   - "light"         explicit light
+ *   - "auto" / unset  follow the browser via prefers-color-scheme
+ * Dark is the base (`:root`) so the pre-JS shell — and any stale/unknown value — defaults to
+ * it; the light palette applies for explicit light and for auto/unset under a light system.
+ * Everything downstream is expressed in these variables, so components, the sync gauge and the
+ * Chart.js chart (which reads them via getComputedStyle) all follow the active theme. */
+:root,
+:root[data-theme="dark"] {
     --bg: #0d1117; --card: #161b22; --border: #30363d;
     --text: #c9d1d9; --text-muted: #8b949e;
     --accent: #58a6ff; --ok: #238636; --bad: #da3633; --warn: #d29922; --purple: #a371f7;
+    --elevated: #2d333b;   /* raised surface (e.g. the active theme segment): lighter than --card */
 }
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); padding: 20px; margin: 0; }
+
+/* Light palette — GitHub Primer light, mirroring the dark set's GitHub-dark origin. Kept in
+ * sync with the auto block below (plain CSS has no way to share one declaration list across a
+ * selector and a media query). */
+:root[data-theme="light"] {
+    --bg: #ffffff; --card: #f6f8fa; --border: #d0d7de;
+    --text: #1f2328; --text-muted: #656d76;
+    --accent: #0969da; --ok: #1a7f37; --bad: #cf222e; --warn: #9a6700; --purple: #8250df;
+    --elevated: #ffffff;   /* white raised thumb on the off-white --card track */
+}
+
+/* Auto: follow the system, but only when the user hasn't pinned dark or light. */
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]):not([data-theme="light"]) {
+        --bg: #ffffff; --card: #f6f8fa; --border: #d0d7de;
+        --text: #1f2328; --text-muted: #656d76;
+        --accent: #0969da; --ok: #1a7f37; --bad: #cf222e; --warn: #9a6700; --purple: #8250df;
+        --elevated: #ffffff;
+    }
+}
+
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); padding: 20px; margin: 0; transition: background-color 0.2s ease, color 0.2s ease; }
 
 .container { max-width: 1400px; margin: 0 auto; }
 
@@ -40,7 +73,7 @@ h3 { margin: 0 0 15px 0; font-size: 0.85rem; text-transform: uppercase; color: v
 /* Table */
 table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
 th { text-align: left; font-size: 0.75rem; color: var(--text-muted); padding: 10px; border-bottom: 1px solid var(--border); text-transform: uppercase; cursor: pointer; }
-td { padding: 10px; border-bottom: 1px solid #21262d; }
+td { padding: 10px; border-bottom: 1px solid var(--border); }
 tr:last-child td { border-bottom: none; }
 
 /* Components */
@@ -63,7 +96,7 @@ tr:last-child td { border-bottom: none; }
 /* Header status badges sit in a gapped row, so individual badges need no margins. */
 .badge-row { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-left: 10px; }
 
-.wallet-text { font-size: 0.7rem; color: #666; margin-top: auto; padding-top: 15px; word-break: break-all; font-family: monospace; }
+.wallet-text { font-size: 0.7rem; color: var(--text-muted); margin-top: auto; padding-top: 15px; word-break: break-all; font-family: monospace; }
 
 /* Chart Controls */
 .chart-controls { display: flex; justify-content: center; align-items: center; gap: 5px; margin-bottom: 15px; }
@@ -75,8 +108,28 @@ tr:last-child td { border-bottom: none; }
 .view-controls { display: flex; justify-content: flex-end; margin-bottom: 15px; }
 .toggle-group { display: inline-flex; background: var(--card); border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
 .btn-toggle { background: transparent; border: none; color: var(--text-muted); padding: 6px 16px; cursor: pointer; font-size: 0.85rem; transition: all 0.2s; }
-.btn-toggle:hover { color: var(--text); background: rgba(255,255,255,0.05); }
+.btn-toggle:hover { color: var(--text); background: rgba(128,128,128,0.15); }
 .btn-toggle.active { background: var(--accent); color: #fff; font-weight: 600; }
+
+/* Theme switcher (Issue #43): a small fixed segmented control in the bottom-right that picks
+ * light / auto / dark. Kept visually quiet — muted icons on a subtle pill — with the active
+ * segment raised. The chosen mode is persisted in localStorage and re-applied before the first
+ * paint (see dashboard.js / theme-init.js), so it survives reloads and stack restarts. */
+.theme-switcher {
+    position: fixed; bottom: 16px; right: 16px; z-index: 50;
+    display: inline-flex; gap: 2px; padding: 3px;
+    background: var(--card); border: 1px solid var(--border); border-radius: 999px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+.theme-seg {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 30px; height: 28px; padding: 0; border: 0; border-radius: 999px;
+    background: transparent; color: var(--text-muted); cursor: pointer;
+    transition: color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+}
+.theme-seg:hover { color: var(--text); }
+.theme-seg.active { background: var(--elevated); color: var(--text); box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22); }
+.theme-seg svg { display: block; }
 
 /* View Modes */
 .card-advanced { display: none !important; }
@@ -132,10 +185,10 @@ tr:last-child td { border-bottom: none; }
 .progress-wheel {
   width: 100%; height: 100%; border-radius: 50%;
   /* --p is set at runtime by dashboard.js from the data-percent attribute. */
-  background: conic-gradient(#238636 var(--p), #30363d 0deg);
+  background: conic-gradient(var(--ok) var(--p), var(--border) 0deg);
   display: flex; align-items: center; justify-content: center;
 }
-.progress-wheel::before { content: ""; position: absolute; width: 120px; height: 120px; border-radius: 50%; background: #161b22; }
-.progress-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 24px; font-weight: bold; color: #fff; z-index: 10; }
-.status-text { font-size: 1.1em; margin-top: 15px; color: #8b949e; text-align: center; }
-.header-placeholder { text-align: center; margin: 40px 0; border-bottom: 1px solid #30363d; padding-bottom: 20px; }
+.progress-wheel::before { content: ""; position: absolute; width: 120px; height: 120px; border-radius: 50%; background: var(--card); }
+.progress-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 24px; font-weight: bold; color: var(--text); z-index: 10; }
+.status-text { font-size: 1.1em; margin-top: 15px; color: var(--text-muted); text-align: center; }
+.header-placeholder { text-align: center; margin: 40px 0; border-bottom: 1px solid var(--border); padding-bottom: 20px; }

--- a/build/dashboard/mining_dashboard/web/static/dashboard.js
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.js
@@ -6,6 +6,7 @@
 // the simple/advanced view — plus the latest data snapshot and connection status.
 import { render, html } from './preact.mjs';
 import { App } from './components.mjs';
+import { normalizeTheme } from './logic.mjs';
 
 const root = document.getElementById('app');
 const REFRESH_MS = 30000;
@@ -15,7 +16,17 @@ const ui = {
     sortIndex: null,
     sortAsc: true,
     view: localStorage.getItem('dashboardView') === 'advanced' ? 'advanced' : 'simple',
+    // Theme is persisted in localStorage so it survives reloads and stack restarts (Issue #43).
+    // theme-init.js already applied it to <html> before first paint; we mirror it into the UI
+    // state and re-apply on toggle.
+    theme: normalizeTheme(localStorage.getItem('dashboardTheme')),
 };
+
+// Reflect the current theme onto <html data-theme>; the CSS palette (and the chart, which reads
+// the resolved CSS variables) follow from there.
+function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+}
 
 let state = null;        // latest /api/state payload, or null before the first response
 let connected = true;    // false after a failed fetch (we keep showing the last snapshot)
@@ -24,7 +35,7 @@ let inflight = false;    // guard against overlapping fetches if one is slow
 function rerender() {
     render(
         html`<${App} state=${state} connected=${connected} ui=${ui}
-                     onRange=${setRange} onSort=${onSort} onView=${setView} />`,
+                     onRange=${setRange} onSort=${onSort} onView=${setView} onTheme=${setTheme} />`,
         root,
     );
 }
@@ -66,6 +77,14 @@ function setView(mode) {
     rerender();
 }
 
+function setTheme(theme) {
+    ui.theme = theme;
+    localStorage.setItem('dashboardTheme', theme);
+    applyTheme(theme);   // updates <html data-theme>; the chart recolours on the next render
+    rerender();
+}
+
+applyTheme(ui.theme);            // re-assert the (normalized) theme before the first paint
 rerender();                      // paint the loading shell immediately
 tick();                          // first data load
 setInterval(tick, REFRESH_MS);   // then live updates

--- a/build/dashboard/mining_dashboard/web/static/logic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/logic.mjs
@@ -36,3 +36,18 @@ export function fmtTimestamp(ms) {
         month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
     });
 }
+
+// Theme switching (Issue #43). Three modes; "auto" follows the browser's prefers-color-scheme.
+// The valid set, display order and labels live here (pure, no DOM) so they're unit-tested; the
+// localStorage + <html data-theme> wiring is in dashboard.js and the segmented control (with its
+// SVG icons) in components.mjs.
+export const THEMES = ['auto', 'light', 'dark'];
+export const THEME_LABELS = { auto: 'Auto', light: 'Light', dark: 'Dark' };
+// Left→right order of the segmented control: light · auto · dark (brightness low→high with the
+// system option in the middle).
+export const THEME_ORDER = ['light', 'auto', 'dark'];
+
+// Clamp any value (incl. a stale/garbage localStorage entry) to a valid theme; default "auto".
+export function normalizeTheme(t) {
+    return THEMES.includes(t) ? t : 'auto';
+}

--- a/build/dashboard/mining_dashboard/web/static/theme-init.js
+++ b/build/dashboard/mining_dashboard/web/static/theme-init.js
@@ -1,0 +1,20 @@
+// Apply the saved theme (Issue #43) before the first paint, so an explicit light/dark choice
+// doesn't flash the opposite palette while the deferred ES modules load.
+//
+// This is intentionally a *classic*, render-blocking <script src> in <head> (not a module —
+// modules are deferred and would run after the shell has already painted). It's same-origin,
+// so it loads under the CSP's `script-src 'self'` without needing 'unsafe-inline'.
+//
+// It only sets the attribute the CSS reacts to; dashboard.js owns the live toggle and keeps
+// localStorage in sync. An unset/unknown value is left alone — the CSS default is "auto"
+// (follow prefers-color-scheme), so nothing to do.
+(function () {
+    try {
+        var t = localStorage.getItem('dashboardTheme');
+        if (t === 'light' || t === 'dark' || t === 'auto') {
+            document.documentElement.setAttribute('data-theme', t);
+        }
+    } catch (e) {
+        /* localStorage blocked (e.g. privacy mode) — fall back to the CSS default (auto). */
+    }
+})();

--- a/build/dashboard/mining_dashboard/web/templates/index.html
+++ b/build/dashboard/mining_dashboard/web/templates/index.html
@@ -6,6 +6,10 @@
     <title>Mining Dashboard</title>
     <link rel="icon" type="image/png" href="/static/p2pool-starter-stack-logo.png">
     <link rel="apple-touch-icon" href="/static/p2pool-starter-stack-logo.png">
+    <!-- Apply the saved light/dark/auto theme before the stylesheet paints, to avoid a flash
+         of the wrong palette (Issue #43). Classic blocking script, not a module, so it runs
+         before first paint; same-origin so it loads under the CSP's script-src 'self'. -->
+    <script src="/static/theme-init.js"></script>
     <link rel="stylesheet" href="/static/dashboard.css">
     <!-- Chart.js is a classic global (window.Chart); the app is an ES module that uses it. -->
     <script src="/static/chart.umd.min.js"></script>

--- a/build/dashboard/tests/frontend/logic.test.mjs
+++ b/build/dashboard/tests/frontend/logic.test.mjs
@@ -9,7 +9,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { sortWorkers, fmtTimestamp, WORKER_COLUMNS } from '../../mining_dashboard/web/static/logic.mjs';
+import {
+    sortWorkers, fmtTimestamp, WORKER_COLUMNS,
+    THEMES, THEME_ORDER, normalizeTheme,
+} from '../../mining_dashboard/web/static/logic.mjs';
 
 const col = (key) => WORKER_COLUMNS.findIndex((c) => c.key === key);
 
@@ -71,4 +74,16 @@ test('fmtTimestamp: returns a non-empty string for an epoch-ms value', () => {
     const out = fmtTimestamp(0);
     assert.equal(typeof out, 'string');
     assert.ok(out.length > 0);
+});
+
+test('normalizeTheme: passes valid modes through, defaults the rest to auto', () => {
+    for (const t of THEMES) assert.equal(normalizeTheme(t), t);
+    assert.equal(normalizeTheme(null), 'auto');       // nothing saved yet
+    assert.equal(normalizeTheme('sepia'), 'auto');    // garbage in localStorage
+});
+
+test('THEME_ORDER: the control renders every theme exactly once', () => {
+    // The segmented control maps over THEME_ORDER, so it must cover the same set as THEMES with
+    // no dupes/strays — otherwise a mode would be unreachable or rendered twice.
+    assert.deepEqual([...THEME_ORDER].sort(), [...THEMES].sort());
 });


### PR DESCRIPTION
Closes #43.

Adds light / dark / auto theming to the dashboard, which was previously hard-coded dark.

## What's in it
- **Three palettes** selected by a `data-theme` attribute on `<html>`. `auto` (the default) follows `prefers-color-scheme`. The dark palette is the GitHub-dark set the dashboard already used; the light palette is GitHub Primer light. Everything is now expressed in CSS variables, so the sync gauge and a handful of previously hard-coded hexes (table separators, wallet text, toggle hover) theme correctly too.
- **A subtle segmented control** fixed in the bottom-right — `☀ Light · 🖥 Auto · 🌙 Dark` as inline Lucide-style SVG icons. Icons are muted by default; only the active segment is raised, via a new `--elevated` surface token so it reads clearly in both themes (GitHub Primer SegmentedControl pattern). `role="group"` + per-segment `aria-label`/`aria-pressed`.
- **Theme-aware chart** — Chart.js line/fill/grid/tick colours are read from the CSS variables and recolour in place when you switch.
- **Persistence** — the choice is stored in `localStorage`, so it survives page reloads **and** stack/container restarts (browser-side, keyed to the origin). It's re-applied before first paint by a classic, same-origin `theme-init.js`, so there's no flash of the wrong palette.

## Design notes
- **Purely client-side** (the issue's open question): no server/config state, `server.py` stays pure transport.
- **CSP unchanged** — still no `unsafe-inline`/`unsafe-eval`. `theme-init.js` is an external same-origin script; icons are inline SVG, not inline scripts/styles.

## Tests
- `node --test` frontend: green (added coverage for `normalizeTheme` and that the control renders every mode exactly once).
- `pytest` with the coverage gate: green, including the CSP and shell-HTML assertions.
- Manually verified in a browser: light, dark, and auto (follows the emulated system preference); chart recolours; selection persists across a full reload.

## Screenshots
Active segment raised; inactive icons muted.

- Light: white thumb on the off-white track.
- Dark: lighter thumb on the dark track, chart grid/lines recoloured.