### PR TITLE
Wrap a long hostname in the dashboard header

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -50,6 +50,10 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Ar
 
 /* Layout & Grid */
 .header { display: flex; justify-content: space-between; align-items: flex-start; border-bottom: 1px solid var(--border); padding-bottom: 20px; margin-bottom: 20px; }
+/* The hostname (HOST_IP) is arbitrary user input; a long unbroken value (no hyphens/dots to
+ * break at) would otherwise push the header — and the page — wider than a phone (Issue #83).
+ * overflow-wrap:anywhere lets it break mid-token so it wraps instead of overflowing. */
+.header h2 { overflow-wrap: anywhere; }
 .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 20px; margin-bottom: 20px; }
 .card { background: var(--card); border: 1px solid var(--border); border-radius: 6px; padding: 20px; display: flex; flex-direction: column; min-width: 0; }
 

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -226,3 +226,9 @@ class TestResponsiveLayout:
         # card and overflows it on a phone. Guard that the wrap rule stays present.
         css = await (await client.get("/static/dashboard.css")).text()
         assert "overflow-wrap" in css
+
+    async def test_css_lets_hostname_wrap(self, client):
+        # HOST_IP is arbitrary user input; a long unbroken hostname would push the header (and
+        # the page) wider than a phone without a wrap rule on the header's <h2>.
+        css = await (await client.get("/static/dashboard.css")).text()
+        assert ".header h2" in css


### PR DESCRIPTION
Follow-up to the responsive dashboard layout (#83). After that merged, I checked the one area it didn't touch — the **header telemetry strip** at very narrow widths.

## What I found
The header holds up well at phone widths: badges wrap, telemetry lines wrap, the disk bar goes full-width, and realistic hostnames (with hyphens/dots, like `mining-rig-basement-01.lan`) wrap cleanly. **One gap:** `HOST_IP` is arbitrary user input, and a long *unbroken* hostname (no hyphens/dots to break at) becomes a single max-content `<h2>` token that pushes the header — and the whole page — wider than the screen.

Reproduced at 320px with a 32-char unbroken hostname: the header overflowed (`scrollWidth 409` in a `296` box) and the page scrolled sideways (`422 > 320`).

## Fix
`overflow-wrap: anywhere` on `.header h2`, so the hostname breaks mid-token and wraps instead of overflowing. It only breaks when a token would otherwise overflow, so normal hostnames/IPs are visually unchanged (verified one stays on a single line on desktop).

## Testing
- Browser-verified at 320px with the real CSS: the unbroken hostname wraps to two lines, `overflow-wrap` computes to `anywhere`, and the page no longer overflows (`scrollWidth == 320`). The dense worst-case header (long hostname + 7 badges + 3 High Usage tags) lays out cleanly.
- Added a regression guard (`test_css_lets_hostname_wrap`); full server suite green (22 tests).

Everything else in the header was already correct at phone widths — this is the only change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)