### PR TITLE
Show the host IP address next to the hostname in the header (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 ### Added
 
 - Dashboard header shows the host's **IP address** next to the hostname when the configured
-  `dashboard.host` is a name (e.g. `pithead.local · 192.168.1.42`), so you can still reach the
+  `dashboard.host` is a name, as `hostname @ ip` (e.g. `pithead.local @ 192.168.1.42`), so you can still reach the
   dashboard when the hostname doesn't resolve from your phone or another machine on the LAN. The
   address is detected on the host (the dashboard runs `network_mode: host`), and is omitted when
   the host is already an IP or can't be determined (#119).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- Dashboard header shows the host's **IP address** next to the hostname when the configured
+  `dashboard.host` is a name (e.g. `pithead.local · 192.168.1.42`), so you can still reach the
+  dashboard when the hostname doesn't resolve from your phone or another machine on the LAN. The
+  address is detected on the host (the dashboard runs `network_mode: host`), and is omitted when
+  the host is already an IP or can't be determined (#119).
 - Dashboard header now shows which build is running, as a muted badge on both the
   syncing and main screens: a clean release shows `vX.Y.Z` (from the top-level
   `VERSION` file), while any dev/working-tree build shows `dev · branch @ hash` so

--- a/build/dashboard/mining_dashboard/helper/utils.py
+++ b/build/dashboard/mining_dashboard/helper/utils.py
@@ -1,4 +1,6 @@
 import time
+import socket
+import ipaddress
 from mining_dashboard.config.config import TIER_DEFAULTS
 
 def parse_hashrate(val_str, unit_str=None):
@@ -173,3 +175,36 @@ def resolve_target_threshold(tiers, stable_hr, donation_level, max_fraction):
 
     sustainable = target > 0 and (stable_hr * max_fraction) >= target
     return target, sustainable
+
+
+def is_ip_address(value):
+    """True if ``value`` is a literal IP address (IPv4 or IPv6), False for a hostname.
+
+    Used to decide whether the configured ``dashboard.host`` already *is* an address, in
+    which case there's no separate numeric IP worth showing beside it (Issue #119).
+    """
+    try:
+        ipaddress.ip_address(value.strip())
+        return True
+    except (ValueError, AttributeError):
+        return False
+
+
+def detect_host_ipv4():
+    """Best-effort primary LAN IPv4 of the host this dashboard runs on.
+
+    Opens a UDP socket toward an off-link sentinel address so the kernel selects the source
+    address of the default-route interface — UDP ``connect`` only fixes the route, no packets
+    are sent and the sentinel is never contacted (it's RFC 5737 TEST-NET-1, guaranteed not a
+    real endpoint). The dashboard runs with ``network_mode: host``, so the address picked is the
+    host's own LAN IP, not a Docker bridge address. Returns ``None`` when it can't be determined
+    (e.g. no default route), so callers fall back to showing the hostname alone.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("192.0.2.1", 80))
+        return s.getsockname()[0]
+    except OSError:
+        return None
+    finally:
+        s.close()

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -94,7 +94,7 @@ function Header({ state }) {
                         <${Badges} badges=${state.badges} />
                         <${VersionBadge} version=${state.version} />
                     </div>
-                    <div class="brand-host font-mono text-muted">${state.host_ip}${state.host_addr ? html` · ${state.host_addr}` : null}</div>
+                    <div class="brand-host font-mono text-muted">${state.host_ip}${state.host_addr ? html`<span class="brand-host-at">@</span>${state.host_addr}` : null}</div>
                 </div>
             </div>
             <div class="text-small mt-2">

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -94,7 +94,7 @@ function Header({ state }) {
                         <${Badges} badges=${state.badges} />
                         <${VersionBadge} version=${state.version} />
                     </div>
-                    <div class="brand-host font-mono text-muted">${state.host_ip}</div>
+                    <div class="brand-host font-mono text-muted">${state.host_ip}${state.host_addr ? html` · ${state.host_addr}` : null}</div>
                 </div>
             </div>
             <div class="text-small mt-2">

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -60,7 +60,10 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Ar
 .brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
 .brand-logo { width: 40px; height: 40px; flex: none; }
 .brand-name { margin: 0; font-size: 1.5rem; font-weight: 700; letter-spacing: 0.5px; }
-.brand-host { font-size: 0.8rem; margin-top: 2px; overflow-wrap: anywhere; }
+.brand-host { font-size: 0.8rem; margin-top: 3px; line-height: 1.35; overflow-wrap: anywhere; }
+/* Host subtitle is "hostname @ ip" (Issue #119): the @ is a faint connector, not a value, so
+   dim it and give it even breathing room. Hostname and ip stay at the one muted subtitle weight. */
+.brand-host-at { margin: 0 0.4em; opacity: 0.5; }
 
 /* Hero KPI band (Issue #81): a prominent strip of the headline numbers under the header. A
  * responsive auto-fit grid so the cards sit in one row on a wide screen and reflow when narrow;

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -16,7 +16,9 @@ import bisect
 import logging
 
 from mining_dashboard.config.config import HOST_IP, UPDATE_INTERVAL
-from mining_dashboard.helper.utils import format_hashrate, format_duration, format_time_abs
+from mining_dashboard.helper.utils import (
+    format_hashrate, format_duration, format_time_abs, is_ip_address, detect_host_ipv4,
+)
 from mining_dashboard.service.metrics import build_metrics
 from mining_dashboard.version import resolve_version
 
@@ -565,6 +567,23 @@ def build_badges(data, metrics, mode_variant):
 # Assembly.
 # --------------------------------------------------------------------------------------
 
+def host_display_addr(host):
+    """The numeric IP to show *beside* the configured host in the header, or ``None`` (Issue #119).
+
+    The configured ``dashboard.host`` is often a hostname that won't resolve from another machine
+    on the LAN (flaky mDNS/``.local``, no DNS entry), so we surface the host's primary IP next to
+    it as a fallback way in. Returns ``None`` — meaning "show the host alone" — when there's
+    nothing useful to add: the host is already an IP, the address can't be determined, or it just
+    duplicates the host.
+    """
+    if is_ip_address(host):
+        return None
+    addr = detect_host_ipv4()
+    if not addr or addr == host:
+        return None
+    return addr
+
+
 def build_state(data, state_mgr, range_arg, window=None):
     """Assemble the full ``/api/state`` payload — the contract the client renders against.
 
@@ -583,6 +602,7 @@ def build_state(data, state_mgr, range_arg, window=None):
         "syncing": metrics.global_syncing,
         "page_title": "Mining Dashboard - Syncing" if metrics.global_syncing else "Mining Dashboard",
         "host_ip": HOST_IP,
+        "host_addr": host_display_addr(HOST_IP),
         "version": resolve_version(),
         "last_update": format_time_abs(time.time()),
         "range": range_arg,

--- a/build/dashboard/tests/helper/test_utils.py
+++ b/build/dashboard/tests/helper/test_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from mining_dashboard.helper.utils import (
     parse_hashrate, format_hashrate, format_duration,
     format_time_abs, get_tier_info, resolve_target_threshold,
+    is_ip_address, detect_host_ipv4,
 )
 
 
@@ -115,3 +116,48 @@ class TestResolveTargetThreshold:
     def test_unknown_level_falls_back_to_lowest(self):
         target, _ = resolve_target_threshold(self.TIERS, 1_000_000, "bogus", 0.85)
         assert target == 1_000
+
+
+class TestIsIpAddress:
+    def test_ipv4_is_an_address(self):
+        assert is_ip_address("192.168.1.42") is True
+        assert is_ip_address("127.0.0.1") is True
+
+    def test_ipv6_is_an_address(self):
+        assert is_ip_address("::1") is True
+        assert is_ip_address("fe80::1") is True
+
+    def test_hostname_is_not_an_address(self):
+        assert is_ip_address("pithead.local") is False
+        assert is_ip_address("my-rig") is False
+        assert is_ip_address("256.256.256.256") is False
+
+    def test_surrounding_whitespace_tolerated(self):
+        assert is_ip_address("  10.0.0.5  ") is True
+
+    def test_non_string_and_empty_are_not_addresses(self):
+        assert is_ip_address("") is False
+        assert is_ip_address(None) is False
+
+
+class TestDetectHostIpv4:
+    def test_returns_socket_source_address(self):
+        # UDP connect only fixes the route; getsockname() then exposes the chosen source IP.
+        sock = patch("mining_dashboard.helper.utils.socket.socket").start()
+        try:
+            sock.return_value.getsockname.return_value = ("192.168.1.42", 54321)
+            assert detect_host_ipv4() == "192.168.1.42"
+        finally:
+            patch.stopall()
+
+    def test_none_when_no_route(self):
+        with patch("mining_dashboard.helper.utils.socket.socket") as sock:
+            sock.return_value.connect.side_effect = OSError("network unreachable")
+            assert detect_host_ipv4() is None
+
+    def test_socket_is_closed_even_on_error(self):
+        with patch("mining_dashboard.helper.utils.socket.socket") as sock:
+            inst = sock.return_value
+            inst.connect.side_effect = OSError("boom")
+            detect_host_ipv4()
+            inst.close.assert_called_once()

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -233,3 +233,11 @@ class TestResponsiveLayout:
         # brand subtitle (`.brand-host`), which carries the overflow-wrap protection.
         css = await (await client.get("/static/dashboard.css")).text()
         assert ".brand-host" in css and "overflow-wrap" in css
+
+    async def test_host_at_separator_styled_and_rendered(self, client):
+        # The "hostname @ ip" subtitle (#119) renders the @ as a dimmed connector span, so the
+        # markup must emit `.brand-host-at` and the CSS must carry a matching dimming rule.
+        mjs = await (await client.get("/static/components.mjs")).text()
+        css = await (await client.get("/static/dashboard.css")).text()
+        assert "brand-host-at" in mjs and "state.host_addr" in mjs
+        assert ".brand-host-at" in css and "opacity" in css

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -8,7 +8,7 @@ presentation tokens), the chart series (Issue #65), and the full ``build_state``
 import json
 import time
 from dataclasses import replace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -17,6 +17,7 @@ from mining_dashboard.web.views import (
     build_chart, build_hashrate, build_pool_network, build_workers, build_tari,
     build_system, build_sync, build_badges, build_state, get_shell_html, _mode_palette,
     parse_window, _target_points, _chart_tension, build_proxy_summary, _reject_flag,
+    host_display_addr,
 )
 from mining_dashboard.service.metrics import Metrics, SyncMetric
 
@@ -562,6 +563,28 @@ class TestPoolNetwork:
         assert pn["monero"]["db_size"] == "—"
 
 
+# --- Host address beside the hostname (Issue #119) ------------------------------------
+
+class TestHostDisplayAddr:
+    def test_resolves_ip_for_a_hostname(self):
+        with patch.object(views, "detect_host_ipv4", return_value="192.168.1.42"):
+            assert host_display_addr("pithead.local") == "192.168.1.42"
+
+    def test_none_when_host_is_already_an_ip(self):
+        # Nothing to add beside a literal address — don't call detection at all.
+        with patch.object(views, "detect_host_ipv4") as detect:
+            assert host_display_addr("192.168.1.42") is None
+            detect.assert_not_called()
+
+    def test_none_when_ip_undetectable(self):
+        with patch.object(views, "detect_host_ipv4", return_value=None):
+            assert host_display_addr("pithead.local") is None
+
+    def test_none_when_detected_ip_equals_host(self):
+        with patch.object(views, "detect_host_ipv4", return_value="my-rig"):
+            assert host_display_addr("my-rig") is None
+
+
 # --- build_state integration ----------------------------------------------------------
 
 def _state_mgr(history=None, mode="P2POOL"):
@@ -585,9 +608,10 @@ def _data(**over):
 class TestBuildState:
     def test_has_all_sections(self):
         st = build_state(_data(), _state_mgr(), "all")
-        for key in ("syncing", "page_title", "host_ip", "version", "last_update", "range", "window",
-                    "badges", "hashrate", "system", "sync", "stratum", "pool", "network", "monero",
-                    "shares_window", "proxy_workers", "tari", "workers", "proxy_summary", "chart"):
+        for key in ("syncing", "page_title", "host_ip", "host_addr", "version", "last_update",
+                    "range", "window", "badges", "hashrate", "system", "sync", "stratum", "pool",
+                    "network", "monero", "shares_window", "proxy_workers", "tari", "workers",
+                    "proxy_summary", "chart"):
             assert key in st, f"missing section: {key}"
 
     def test_version_section_shape(self):

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -75,6 +75,10 @@ HugePages, disk), your **total hashrate**, and headline **1h / 24h averages** fo
 XvB so you can see your split at a glance. Next to the disk readout, an **`XMR Pruned`** /
 **`XMR Full`** badge shows the Monero node's blockchain mode at a glance.
 
+When the dashboard host is a name (not already an IP), the machine's **IP address** is shown
+beside it (e.g. `pithead.local · 192.168.1.42`) — a reliable way back in when the hostname doesn't
+resolve from your phone or another machine on the LAN.
+
 A small **version badge** sits beside the hostname so you always know which build is running. A
 released build shows the version (e.g. **`v1.3.0`**); a development or working-tree build shows a
 dashed **`dev · branch @ commit`** marker instead, so it's never mistaken for a release. It appears

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -76,8 +76,8 @@ XvB so you can see your split at a glance. Next to the disk readout, an **`XMR P
 **`XMR Full`** badge shows the Monero node's blockchain mode at a glance.
 
 When the dashboard host is a name (not already an IP), the machine's **IP address** is shown
-beside it (e.g. `pithead.local · 192.168.1.42`) — a reliable way back in when the hostname doesn't
-resolve from your phone or another machine on the LAN.
+beside it as `hostname @ ip` (e.g. `pithead.local @ 192.168.1.42`) — a reliable way back in when
+the hostname doesn't resolve from your phone or another machine on the LAN.
 
 A small **version badge** sits beside the hostname so you always know which build is running. A
 released build shows the version (e.g. **`v1.3.0`**); a development or working-tree build shows a


### PR DESCRIPTION
Closes #119.

## What

The dashboard header now shows the host's **IP address** next to the hostname, as `hostname @ ip`, when the configured `dashboard.host` is a name:

> Pithead  `pithead.local @ 192.168.1.42`

The configured host is often a hostname (`*.local`, a custom name) that doesn't resolve from a phone or another machine on the LAN — mDNS is flaky and there may be no DNS entry. Showing the numeric IP beside it gives a reliable fallback way in, complementing the existing "use the hostname/IP" guidance in the docs.

## How

- **`detect_host_ipv4()`** (`helper/utils.py`) — best-effort primary LAN IPv4. Opens a UDP socket toward an RFC 5737 TEST-NET sentinel so the kernel picks the default-route interface's source address; `connect` only fixes the route, **no packets are sent**. The dashboard runs `network_mode: host`, so the address is the host's own (not a Docker bridge). Returns `None` if it can't be determined (e.g. no default route).
- **`is_ip_address()`** (`helper/utils.py`) — so a host that's *already* an IP isn't doubled up.
- **`host_display_addr()`** (`web/views.py`) — adds `host_addr` to the `/api/state` payload. It's `None` (→ "show the host alone") when the host is already an IP, the address can't be determined, or it just duplicates the host.
- **Header render** (`components.mjs` + `dashboard.css`) — shows `host_ip @ host_addr` only when `host_addr` is present. The `@` is a dimmed connector (`.brand-host-at`, opacity 0.5), not a value, so the hostname and IP stay at the one muted subtitle weight. Existing `overflow-wrap` keeps it wrapping cleanly on a phone.

## Design / verification

Verified in a browser against the real `dashboard.css`, in **dark and light** themes and at **320px**:

- `pithead.local @ 192.168.1.42` — clean, with the `@` reading as a faint connector.
- Host already an IP → just `192.168.1.42`, no `@`.
- Long hostname wraps to a second line (`@` leads the IP) with **no horizontal page overflow** (`scrollWidth == clientWidth` at 320px).

## Edge cases handled

- `dashboard.host` already an IP → no duplicate (detection skipped entirely).
- IP undeterminable → degrades to hostname-only.
- Detected IP equal to the configured host → not repeated.

## Tests

- Unit tests for `is_ip_address`, `detect_host_ipv4` (mocked socket, incl. the no-route → `None` path and socket-closed-on-error), and `host_display_addr` (all four branches).
- `build_state` contract test updated to require the new `host_addr` key.
- CSS/markup structural test asserts the `@` connector is emitted and dimmed.
- Full dashboard suite: **402 passed**, coverage **92.9%** (gate 80%). Frontend `node --test`: **20 passed**.
- CHANGELOG + `docs/dashboard.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)