### PR TITLE
Launch polish: doc service count, UTC default TZ, avahi :ro, monerod RPC comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ addresses, provisions Tor, tunes the kernel for RandomX, and offers to start the
 | **[Configuration](docs/configuration.md)** | Every `config.json` key, applying changes safely, reusing an existing node, and remote Monero nodes. |
 | **[The Dashboard](docs/dashboard.md)** | Sync Mode and a tour of the live operational view. |
 | **[Connecting Miners](docs/workers.md)** | Point any existing rig at the stack, or spin up a tuned miner with [RigForge](https://github.com/p2pool-starter-stack/rigforge). |
-| **[Architecture](docs/architecture.md)** | The eight services, the privacy model, and the algorithmic XvB switching engine. |
+| **[Architecture](docs/architecture.md)** | The nine services, the privacy model, and the algorithmic XvB switching engine. |
 | **[Operations & Maintenance](docs/operations.md)** | Full command reference, upgrades, backups, and troubleshooting. |
 
 Browse the full index at **[docs/](docs/README.md)**.

--- a/build/monero/bitmonero.conf.template
+++ b/build/monero/bitmonero.conf.template
@@ -9,7 +9,10 @@ prune-blockchain=${MONERO_PRUNE}
 sync-pruned-blocks=${MONERO_PRUNE}
 
 # --- Network Interface Binding ---
-# Bind to all interfaces (0.0.0.0) to allow communication with P2Pool and Tari containers
+# Bind to all interfaces (0.0.0.0) to allow communication with P2Pool and Tari containers.
+# NOTE: this 0.0.0.0 is *container-internal* only. Host-level RPC exposure is controlled
+# separately by MONERO_RPC_BIND in docker-compose.yml (default 127.0.0.1 — localhost only).
+# Combined with restricted-rpc=1 + rpc-login below, the RPC is not reachable off-host by default.
 p2p-bind-ip=0.0.0.0
 p2p-bind-port=18080
 rpc-bind-ip=0.0.0.0

--- a/config.advanced.example.json
+++ b/config.advanced.example.json
@@ -44,6 +44,7 @@
     "dashboard": {
         "secure": true,
         "host": "auto",
+        "timezone": "auto",
         "data_dir": "auto",
         "tari_required": true
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,10 +213,12 @@ services:
         - ${P2POOL_DATA_DIR}/stats:/app/stats:ro
         - ${DASHBOARD_DATA_DIR}:/data
         - /var/run/dbus:/var/run/dbus:ro
-        - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+        - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket:ro
       environment:
       - HOST_IP=${HOST_IP:-127.0.0.1}
-      - TZ=${TZ:-America/Chicago}
+      # Timezone for dashboard timestamps/charts. Override by setting TZ in your
+      # environment / .env (e.g. TZ=America/Chicago); defaults to UTC.
+      - TZ=${TZ:-Etc/UTC}
       - MONERO_NODE_HOST=${MONERO_NODE_HOST:-172.28.0.26}
       # monerod get_info RPC creds (Issue #29): the dashboard reads sync height/target over
       # 127.0.0.1:18081 (reachable via network_mode: host) using digest auth, instead of

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,9 +216,9 @@ services:
         - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket:ro
       environment:
       - HOST_IP=${HOST_IP:-127.0.0.1}
-      # Timezone for dashboard timestamps/charts. Override by setting TZ in your
-      # environment / .env (e.g. TZ=America/Chicago); defaults to UTC.
-      - TZ=${TZ:-Etc/UTC}
+      # Timezone for dashboard timestamps/charts. Set via `dashboard.timezone` in
+      # config.json (pithead renders it to DASHBOARD_TZ in .env); defaults to Etc/UTC.
+      - TZ=${DASHBOARD_TZ:-Etc/UTC}
       - MONERO_NODE_HOST=${MONERO_NODE_HOST:-172.28.0.26}
       # monerod get_info RPC creds (Issue #29): the dashboard reads sync height/target over
       # 127.0.0.1:18081 (reachable via network_mode: host) using digest auth, instead of

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,7 @@ services:
         - ${P2POOL_DATA_DIR}/stats:/app/stats:ro
         - ${DASHBOARD_DATA_DIR}:/data
         - /var/run/dbus:/var/run/dbus:ro
-        - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket:ro
+        - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
       environment:
       - HOST_IP=${HOST_IP:-127.0.0.1}
       # Timezone for dashboard timestamps/charts. Set via `dashboard.timezone` in config.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,8 +216,9 @@ services:
         - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket:ro
       environment:
       - HOST_IP=${HOST_IP:-127.0.0.1}
-      # Timezone for dashboard timestamps/charts. Set via `dashboard.timezone` in
-      # config.json (pithead renders it to DASHBOARD_TZ in .env); defaults to Etc/UTC.
+      # Timezone for dashboard timestamps/charts. Set via `dashboard.timezone` in config.json
+      # (`auto` = the host's timezone, auto-detected); pithead renders it to DASHBOARD_TZ in
+      # .env. The Etc/UTC here is only a last-resort fallback if DASHBOARD_TZ is unset.
       - TZ=${DASHBOARD_TZ:-Etc/UTC}
       - MONERO_NODE_HOST=${MONERO_NODE_HOST:-172.28.0.26}
       # monerod get_info RPC creds (Issue #29): the dashboard reads sync height/target over

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ deeper on individual topics once you're up and running.
 | [Configuration](configuration.md) | Every `config.json` key and default, applying changes safely, **reusing an existing node via data directories**, and connecting to a **remote Monero node**. |
 | [The Dashboard](dashboard.md) | **Sync Mode**, the live operational view, and how to read every panel. |
 | [Connecting Miners](workers.md) | Pointing any existing rig at the stack, plus [RigForge](https://github.com/p2pool-starter-stack/rigforge) for setting up new miners. |
-| [Architecture](architecture.md) | The eight services, how they fit together, the privacy model, and the algorithmic XvB switching engine. |
+| [Architecture](architecture.md) | The nine services, how they fit together, the privacy model, and the algorithmic XvB switching engine. |
 | [Operations & Maintenance](operations.md) | The full `pithead` command reference, upgrades, backups, and troubleshooting. |
 
 ## Quick links

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ plain HTTP, edit `config.json` and run `./pithead apply`.
 | `tor.data_dir` | `auto` | Where Tor's state (including onion keys) lives. `auto` = `./data/tor`. |
 | `dashboard.secure` | `true` | `true` serves the dashboard over HTTPS (Caddy `tls internal`); `false` uses plain HTTP. |
 | `dashboard.host` | `auto` | Hostname you use to reach the dashboard. `auto` = this machine's hostname. |
-| `dashboard.timezone` | `auto` | Timezone for the dashboard's timestamps and charts. `auto` = `Etc/UTC`; set an IANA name (e.g. `America/Chicago`) for local time. |
+| `dashboard.timezone` | `auto` | Timezone for the dashboard's timestamps and charts. `auto` = **the host machine's timezone** (auto-detected, falling back to `Etc/UTC`); set an IANA name (e.g. `America/Chicago`) to override. |
 | `dashboard.data_dir` | `auto` | Where the dashboard's database lives. `auto` = `./data/dashboard`. |
 | `dashboard.tari_required` | `true` | How much a Tari problem holds up the rest of the stack. Monero is **required** to mine, so its behavior isn't configurable: a monerod outage always rejects workers (stops `xmrig-proxy` so miners **fail over to their backup pools**), and the miner is always held until monerod finishes syncing. Tari is **only needed for merge mining**, so this one flag decides how much it blocks. **`true` (default):** a Tari outage also rejects workers, the miner waits for Tari's initial sync too, and a Tari-only (re)sync shows the full-screen Sync view. **`false` (non-blocking):** keep mining Monero through a Tari outage, start mining as soon as Monero is synced (Tari finishes in the background), and keep the normal dashboard — with a `Tari syncing` indicator — instead of the takeover screen. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,7 @@ plain HTTP, edit `config.json` and run `./pithead apply`.
 | `tor.data_dir` | `auto` | Where Tor's state (including onion keys) lives. `auto` = `./data/tor`. |
 | `dashboard.secure` | `true` | `true` serves the dashboard over HTTPS (Caddy `tls internal`); `false` uses plain HTTP. |
 | `dashboard.host` | `auto` | Hostname you use to reach the dashboard. `auto` = this machine's hostname. |
+| `dashboard.timezone` | `auto` | Timezone for the dashboard's timestamps and charts. `auto` = `Etc/UTC`; set an IANA name (e.g. `America/Chicago`) for local time. |
 | `dashboard.data_dir` | `auto` | Where the dashboard's database lives. `auto` = `./data/dashboard`. |
 | `dashboard.tari_required` | `true` | How much a Tari problem holds up the rest of the stack. Monero is **required** to mine, so its behavior isn't configurable: a monerod outage always rejects workers (stops `xmrig-proxy` so miners **fail over to their backup pools**), and the miner is always held until monerod finishes syncing. Tari is **only needed for merge mining**, so this one flag decides how much it blocks. **`true` (default):** a Tari outage also rejects workers, the miner waits for Tari's initial sync too, and a Tari-only (re)sync shows the full-screen Sync view. **`false` (non-blocking):** keep mining Monero through a Tari outage, start mining as soon as Monero is synced (Tari finishes in the background), and keep the normal dashboard — with a `Tari syncing` indicator — instead of the takeover screen. |
 

--- a/pithead
+++ b/pithead
@@ -699,22 +699,23 @@ ensure_directories() {
     fi
 }
 
-# Decide the hostname the dashboard is reached at: config wins, then the preserved .env value,
-# then (only during interactive setup) a prompt, otherwise the machine hostname.
+# Decide the hostname the dashboard is reached at: an explicit dashboard.host wins; otherwise
+# "auto"/unset means this machine's hostname, re-derived each run (so reverting to "auto" takes
+# effect). Interactive setup prompts, defaulting to any previously-set value then the hostname.
 resolve_dashboard_host() {
     local allow_prompt="${1:-}"
     if [ -n "${DASHBOARD_HOST:-}" ]; then
         HOST_IP="$DASHBOARD_HOST"
         log "Using dashboard hostname '$HOST_IP' from $CONFIG_FILE."
-    elif [ -n "${PRESERVED_HOST_IP:-}" ]; then
-        HOST_IP="$PRESERVED_HOST_IP"
     elif [ "$allow_prompt" == "interactive" ]; then
         local default_host
-        default_host=$(hostname)
+        default_host="${PRESERVED_HOST_IP:-$(hostname)}"
         echo "The stack needs to know what hostname you will use to access the dashboard in your browser."
         read -r -p "Enter Hostname [$default_host]: " input_host || true
         HOST_IP="${input_host:-$default_host}"
     else
+        # "auto"/unset on a non-interactive run (e.g. apply): always the machine hostname, so
+        # setting dashboard.host back to "auto" reverts HOST_IP instead of keeping a stale value.
         HOST_IP=$(hostname)
     fi
 }

--- a/pithead
+++ b/pithead
@@ -317,6 +317,32 @@ resolve_default() {
     esac
 }
 
+# Best-effort detection of the host's IANA timezone (Linux + macOS), used as the dashboard
+# default when dashboard.timezone is "auto"/unset. Falls back to Etc/UTC if it can't tell.
+detect_host_timezone() {
+    local tz="" link
+    # 1) Explicit TZ in the environment wins.
+    if [ -n "${TZ:-}" ]; then tz="$TZ"
+    # 2) systemd hosts.
+    elif command -v timedatectl >/dev/null 2>&1; then
+        tz=$(timedatectl show -p Timezone --value 2>/dev/null || true)
+    fi
+    # 3) Debian/Ubuntu file.
+    [ -z "$tz" ] && [ -r /etc/timezone ] && tz=$(cat /etc/timezone 2>/dev/null || true)
+    # 4) /etc/localtime symlink (works on Linux + macOS): .../zoneinfo/<Area/City>.
+    if [ -z "$tz" ] && [ -L /etc/localtime ]; then
+        link=$(readlink /etc/localtime 2>/dev/null || true)
+        tz=${link##*/zoneinfo/}
+        [ "$tz" = "$link" ] && tz=""   # prefix not found -> unusable
+    fi
+    # Sanity-check it looks like an IANA zone (Area/City, UTC, Etc/GMT+5, ...); else UTC.
+    if [ -n "$tz" ] && [[ "$tz" =~ ^[A-Za-z0-9._+-]+(/[A-Za-z0-9._+-]+)*$ ]]; then
+        printf '%s' "$tz"
+    else
+        printf '%s' "Etc/UTC"
+    fi
+}
+
 # --- Setup Steps ---
 
 # Read the os-release file into OS_ID / OS_VERSION / OS_PRETTY (subshell-sourced to avoid clobber).
@@ -615,9 +641,10 @@ parse_and_validate_config() {
     DASHBOARD_HOST=$(resolve_default "$(jq -r '.dashboard.host // empty' "$CONFIG_FILE")" "")
     # Ensure a strict true/false string is returned, defaulting to true
     DASHBOARD_SECURE=$(jq -r 'if .dashboard.secure != null then .dashboard.secure | tostring else "true" end' "$CONFIG_FILE")
-    # Timezone for the dashboard's timestamps/charts. "auto"/empty -> Etc/UTC; set an IANA
-    # name (e.g. America/Chicago) for local time. Rendered into .env as DASHBOARD_TZ.
-    DASHBOARD_TZ=$(resolve_default "$(jq -r '.dashboard.timezone // empty' "$CONFIG_FILE")" "Etc/UTC")
+    # Timezone for the dashboard's timestamps/charts. "auto"/empty -> the host's timezone
+    # (auto-detected; falls back to Etc/UTC). Set an IANA name (e.g. America/Chicago) to
+    # override. Rendered into .env as DASHBOARD_TZ.
+    DASHBOARD_TZ=$(resolve_default "$(jq -r '.dashboard.timezone // empty' "$CONFIG_FILE")" "$(detect_host_timezone)")
 }
 
 # Load secrets and one-time-provisioned values from an existing .env so that re-rendering

--- a/pithead
+++ b/pithead
@@ -615,6 +615,9 @@ parse_and_validate_config() {
     DASHBOARD_HOST=$(resolve_default "$(jq -r '.dashboard.host // empty' "$CONFIG_FILE")" "")
     # Ensure a strict true/false string is returned, defaulting to true
     DASHBOARD_SECURE=$(jq -r 'if .dashboard.secure != null then .dashboard.secure | tostring else "true" end' "$CONFIG_FILE")
+    # Timezone for the dashboard's timestamps/charts. "auto"/empty -> Etc/UTC; set an IANA
+    # name (e.g. America/Chicago) for local time. Rendered into .env as DASHBOARD_TZ.
+    DASHBOARD_TZ=$(resolve_default "$(jq -r '.dashboard.timezone // empty' "$CONFIG_FILE")" "Etc/UTC")
 }
 
 # Load secrets and one-time-provisioned values from an existing .env so that re-rendering
@@ -861,6 +864,7 @@ MONERO_RPC_PORT=$rpc_port
 MONERO_ZMQ_PORT=$zmq_port
 COMPOSE_PROFILES=$profiles
 DASHBOARD_SECURE=$DASHBOARD_SECURE
+DASHBOARD_TZ=$DASHBOARD_TZ
 HOST_IP=$HOST_IP
 DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false}
 EOF


### PR DESCRIPTION
Polish + small fixes toward the **v1.0** milestone, found during the launch-readiness review and config testing.

## Changes
1. **Docs service count** — `README.md` / `docs/README.md` said "**eight** services"; the stack has **nine** (predates the `docker-control` proxy from #31).
2. **Configurable dashboard timezone** — was hardcoded to `America/Chicago`. Now driven through the config model:
   - new **`dashboard.timezone`** key (default `auto`),
   - `auto` **auto-detects the host's timezone** (`$TZ` → `timedatectl` → `/etc/timezone` → `/etc/localtime` symlink; Linux + macOS), falling back to `Etc/UTC`,
   - `pithead` renders it to **`DASHBOARD_TZ`** in `.env`; compose uses `TZ=${DASHBOARD_TZ:-Etc/UTC}`,
   - default added to `config.advanced.example.json`; documented in `docs/configuration.md` (slim `config.json.template` left untouched).
3. **Fix `dashboard.host: auto` not reverting** — `resolve_dashboard_host` kept a stale `HOST_IP` from `.env` when `dashboard.host` was set back to `auto`/removed. Now `auto`/unset always re-derives the machine hostname on non-interactive runs (`apply`); `PRESERVED_HOST_IP` is only the interactive-prompt default. (Reported during testing.)
4. **monerod RPC bind comment** — clarify `rpc-bind-ip=0.0.0.0` in `bitmonero.conf.template` is *container-internal only*; host exposure is gated by `MONERO_RPC_BIND` (default localhost).

> An earlier avahi-socket `:ro` tweak was **reverted** (it broke `.local`/mDNS resolution) — net zero change here. Whether to remove mDNS/Avahi entirely is tracked in **#93**.

## Verification
- `shellcheck` clean on `pithead`; `config.advanced.example.json` valid JSON.
- `detect_host_timezone` verified (detected the host TZ via the `/etc/localtime` symlink on macOS; honors `$TZ`).
- `dashboard.host: auto` verified to resolve to the machine hostname even with a stale preserved value.

Related: #93 (mDNS/Avahi removal), #80 / #88 / #89 (docs polish), #90 / #91 (hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)