### PR TITLE
Surface per-worker share stats + proxy /summary totals (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- Per-worker share stats in the dashboard's Workers table: accepted / rejected (with invalid
+  folded in) counts per rig, a **⚠** flag on a high reject rate, and a **Proxy totals** footer
+  (pool-wide accepted / rejected / invalid + best difficulty) collected from the xmrig-proxy
+  `/summary` endpoint. The proxy already reported all of this; it was being parsed and discarded
+  (#82).
 - Release & versioning scaffold: top-level `VERSION` file (single source of truth),
   this changelog, and `docs/releasing.md` documenting the release process. The
   GHCR publishing pipeline and `make release` / `pithead release` command are still

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -24,6 +24,9 @@ logger = logging.getLogger("DataService")
 _PX_NAME = 0
 _PX_IP = 1
 _PX_CONNECTIONS = 2     # active connections; 0 means a stale/disconnected worker
+_PX_ACCEPTED = 3        # accepted shares (cumulative)
+_PX_REJECTED = 4        # rejected shares (cumulative)
+_PX_INVALID = 5         # invalid shares (cumulative)
 _PX_LAST_SHARE_MS = 7   # epoch ms of the last accepted share
 _PX_HR_1M = 8           # 1-minute hashrate, kH/s
 _PX_HR_10M = 9          # 10-minute hashrate, kH/s
@@ -53,6 +56,10 @@ def _parse_proxy_list_worker(w):
         "h60": w[_PX_HR_1M] * _KHS_TO_HS,
         "h15": w[_PX_HR_10M] * _KHS_TO_HS,
         "uptime": uptime_estimate,
+        # Per-worker share health (Issue #82) — collected here, surfaced in the Workers table.
+        "accepted": w[_PX_ACCEPTED] or 0,
+        "rejected": w[_PX_REJECTED] or 0,
+        "invalid": w[_PX_INVALID] or 0,
     }
 
 
@@ -67,6 +74,10 @@ def _parse_legacy_dict_worker(w):
         "h60": hr[1] if len(hr) > 1 else 0,
         "h15": hr[2] if len(hr) > 2 else 0,
         "uptime": w.get("uptime", 0),
+        # Share health (Issue #82); the legacy shape rarely carries these, so default to 0.
+        "accepted": w.get("accepted", 0),
+        "rejected": w.get("rejected", 0),
+        "invalid": w.get("invalid", 0),
     }
 
 
@@ -87,6 +98,27 @@ def _normalize_proxy_workers(proxy_data):
         elif isinstance(w, dict):
             workers.append(_parse_legacy_dict_worker(w))
     return workers
+
+
+def _parse_proxy_summary(summary_data):
+    """Extract the pool-wide share-health totals from an xmrig-proxy ``/summary`` payload (#82).
+
+    The ``results`` block carries the proxy's cumulative accepted/rejected/invalid/expired share
+    counts to the upstream pool, plus ``best`` (a list of best difficulties found, highest first).
+    Returns a flat dict of just the fields the dashboard surfaces, and ``{}`` for a missing or
+    malformed payload — so one bad poll leaves the last good value in place rather than erroring.
+    """
+    if not isinstance(summary_data, dict):
+        return {}
+    results = summary_data.get("results", {}) or {}
+    best = results.get("best", []) or []
+    return {
+        "accepted": results.get("accepted", 0) or 0,
+        "rejected": results.get("rejected", 0) or 0,
+        "invalid": results.get("invalid", 0) or 0,
+        "expired": results.get("expired", 0) or 0,
+        "best": best[0] if best else 0,
+    }
 
 
 def _merge_direct_stats(workers, results, active_pool_port):
@@ -152,6 +184,7 @@ class DataService:
         
         self.latest_data = {
             "workers": [],
+            "proxy_summary": {},
             "total_live_h15": 0,
             "total_live_h10": 0,
             "pool": {"p2p": {}, "pool": {}},
@@ -309,6 +342,16 @@ class DataService:
                     except Exception as e:
                         logger.error(f"Proxy Data Fetch Error: {e}")
 
+                    # 2b. Fetch the proxy /summary for pool-wide share totals (Issue #82). Kept
+                    # separate from the workers fetch so one failing doesn't blank the other; a
+                    # bad poll leaves the last good summary in latest_data.
+                    proxy_summary = self.latest_data.get("proxy_summary", {})
+                    try:
+                        summary_data = await asyncio.to_thread(self.proxy_client.get_summary)
+                        proxy_summary = _parse_proxy_summary(summary_data)
+                    except Exception as e:
+                        logger.error(f"Proxy Summary Fetch Error: {e}")
+
                     # 3. Augment with Direct Worker Stats (Uptime, Hashrate) via Local API
                     tasks = [worker_client.get_stats(w['ip'], w['name']) for w in proxy_workers]
                     worker_results = await asyncio.gather(*tasks)
@@ -399,6 +442,7 @@ class DataService:
 
                     self.latest_data.update({
                         "workers": final_workers,
+                        "proxy_summary": proxy_summary,
                         "shares": shares_list,
                         "total_live_h15": total_hr,
                         "total_live_h10": total_h10,

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -283,11 +283,14 @@ function PoolBadge({ pool }) {
 // has reported any shares so it isn't an all-zero line on a fresh start.
 const ProxyTotals = ({ summary }) => {
     if (!summary || !summary.has_data) return null;
+    // htm trims whitespace that wraps across a newline at an element boundary, so the spaces
+    // around the rejected <span> are added explicitly via ${' '} rather than left to indentation.
+    const rejCls = summary.reject_level === 'high' ? 'status-bad' : '';
     return html`
     <div class="proxy-totals text-small text-muted">
-        Proxy totals: <span class="status-ok">${summary.accepted}</span> accepted ·
-        <span class=${summary.reject_level === 'high' ? 'status-bad' : ''}>${summary.rejected}</span>
-        rejected (${summary.reject_pct}) · ${summary.invalid} invalid · Best diff ${summary.best}
+        Proxy totals: <span class="status-ok">${summary.accepted}</span> accepted ·${' '}
+        <span class=${rejCls}>${summary.rejected}</span> rejected (${summary.reject_pct}) ·${' '}
+        ${summary.invalid} invalid · Best diff ${summary.best}
     </div>`;
 };
 

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -279,7 +279,19 @@ function PoolBadge({ pool }) {
     return html`<span class="badge badge-bad">Unknown</span>`;
 }
 
-function WorkersTable({ workers, ui, onSort }) {
+// Pool-wide proxy share totals (Issue #82) — a footer under the table. Hidden until the proxy
+// has reported any shares so it isn't an all-zero line on a fresh start.
+const ProxyTotals = ({ summary }) => {
+    if (!summary || !summary.has_data) return null;
+    return html`
+    <div class="proxy-totals text-small text-muted">
+        Proxy totals: <span class="status-ok">${summary.accepted}</span> accepted ·
+        <span class=${summary.reject_level === 'high' ? 'status-bad' : ''}>${summary.rejected}</span>
+        rejected (${summary.reject_pct}) · ${summary.invalid} invalid · Best diff ${summary.best}
+    </div>`;
+};
+
+function WorkersTable({ workers, summary, ui, onSort }) {
     const rows = sortWorkers(workers, ui.sortIndex, ui.sortAsc);
     return html`
     <div class="card">
@@ -297,9 +309,14 @@ function WorkersTable({ workers, ui, onSort }) {
                         <td>${w.h10_str}</td>
                         <td>${w.h60_str}</td>
                         <td>${w.h15_str}</td>
+                        <td>${w.accepted_str}</td>
+                        <td>${w.rejected_str}${w.reject_flag
+                            ? html` <span class="badge badge-bad" title=${w.reject_flag.title}>${w.reject_flag.text}</span>`
+                            : null}</td>
                     </tr>`)}
             </tbody>
         </table>
+        <${ProxyTotals} summary=${summary} />
     </div>`;
 }
 
@@ -326,7 +343,7 @@ function DashboardView({ state, ui, onRange, onSort, onView, onZoom, onResetZoom
             <${NetworkCard} state=${state} />
             <${TariCard} tari=${state.tari} />
         </div>
-        <${WorkersTable} workers=${state.workers} ui=${ui} onSort=${onSort} />
+        <${WorkersTable} workers=${state.workers} summary=${state.proxy_summary} ui=${ui} onSort=${onSort} />
     </div>`;
 }
 

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -75,6 +75,8 @@ table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
 th { text-align: left; font-size: 0.75rem; color: var(--text-muted); padding: 10px; border-bottom: 1px solid var(--border); text-transform: uppercase; cursor: pointer; }
 td { padding: 10px; border-bottom: 1px solid var(--border); }
 tr:last-child td { border-bottom: none; }
+/* Pool-wide proxy share totals under the Workers table (Issue #82). */
+.proxy-totals { margin-top: 12px; }
 
 /* Components */
 .status-ok { color: var(--ok); }

--- a/build/dashboard/mining_dashboard/web/static/logic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/logic.mjs
@@ -3,9 +3,9 @@
 // without a browser or a JS toolchain. Presentation (components, the canvas) stays elsewhere and
 // is covered by the browser smoke test.
 
-// Worker table columns, each carrying the state key it sorts on. Hashrate/uptime/IP sort
-// numerically (raw values the server includes alongside the formatted strings); name sorts as
-// text. The order matches the rendered <th>s.
+// Worker table columns, each carrying the state key it sorts on. Hashrate/uptime/IP and the
+// accepted/rejected share counts sort numerically (raw values the server includes alongside the
+// formatted strings); name sorts as text. The order matches the rendered <th>s.
 export const WORKER_COLUMNS = [
     { label: 'Worker', key: 'name' },
     { label: 'IP', key: 'ip_sort' },
@@ -13,6 +13,8 @@ export const WORKER_COLUMNS = [
     { label: '10s', key: 'h10' },
     { label: '60s', key: 'h60' },
     { label: '15m', key: 'h15' },
+    { label: 'Accepted', key: 'accepted' },
+    { label: 'Rejected', key: 'rejected' },
 ];
 
 // Return a new array of workers sorted by the given column index. ``idx == null`` keeps the

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -335,6 +335,25 @@ def _usage_level(percent, threshold=80):
     return "high" if percent > threshold else "ok"
 
 
+# Per-worker reject flag (Issue #82). Purely presentational: flag a worker once its rejected-share
+# rate crosses _REJECT_FLAG_RATE *and* it has enough rejects to not just be early-run noise, so an
+# operator can spot a misbehaving rig. A worker submitting all-rejects (rate 100%) still trips the
+# noise floor, so it flags as soon as the floor is reached.
+_REJECT_FLAG_RATE = 0.05   # >= 5% of submitted shares rejected
+_REJECT_FLAG_MIN = 3       # and at least this many rejects
+
+
+def _reject_flag(accepted, rejected):
+    """A ``{text, title}`` warning flag for a high per-worker reject rate, or ``None``."""
+    total = accepted + rejected
+    if total <= 0 or rejected < _REJECT_FLAG_MIN:
+        return None
+    rate = rejected / total
+    if rate < _REJECT_FLAG_RATE:
+        return None
+    return {"text": "⚠", "title": f"High reject rate: {rate * 100:.1f}% ({rejected} rejected)"}
+
+
 def build_system(data):
     """System resource metrics (CPU, RAM, Disk, HugePages) as formatted values + level tokens.
 
@@ -404,6 +423,13 @@ def build_workers(workers):
             h10 = worker.get('h10', 0)
             h60 = worker.get('h60', 0)
             h15 = worker.get('h15', 0)
+            # Per-worker share health (Issue #82). Raw counts for client-side sorting; a display
+            # string that appends invalid only when it's non-zero (keeps the common case clean);
+            # and an optional warning flag the client renders when the reject rate is high.
+            accepted = worker.get('accepted', 0)
+            rejected = worker.get('rejected', 0)
+            invalid = worker.get('invalid', 0)
+            rejected_str = f"{rejected:,} (+{invalid:,} inv)" if invalid else f"{rejected:,}"
             rows.append({
                 "name": worker['name'],
                 "ip": worker['ip'],
@@ -414,11 +440,41 @@ def build_workers(workers):
                 "h10": h10, "h10_str": format_hashrate(h10),
                 "h60": h60, "h60_str": format_hashrate(h60),
                 "h15": h15, "h15_str": format_hashrate(h15),
+                "accepted": accepted, "accepted_str": f"{accepted:,}",
+                "rejected": rejected, "rejected_str": rejected_str,
+                "invalid": invalid,
+                "reject_flag": _reject_flag(accepted, rejected),
             })
         except Exception as e:
             logger.error(f"Error processing worker {worker.get('name', 'unknown')}: {e}")
             continue
     return rows
+
+
+def build_proxy_summary(data):
+    """Pool-wide share-health totals from the xmrig-proxy ``/summary`` (Issue #82): cumulative
+    accepted/rejected/invalid/expired shares submitted to the upstream pool, the aggregate reject
+    rate, and the best difficulty found. ``has_data`` is False until the proxy has been polled (no
+    shares yet) so the client can hide an all-zero footer."""
+    summary = data.get('proxy_summary', {}) or {}
+    accepted = summary.get('accepted', 0) or 0
+    rejected = summary.get('rejected', 0) or 0
+    invalid = summary.get('invalid', 0) or 0
+    expired = summary.get('expired', 0) or 0
+    best = summary.get('best', 0) or 0
+
+    total = accepted + rejected
+    reject_pct = (rejected / total * 100) if total > 0 else 0.0
+    return {
+        "accepted": f"{accepted:,}",
+        "rejected": f"{rejected:,}",
+        "invalid": f"{invalid:,}",
+        "expired": f"{expired:,}",
+        "best": f"{int(best):,}" if best else "—",
+        "reject_pct": f"{reject_pct:.2f}%",
+        "reject_level": _usage_level(reject_pct, threshold=_REJECT_FLAG_RATE * 100),
+        "has_data": (accepted + rejected + invalid) > 0,
+    }
 
 
 def _ip_to_sort_int(ip):
@@ -541,6 +597,7 @@ def build_state(data, state_mgr, range_arg, window=None):
         "proxy_workers": metrics.workers_online,
         "tari": build_tari(data),
         "workers": build_workers(data.get('workers', [])),
+        "proxy_summary": build_proxy_summary(data),
         "chart": build_chart(history, data.get('shares', []), range_arg, window),
     }
 

--- a/build/dashboard/tests/frontend/logic.test.mjs
+++ b/build/dashboard/tests/frontend/logic.test.mjs
@@ -67,7 +67,16 @@ test('sortWorkers: does not mutate the input array', () => {
 test('WORKER_COLUMNS: keys match the worker fields the server sends', () => {
     assert.deepEqual(
         WORKER_COLUMNS.map((c) => c.key),
-        ['name', 'ip_sort', 'uptime', 'h10', 'h60', 'h15'],
+        ['name', 'ip_sort', 'uptime', 'h10', 'h60', 'h15', 'accepted', 'rejected'],
+    );
+});
+
+test('sortWorkers: rejected column sorts numerically (find problem rigs)', () => {
+    // Per-worker share counts are raw numbers so the operator can sort the worst rejecters up.
+    const ws = [{ rejected: 12 }, { rejected: 0 }, { rejected: 3 }];
+    assert.deepEqual(
+        sortWorkers(ws, col('rejected'), false).map((w) => w.rejected),
+        [12, 3, 0],
     );
 });
 

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -5,7 +5,7 @@ import pytest
 import mining_dashboard.service.data_service as ds_mod
 from mining_dashboard.service.data_service import (
     DataService, _normalize_proxy_workers, _merge_direct_stats, _aggregate_hashrate,
-    _parse_proxy_list_worker, _parse_legacy_dict_worker,
+    _parse_proxy_list_worker, _parse_legacy_dict_worker, _parse_proxy_summary,
 )
 
 
@@ -37,11 +37,19 @@ class TestProxyWorkerParsers:
     """The per-shape row parsers used by _normalize_proxy_workers (Issue #39)."""
 
     def test_parse_list_row_named_fields(self):
-        # idx2=connections, idx8=1m kH/s, idx9=10m kH/s, idx7=last share ms.
+        # idx2=connections, idx3/4/5=accepted/rejected/invalid, idx8=1m kH/s, idx9=10m kH/s,
+        # idx7=last share ms.
         row = ["rig", "10.0.0.1", 1, 0, 0, 0, 0, 0, 1.0, 2.0, 0, 0, 0]
         w = _parse_proxy_list_worker(row)
         assert w == {"name": "rig", "ip": "10.0.0.1", "status": "online",
-                     "h10": 1000, "h60": 1000, "h15": 2000, "uptime": 0}
+                     "h10": 1000, "h60": 1000, "h15": 2000, "uptime": 0,
+                     "accepted": 0, "rejected": 0, "invalid": 0}
+
+    def test_parse_list_row_share_counts(self):
+        # idx3=accepted, idx4=rejected, idx5=invalid are carried through (Issue #82).
+        row = ["rig", "10.0.0.1", 1, 500, 7, 2, 0, 0, 1.0, 2.0, 0, 0, 0]
+        w = _parse_proxy_list_worker(row)
+        assert (w["accepted"], w["rejected"], w["invalid"]) == (500, 7, 2)
 
     def test_parse_list_row_offline_and_uptime(self):
         row = ["rig", "10.0.0.1", 0, 0, 0, 0, 0, 1_000, 1.0, 2.0, 0, 0, 0]
@@ -53,7 +61,13 @@ class TestProxyWorkerParsers:
         w = _parse_legacy_dict_worker({"id": "old", "ip": "1.2.3.4",
                                        "hashrate": [10, 20, 30], "uptime": 5})
         assert w == {"name": "old", "ip": "1.2.3.4", "status": "online",
-                     "h10": 10, "h60": 20, "h15": 30, "uptime": 5}
+                     "h10": 10, "h60": 20, "h15": 30, "uptime": 5,
+                     "accepted": 0, "rejected": 0, "invalid": 0}
+
+    def test_parse_legacy_dict_share_counts(self):
+        # When a legacy payload happens to carry share counts, they pass through.
+        w = _parse_legacy_dict_worker({"id": "old", "accepted": 9, "rejected": 1, "invalid": 0})
+        assert (w["accepted"], w["rejected"], w["invalid"]) == (9, 1, 0)
 
 
 class TestNormalizeProxyWorkers:
@@ -105,6 +119,30 @@ class TestNormalizeProxyWorkers:
         assert _normalize_proxy_workers(None) == []
         assert _normalize_proxy_workers({}) == []
         assert _normalize_proxy_workers({"nope": 1}) == []
+
+
+class TestParseProxySummary:
+    """Pool-wide share totals from the proxy /summary `results` block (Issue #82)."""
+
+    def test_extracts_results_and_best(self):
+        summary = {"results": {"accepted": 1000, "rejected": 12, "invalid": 3, "expired": 1,
+                               "best": [987654, 5000, 100]}}
+        assert _parse_proxy_summary(summary) == {
+            "accepted": 1000, "rejected": 12, "invalid": 3, "expired": 1, "best": 987654,
+        }
+
+    def test_best_defaults_to_zero_when_empty(self):
+        assert _parse_proxy_summary({"results": {"accepted": 5, "best": []}})["best"] == 0
+        assert _parse_proxy_summary({"results": {"accepted": 5}})["best"] == 0
+
+    def test_missing_results_block_zeros_out(self):
+        out = _parse_proxy_summary({"version": "6.x"})
+        assert out == {"accepted": 0, "rejected": 0, "invalid": 0, "expired": 0, "best": 0}
+
+    def test_malformed_payload_returns_empty(self):
+        assert _parse_proxy_summary(None) == {}
+        assert _parse_proxy_summary([1, 2, 3]) == {}
+        assert _parse_proxy_summary("nope") == {}
 
 
 class TestMergeDirectStats:
@@ -374,6 +412,8 @@ class TestRunIteration:
         # idx8=1.0 kH/s, idx9=2.0 kH/s -> h15 = 2000 H/s.
         worker_row = ["rig1", "10.0.0.1", 1, 0, 0, 0, 0, 0, 1.0, 2.0, 0, 0, 0]
         proxy.get_workers.return_value = {"workers": [worker_row]}
+        proxy.get_summary.return_value = {"results": {"accepted": 100, "rejected": 5, "invalid": 1,
+                                                      "expired": 2, "best": [123456]}}
 
         worker_client = MagicMock()
         worker_client.get_stats = AsyncMock(return_value={})  # direct API unreachable
@@ -402,6 +442,10 @@ class TestRunIteration:
         assert svc.latest_data["workers"][0]["name"] == "rig1"
         assert svc.latest_data["workers"][0]["status"] == "online"
         assert svc.latest_data["total_live_h15"] == 2000.0
+        # The proxy /summary totals were collected and surfaced (Issue #82).
+        assert svc.latest_data["proxy_summary"] == {
+            "accepted": 100, "rejected": 5, "invalid": 1, "expired": 2, "best": 123456,
+        }
         sm.update_history.assert_called()
         sm.save_snapshot.assert_called()
 

--- a/build/dashboard/tests/service/test_storage_service.py
+++ b/build/dashboard/tests/service/test_storage_service.py
@@ -93,6 +93,26 @@ class TestSnapshot:
     def test_load_missing_snapshot_returns_none(self, state_manager):
         assert state_manager.load_snapshot() is None
 
+    def test_share_stats_persist_across_instances(self, tmp_path):
+        # Issue #82: the per-worker share counts and the proxy /summary totals ride along in the
+        # latest_data snapshot, so they survive a dashboard restart (the snapshot is what
+        # DataService restores on init). Save with one instance, read back with a fresh one.
+        db = str(tmp_path / "state.db")
+        sm1 = StateManager(db_path=db)
+        sm1.save_snapshot({
+            "workers": [{"name": "rig1", "ip": "10.0.0.1", "status": "online",
+                         "accepted": 1234, "rejected": 5, "invalid": 0}],
+            "proxy_summary": {"accepted": 12345, "rejected": 67, "invalid": 2,
+                              "expired": 1, "best": 9876543},
+        })
+        sm1.close()
+
+        snap = StateManager(db_path=db).load_snapshot()  # fresh instance -> reads from disk
+        assert snap["workers"][0]["accepted"] == 1234
+        assert snap["workers"][0]["rejected"] == 5
+        assert snap["proxy_summary"] == {"accepted": 12345, "rejected": 67, "invalid": 2,
+                                         "expired": 1, "best": 9876543}
+
 
 class TestPersistenceAndMigration:
     def test_state_persists_across_instances(self, tmp_path):

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -16,7 +16,7 @@ import mining_dashboard.web.views as views
 from mining_dashboard.web.views import (
     build_chart, build_hashrate, build_pool_network, build_workers, build_tari,
     build_system, build_sync, build_badges, build_state, get_shell_html, _mode_palette,
-    parse_window, _target_points, _chart_tension,
+    parse_window, _target_points, _chart_tension, build_proxy_summary, _reject_flag,
 )
 from mining_dashboard.service.metrics import Metrics, SyncMetric
 
@@ -433,6 +433,55 @@ class TestWorkers:
         # Raw name as data; the client text-escapes it on render.
         assert build_workers([{"name": "<rig>", "ip": "1.1.1.1", "status": "online", "active_pool": "3333"}])[0]["name"] == "<rig>"
 
+    def test_share_counts_raw_and_formatted(self):
+        # Per-worker accepted/rejected/invalid: raw counts (sort keys) + display strings (#82).
+        row = build_workers([{"name": "r", "ip": "10.0.0.1", "status": "online", "active_pool": "3333",
+                              "accepted": 1234, "rejected": 5, "invalid": 0}])[0]
+        assert row["accepted"] == 1234 and row["accepted_str"] == "1,234"
+        assert row["rejected"] == 5 and row["rejected_str"] == "5"
+        assert row["invalid"] == 0
+
+    def test_invalid_appended_to_rejected_string_only_when_nonzero(self):
+        with_inv = build_workers([{"name": "r", "ip": "1.1.1.1", "status": "online",
+                                   "active_pool": "3333", "rejected": 3, "invalid": 2}])[0]
+        assert with_inv["rejected_str"] == "3 (+2 inv)"
+
+    def test_missing_share_fields_default_to_zero(self):
+        # Workers restored from an old snapshot (pre-#82) lack the share fields entirely.
+        row = build_workers([{"name": "r", "ip": "1.1.1.1", "status": "online", "active_pool": "3333"}])[0]
+        assert (row["accepted"], row["rejected"], row["invalid"]) == (0, 0, 0)
+        assert row["reject_flag"] is None
+
+    def test_reject_flag_set_on_high_reject_rate(self):
+        row = build_workers([{"name": "r", "ip": "1.1.1.1", "status": "online", "active_pool": "3333",
+                              "accepted": 90, "rejected": 10, "invalid": 0}])[0]
+        assert row["reject_flag"] and row["reject_flag"]["text"] == "⚠"
+        assert "10.0%" in row["reject_flag"]["title"]
+
+
+class TestRejectFlag:
+    """The per-worker reject-rate flag (Issue #82)."""
+
+    def test_none_without_rejects(self):
+        assert _reject_flag(1000, 0) is None
+
+    def test_none_below_noise_floor(self):
+        # A couple of rejects out of a few shares is noise, even at a high rate.
+        assert _reject_flag(2, 1) is None     # 33% but only 1 reject
+        assert _reject_flag(0, 2) is None     # 100% but below the 3-reject floor
+
+    def test_none_when_rate_low(self):
+        assert _reject_flag(1000, 5) is None  # 5 rejects but only 0.5%
+
+    def test_flags_high_rate_above_floor(self):
+        flag = _reject_flag(90, 10)           # 10% with 10 rejects
+        assert flag["text"] == "⚠"
+        assert "10.0%" in flag["title"] and "10 rejected" in flag["title"]
+
+    def test_flags_all_rejects_at_floor(self):
+        # A worker submitting only rejects trips the floor immediately (rate 100%).
+        assert _reject_flag(0, 3) is not None
+
 
 # --- Tari -----------------------------------------------------------------------------
 
@@ -452,6 +501,37 @@ class TestTari:
     def test_long_wallet_shortened(self):
         t = build_tari({"tari": {"active": True, "address": "T" * 40}})
         assert "..." in t["wallet_short"] and t["wallet"] == "T" * 40
+
+
+# --- Proxy summary (Issue #82) --------------------------------------------------------
+
+class TestProxySummary:
+    def test_formats_totals_and_best(self):
+        ps = build_proxy_summary({"proxy_summary": {
+            "accepted": 12345, "rejected": 67, "invalid": 2, "expired": 1, "best": 9876543}})
+        assert ps["accepted"] == "12,345"
+        assert ps["rejected"] == "67"
+        assert ps["invalid"] == "2"
+        assert ps["expired"] == "1"
+        assert ps["best"] == "9,876,543"
+        assert ps["has_data"] is True
+
+    def test_reject_pct_and_level(self):
+        # 5 rejected of 105 submitted -> ~4.76%, below the 5% highlight threshold.
+        ok = build_proxy_summary({"proxy_summary": {"accepted": 100, "rejected": 5}})
+        assert ok["reject_pct"] == "4.76%" and ok["reject_level"] == "ok"
+        # 10 of 100 -> 10%, highlighted.
+        high = build_proxy_summary({"proxy_summary": {"accepted": 90, "rejected": 10}})
+        assert high["reject_pct"] == "10.00%" and high["reject_level"] == "high"
+
+    def test_best_dash_when_unknown(self):
+        assert build_proxy_summary({"proxy_summary": {"accepted": 1, "best": 0}})["best"] == "—"
+
+    def test_empty_summary_has_no_data(self):
+        ps = build_proxy_summary({})
+        assert ps["has_data"] is False
+        assert ps["reject_pct"] == "0.00%"
+        assert ps["best"] == "—"
 
 
 # --- pool/network passthrough ---------------------------------------------------------
@@ -507,7 +587,7 @@ class TestBuildState:
         st = build_state(_data(), _state_mgr(), "all")
         for key in ("syncing", "page_title", "host_ip", "last_update", "range", "window", "badges",
                     "hashrate", "system", "sync", "stratum", "pool", "network", "monero",
-                    "shares_window", "proxy_workers", "tari", "workers", "chart"):
+                    "shares_window", "proxy_workers", "tari", "workers", "proxy_summary", "chart"):
             assert key in st, f"missing section: {key}"
 
     def test_is_json_serializable(self):

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -125,6 +125,19 @@ several windows (e.g. 10s / 60s / 15m) — so you can spot a rig that has droppe
 underperforming. A worker that's connected but whose direct API is unreachable still counts (with
 proxy-derived hashrate); a worker whose miner has stopped drops out of the total.
 
+Each rig also shows its **accepted** and **rejected** share counts (with invalid shares folded
+into the rejected column as `3 (+2 inv)` when present). A rig whose reject rate climbs past ~5%
+gets a red **⚠** flag next to its rejected count — a quick way to catch a rig that's submitting
+stale or bad shares (bad overclock, flaky network, clock drift) rather than earning. Every column
+is sortable, so you can click **Rejected** to float the worst offenders to the top. The shares are
+cumulative since the proxy last started, so a brief early-run blip clears itself as good shares
+accumulate.
+
+Below the table, a **Proxy totals** line sums the whole stack's share health as reported by the
+xmrig-proxy: total accepted / rejected (with the aggregate reject %) / invalid shares submitted
+upstream, plus the **best difficulty** any of your shares has hit. It's hidden until the proxy has
+submitted its first shares.
+
 ---
 
 ## Tips


### PR DESCRIPTION
Closes #82.

## What & why
The xmrig-proxy already reports per-worker **accepted / rejected / invalid** shares (in `/workers`) and pool-wide **accepted / rejected / invalid / expired** totals + **best difficulty** (in `/summary`) — but `_parse_proxy_list_worker` discarded the share counts and `/summary` was never collected. This surfaces the share health miners care about most, plumbed through the existing **collector → data_service → views → frontend** pipeline (no HTML scraping).

## Changes
**Collector (`data_service.py`)**
- Named the accepted/rejected/invalid positional indices; carried them on both worker shapes (6.x list + legacy dict).
- Added `_parse_proxy_summary()` and wired a `get_summary()` poll into the run loop — its own try/except so a bad summary poll can't blank the worker fetch (and vice-versa); the last good summary is kept on a failed poll.

**Views (`views.py`)** — formatting at the edge, per the layer's contract
- `build_workers` now emits raw counts (client-side sort keys) + display strings + an optional `reject_flag`.
- `_reject_flag()` flags a rig once its reject rate crosses ~5% **and** it has ≥3 rejects (noise floor so an early-run blip doesn't false-positive; an all-rejects rig trips immediately).
- `build_proxy_summary()` formats the pool-wide totals with an aggregate reject %.

**Frontend**
- Sortable **Accepted** / **Rejected** columns (invalid folded into the rejected cell as `3 (+2 inv)`).
- A red **⚠** flag badge on high reject rate.
- A **Proxy totals** footer under the table (accepted / rejected (reject %) / invalid + best diff), hidden until the proxy has submitted shares.

## Acceptance criteria
- [x] Workers table shows accepted/rejected(/invalid) per worker with a visual flag on high reject rates.
- [x] Proxy `/summary` totals surfaced (accepted/rejected/best diff).
- [x] Plumbed through collector → data_service → views (no HTML scraping).

## Testing
- **Python:** parser/summary/reject-flag unit tests, `build_proxy_summary` tests, and an end-to-end run-iteration assertion. Full dashboard suite passes at **92.75%** coverage (gate 80%).
- **Frontend:** updated `WORKER_COLUMNS` assertion + a rejected-column sort test — **15/15** pass (`node --test`).
- **Docs:** expanded the "Workers Alive" section in `docs/dashboard.md` + CHANGELOG entry.

Backward-compatible: workers restored from a pre-#82 snapshot default the new fields to 0.

> Note: the live UI render wasn't exercised (needs the full Docker stack); component rendering relies on the server-side `build_state` tests plus the repo's existing manual browser smoke-test convention, consistent with the rest of the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)