### PR TITLE
Dashboard branding: header logo/wordmark + hero KPI band (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   stacks, the card grid collapses to a single column, the disk bar goes full-width, and the
   workers table scrolls horizontally within its card instead of overflowing the page. Desktop
   is unchanged.
+- Dashboard branding (#81): the header now leads with the Pithead mark + wordmark and demotes
+  the host IP to a subtitle, and a hero KPI band above the dashboard surfaces the headline
+  numbers — total hashrate, shares in the PPLNS window, blocks found, XvB tier, and mining mode.
 - Release & versioning scaffold: top-level `VERSION` file (single source of truth),
   this changelog, and `docs/releasing.md` documenting the release process. The
   GHCR publishing pipeline and `make release` / `pithead release` command are still

--- a/build/dashboard/README.md
+++ b/build/dashboard/README.md
@@ -26,7 +26,7 @@ plus the app modules and `dashboard.css`. Nothing is inlined and the libraries a
 the page runs under a strict Content-Security-Policy with no `'unsafe-inline'`/`'unsafe-eval'`.
 
 Testing: the Python API — where all the logic and formatting live — is fully unit-tested. The
-pure client logic (worker sort, tooltip formatting in `static/logic.mjs`) is unit-tested with
+pure client logic (worker sort, tooltip formatting, hero-KPI selection in `static/logic.mjs`) is unit-tested with
 **Node's built-in runner** (`node --test build/dashboard/tests/frontend/*.test.mjs`) — no
 `package.json`/`node_modules`/build step, so the repo stays Node-free. Component *rendering* has
 no unit tests by design; it's covered by a manual browser smoke test.

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -4,7 +4,7 @@
 // classes — it does no number formatting or business logic of its own.
 import { Component, Fragment, html } from './preact.mjs';
 import { ChartCard } from './chart.mjs';
-import { WORKER_COLUMNS, sortWorkers, THEME_ORDER, THEME_LABELS } from './logic.mjs';
+import { WORKER_COLUMNS, sortWorkers, THEME_ORDER, THEME_LABELS, heroKpis } from './logic.mjs';
 
 // Palette token -> text-colour class (defined in dashboard.css).
 const cVar = (v) => 'c-' + v;
@@ -76,9 +76,15 @@ function Header({ state }) {
     return html`
     <div class="header" id="top-header">
         <div>
-            <div class="flex items-center">
-                <h2>${state.host_ip}</h2>
-                <${Badges} badges=${state.badges} />
+            <div class="brand">
+                <img class="brand-logo" src="/static/pithead-mark.svg" alt="" width="40" height="40" />
+                <div>
+                    <div class="flex items-center">
+                        <h1 class="brand-name">Pithead</h1>
+                        <${Badges} badges=${state.badges} />
+                    </div>
+                    <div class="brand-host font-mono text-muted">${state.host_ip}</div>
+                </div>
             </div>
             <div class="text-small mt-2">
                 <div class="mb-1">
@@ -102,13 +108,27 @@ function Header({ state }) {
             </div>
         </div>
         <div class="text-right">
-            <div class="text-accent font-bold hashrate-total">${hr.total}</div>
             <div class="text-muted text-xs">Last Update: ${state.last_update}</div>
             <div class=${'text-xs mt-1 ' + cVar(hr.p2p_variant)}>P2Pool: ${hr.p2p_1h} (1h) / ${hr.p2p_24h} (24h)</div>
             <div class=${'text-xs mt-xs ' + cVar(hr.xvb_variant)}>XvB: ${hr.xvb_1h} (1h) / ${hr.xvb_24h} (24h)</div>
         </div>
     </div>`;
 }
+
+// --- Hero KPI band -------------------------------------------------------------------
+
+// A prominent strip of the headline numbers (total hashrate, shares in window, blocks found, XvB
+// tier, mining mode) shown above the operational view (Issue #81). heroKpis (logic.mjs,
+// unit-tested) does the selection/labelling/colouring; this only renders the list. Rendered only
+// when operational — during sync the numbers aren't meaningful yet.
+const HeroBand = ({ state }) => html`
+    <div class="hero-band" id="hero-band">
+        ${heroKpis(state).map((k) => html`
+            <div class="hero-kpi">
+                <div class=${'hero-value ' + (k.cls || '')}>${k.value}</div>
+                <div class="hero-label">${k.label}</div>
+            </div>`)}
+    </div>`;
 
 // --- Sync Mode -----------------------------------------------------------------------
 
@@ -368,9 +388,12 @@ export function App({ state, connected, ui, onRange, onSort, onView, onTheme, on
         ${!connected ? html`<div class="disconnected-banner">Disconnected — showing last known data. Retrying…</div>` : null}
         ${state.syncing
             ? html`<${SyncView} sync=${state.sync} />`
-            : html`<${DashboardView} state=${state} ui=${ui} onRange=${onRange} onSort=${onSort}
-                                     onView=${onView} onZoom=${onZoom} onResetZoom=${onResetZoom}
-                                     onToggleSeries=${onToggleSeries} />`}
+            : html`<${Fragment}>
+                <${HeroBand} state=${state} />
+                <${DashboardView} state=${state} ui=${ui} onRange=${onRange} onSort=${onSort}
+                                  onView=${onView} onZoom=${onZoom} onResetZoom=${onResetZoom}
+                                  onToggleSeries=${onToggleSeries} />
+              <//>`}
         ${switcher}
     <//>`;
 }

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -50,12 +50,25 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Ar
 
 /* Layout & Grid */
 .header { display: flex; justify-content: space-between; align-items: flex-start; border-bottom: 1px solid var(--border); padding-bottom: 20px; margin-bottom: 20px; }
-/* The hostname (HOST_IP) is arbitrary user input; a long unbroken value (no hyphens/dots to
- * break at) would otherwise push the header — and the page — wider than a phone (Issue #83).
- * overflow-wrap:anywhere lets it break mid-token so it wraps instead of overflowing. */
-.header h2 { overflow-wrap: anywhere; }
 .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 20px; margin-bottom: 20px; }
 .card { background: var(--card); border: 1px solid var(--border); border-radius: 6px; padding: 20px; display: flex; flex-direction: column; min-width: 0; }
+
+/* Brand block (Issue #81): the Pithead mark + wordmark in the header, with the host IP demoted
+ * to a subtitle beneath the name. The host IP (HOST_IP) is arbitrary user input; a long unbroken
+ * value (no hyphens/dots to break at) would otherwise push the header — and the page — wider than
+ * a phone (Issue #83), so overflow-wrap:anywhere lets it break mid-token and wrap instead. */
+.brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
+.brand-logo { width: 40px; height: 40px; flex: none; }
+.brand-name { margin: 0; font-size: 1.5rem; font-weight: 700; letter-spacing: 0.5px; }
+.brand-host { font-size: 0.8rem; margin-top: 2px; overflow-wrap: anywhere; }
+
+/* Hero KPI band (Issue #81): a prominent strip of the headline numbers under the header. A
+ * responsive auto-fit grid so the cards sit in one row on a wide screen and reflow when narrow;
+ * long tier/mode text wraps inside its card rather than overflowing. */
+.hero-band { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 16px; margin-bottom: 20px; }
+.hero-kpi { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; text-align: center; }
+.hero-value { font-size: 1.6rem; font-weight: 700; line-height: 1.2; overflow-wrap: anywhere; }
+.hero-label { margin-top: 6px; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); }
 
 /* Typography */
 h2 { margin: 0; font-size: 1.5rem; font-weight: 600; }
@@ -65,7 +78,6 @@ h3 { margin: 0 0 15px 0; font-size: 0.85rem; text-transform: uppercase; color: v
 .text-small { font-size: 0.85rem; }
 .text-xs { font-size: 0.75rem; }
 .font-mono { font-family: monospace; }
-.font-bold { font-weight: bold; }
 
 /* Stats */
 .stat-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
@@ -200,7 +212,6 @@ tr:last-child td { border-bottom: none; }
 .bg-accent { background-color: var(--accent); }
 
 /* Misc component sizing previously carried as inline styles. */
-.hashrate-total { font-size: 24px; }
 .disk-bar { width: 150px; }
 .chart-wrap { position: relative; flex-grow: 1; min-height: 300px; width: 100%; overflow: hidden; }
 .check-inline { font-size: 1.2em; }

--- a/build/dashboard/mining_dashboard/web/static/logic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/logic.mjs
@@ -31,6 +31,22 @@ export function sortWorkers(workers, idx, asc) {
     return asc ? sorted : sorted.reverse();
 }
 
+// Hero KPI band (Issue #81). The headline numbers surfaced as a prominent top strip: each entry
+// is { label, value, cls } where `value` is an already-formatted display string from build_state
+// and `cls` is the text-colour class applied to it ('' = default text colour). Pure selection +
+// labelling is kept here so the wiring (which state field feeds which KPI, and the mode/shares
+// colouring) is unit-tested; <HeroBand> in components.mjs only renders the returned list.
+export function heroKpis(state) {
+    const hr = state.hashrate, sw = state.shares_window, p = state.pool;
+    return [
+        { label: 'Total Hashrate', value: hr.total, cls: 'text-accent' },
+        { label: 'Shares in Window', value: sw.count, cls: sw.ok ? 'status-ok' : 'status-bad' },
+        { label: 'Blocks Found', value: p.blocks, cls: '' },
+        { label: 'XvB Tier', value: hr.tier, cls: '' },
+        { label: 'Mining Mode', value: hr.mode_name, cls: 'c-' + hr.mode_variant },
+    ];
+}
+
 // Format an epoch-ms x value for the chart tooltip title (Issue #65). Day + time so long ranges
 // read clearly; browser locale (≈ the server's, for a localhost dashboard).
 export function fmtTimestamp(ms) {

--- a/build/dashboard/tests/frontend/logic.test.mjs
+++ b/build/dashboard/tests/frontend/logic.test.mjs
@@ -14,6 +14,7 @@ import {
     THEMES, THEME_ORDER, normalizeTheme,
     clampZoomWindow, fmtWindowDuration,
     SERIES_KEYS, normalizeSeries,
+    heroKpis,
 } from '../../mining_dashboard/web/static/logic.mjs';
 
 const col = (key) => WORKER_COLUMNS.findIndex((c) => c.key === key);
@@ -132,4 +133,50 @@ test('normalizeSeries: defaults every series to visible, only explicit false hid
     // Garbage / stray keys are ignored; output is always the full key set.
     assert.deepEqual(Object.keys(normalizeSeries({ junk: 1 })).sort(), [...SERIES_KEYS].sort());
     assert.deepEqual(normalizeSeries('nope'), { p2pool: true, xvb: true, shares: true });
+});
+
+// --- Issue #81: hero KPI band selector ------------------------------------------------
+
+// Minimal /api/state shape carrying just the fields the band reads; `over` deep-overrides a
+// section so each test changes only what it asserts on.
+const _heroState = (over = {}) => ({
+    hashrate: { total: '10.50 kH/s', tier: 'Donor (1.00 kH/s+)', mode_name: 'P2POOL',
+                mode_variant: 'ok', ...over.hashrate },
+    shares_window: { count: 5, ok: true, ...over.shares_window },
+    pool: { blocks: 42, ...over.pool },
+});
+const _byLabel = (state) => Object.fromEntries(heroKpis(state).map((k) => [k.label, k]));
+
+test('heroKpis: surfaces the five headline numbers under stable labels, in order', () => {
+    assert.deepEqual(
+        heroKpis(_heroState()).map((k) => k.label),
+        ['Total Hashrate', 'Shares in Window', 'Blocks Found', 'XvB Tier', 'Mining Mode'],
+    );
+});
+
+test('heroKpis: wires each KPI to its build_state field', () => {
+    const k = _byLabel(_heroState());
+    assert.equal(k['Total Hashrate'].value, '10.50 kH/s');   // hashrate.total
+    assert.equal(k['Shares in Window'].value, 5);            // shares_window.count
+    assert.equal(k['Blocks Found'].value, 42);               // pool.blocks
+    assert.equal(k['XvB Tier'].value, 'Donor (1.00 kH/s+)'); // hashrate.tier
+    assert.equal(k['Mining Mode'].value, 'P2POOL');          // hashrate.mode_name
+});
+
+test('heroKpis: shares colour reflects the ok flag', () => {
+    assert.equal(_byLabel(_heroState({ shares_window: { count: 3, ok: true } }))['Shares in Window'].cls, 'status-ok');
+    assert.equal(_byLabel(_heroState({ shares_window: { count: 0, ok: false } }))['Shares in Window'].cls, 'status-bad');
+});
+
+test('heroKpis: mode colour follows the server mode_variant token', () => {
+    // Same c-<token> mapping the Overview card uses, so the band's mode matches the rest of the UI.
+    assert.equal(_byLabel(_heroState({ hashrate: { mode_variant: 'purple' } }))['Mining Mode'].cls, 'c-purple');
+    assert.equal(_byLabel(_heroState({ hashrate: { mode_variant: 'accent' } }))['Mining Mode'].cls, 'c-accent');
+});
+
+test('heroKpis: total is accent-coloured; blocks and tier carry no colour class', () => {
+    const k = _byLabel(_heroState());
+    assert.equal(k['Total Hashrate'].cls, 'text-accent');
+    assert.equal(k['Blocks Found'].cls, '');
+    assert.equal(k['XvB Tier'].cls, '');
 });

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -229,6 +229,7 @@ class TestResponsiveLayout:
 
     async def test_css_lets_hostname_wrap(self, client):
         # HOST_IP is arbitrary user input; a long unbroken hostname would push the header (and
-        # the page) wider than a phone without a wrap rule on the header's <h2>.
+        # the page) wider than a phone without a wrap rule. Since #81 the host IP lives in the
+        # brand subtitle (`.brand-host`), which carries the overflow-wrap protection.
         css = await (await client.get("/static/dashboard.css")).text()
-        assert ".header h2" in css
+        assert ".brand-host" in css and "overflow-wrap" in css


### PR DESCRIPTION
Closes #81.

## What

Makes the dashboard instantly on-brand and screenshot-worthy.

**Header branding** — leads with the shipped `pithead-mark.svg` + a **"Pithead"** wordmark, with the status badges alongside it. The host IP is demoted from the page's `<h2>` heading to a muted, monospace **subtitle** beneath the name. The now-redundant big total-hashrate readout is removed from the header's right column (the hero band owns it); the P2Pool/XvB breakdown + last-update stay.

**Hero KPI band** — a prominent 5-up strip above the dashboard: **Total Hashrate · Shares in Window · Blocks Found · XvB Tier · Mining Mode**. All values come from existing `build_state` fields (pure presentation). Responsive auto-fit grid; rendered only when operational (hidden during sync, when the numbers aren't meaningful).

## Acceptance

- [x] Header shows the logo + "Pithead"; IP as a subtitle.
- [x] A hero KPI band surfaces the headline numbers prominently.

## Testing

Following the repo's split (pure logic in `logic.mjs`, unit-tested with `node --test`; rendering covered by the manual smoke test), the KPI selection is extracted into a pure `heroKpis(state)` and covered by **5 new unit tests** (label order, field wiring, mode/shares colour mapping).

- Frontend: **19/19 pass** (14 existing + 5 new) — `node --test build/dashboard/tests/frontend/*.test.mjs`
- Python: full suite green, **92.76%** coverage (gate 80%) — `make test-dashboard`

Also visually verified the real `App` render by driving a faithful `/api/state` payload through the actual `build_state` and screenshotting it in a browser (header, wordmark, IP subtitle, and hero band all render correctly).

## Notes

- Logo `alt=""` (decorative) since the adjacent "Pithead" wordmark provides the accessible name.
- Removed two CSS rules left dead by this change (`.hashrate-total`, `.font-bold`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)