### PR TITLE
reset-dashboard: add -y/--yes to skip the confirmation prompt (CLI consistency)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,7 +18,7 @@ the full list.
 | `./pithead doctor` | Read-only diagnostics: deps, Docker, AVX2, HugePages, RAM/disk, `.env`/onion state, and container status — a paste-able health report. |
 | `./pithead backup` | Save `config.json`, `.env`, `Caddyfile`, the Tor onion keys, and the dashboard's database (your hashrate history & settings) to a timestamped `tar.gz` under `backups/` (checks free space first; stops a running stack for a clean copy, then restarts it). `--with-chains` also includes the blockchain data; `-y` / `--yes` skips the prompts (low free space and stopping the stack). |
 | `./pithead restore <archive>` | Restore those files from a backup archive (asks before overwriting; fixes Tor key ownership). `-y` / `--yes` skips the prompt. |
-| `./pithead reset-dashboard` | **DESTRUCTIVE** — wipes and recreates the dashboard and P2Pool data. |
+| `./pithead reset-dashboard` | **DESTRUCTIVE** — wipes and recreates the dashboard and P2Pool data. `-y` / `--yes` skips the prompt. |
 | `./pithead help` | Show all commands. |
 
 Service names for `logs` match the containers: `monerod`, `p2pool`, `tari`, `xmrig-proxy`,
@@ -176,7 +176,7 @@ Persistent HugePages require a GRUB change and a **reboot**. Re-run `./pithead s
 **Something looks broken in the dashboard data and you want a clean slate.**
 `./pithead reset-dashboard` wipes and recreates the dashboard and P2Pool data. This is
 **destructive** — you'll lose P2Pool sidechain state and dashboard history (your blockchains and
-wallets are unaffected).
+wallets are unaffected). Pass `-y` / `--yes` to skip the confirmation prompt.
 
 ---
 

--- a/pithead
+++ b/pithead
@@ -386,12 +386,22 @@ announce_dashboard_url() {
 }
 
 reset_dashboard() {
+    local assume_yes=0 arg
+    for arg in "$@"; do
+        case "$arg" in
+            -y|--yes) assume_yes=1 ;;
+            *) error "Unknown option for reset-dashboard: $arg. Run '$0 help'." ;;
+        esac
+    done
+
     echo -e "${C_RED}[WARNING] This is a DESTRUCTIVE action.${C_RESET}"
     echo "It will stop the dashboard/p2pool containers and WIPE their data directories."
-    read -r -p "Are you sure you want to continue? (y/N): " CONFIRM || true
-    if [[ ! "$CONFIRM" =~ ^[Yy] ]]; then
-        log "Reset cancelled."
-        return
+    if [ "$assume_yes" -eq 0 ]; then
+        read -r -p "Are you sure you want to continue? (y/N): " CONFIRM || true
+        if [[ ! "$CONFIRM" =~ ^[Yy] ]]; then
+            log "Reset cancelled."
+            return
+        fi
     fi
 
     log "Resetting dashboard and p2pool..."
@@ -609,7 +619,9 @@ Inspection:
                             .env/onion state, and container status — a paste-able health report.
 
 Maintenance:
-  reset-dashboard           DESTRUCTIVE: wipe and recreate dashboard/p2pool data.
+  reset-dashboard [-y|--yes]
+                            DESTRUCTIVE: wipe and recreate dashboard/p2pool data.
+                              -y, --yes        skip the confirmation prompt.
   backup [--with-chains] [-y|--yes]
                             Write a timestamped, chmod-600 tar.gz under backups/ holding the
                             irreplaceable bits: config.json, .env, Caddyfile, the Tor data dir
@@ -1679,7 +1691,7 @@ main() {
         logs)             require_env; log "Following logs (Ctrl+C to exit)..."; docker compose logs -f "$@" ;;
         status)           require_env; stack_status || exit 1 ;;
         doctor)           doctor ;;
-        reset-dashboard)  require_deployed; reset_dashboard ;;
+        reset-dashboard)  require_deployed; reset_dashboard "$@" ;;
         backup)           stack_backup "$@" ;;
         restore)          stack_restore "$@" ;;
         help|-h|--help)   show_help ;;


### PR DESCRIPTION
## What & why

`reset-dashboard` is destructive (it wipes and recreates the dashboard/p2pool data) and always prompts `Are you sure…? (y/N)` with no way to skip it. `apply` already accepts `-y`/`--yes` to skip its confirmation, so this adds the same flag to `reset-dashboard` for CLI consistency.

The change is purely additive and low-risk: the prompt remains the default, and `-y` is opt-in. Flag parsing mirrors `apply`'s established pattern (`local assume_yes=0` + a `for arg in "$@"; case … -y|--yes) assume_yes=1 ;; *) error "Unknown option …"` loop), erroring on unknown options. The destructive-warning log line is still printed in both paths; only the interactive prompt is skipped when `-y` is passed.

- `main()` dispatch now passes args through: `reset-dashboard) require_deployed; reset_dashboard "$@" ;;`.
- `show_help` documents `reset-dashboard [-y|--yes]` with a sub-note matching apply's phrasing.
- `docs/operations.md` notes the flag in both the command table and the prose, matching apply's tone.

No other command is touched.

## Related issue

Part of the CLI consistency pass (no dedicated issue — small consistency fix mirroring apply's `-y`/`--yes`).

## Checklist

- [x] `make test` passes locally (lint + dashboard pytest ≥ coverage gate + `pithead` shell suite + compose validation)
- [x] `pithead` and test scripts are shellcheck-clean (no new warnings)
- [x] Docs in `docs/` (and the README, if relevant) are updated for any user-facing change
- [x] This PR is focused on a single logical change
- [ ] A linked issue exists for non-trivial changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)