### PR TITLE
Make the hashrate chart fill the card when the line is stable (#145)

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/chart.mjs
+++ b/build/dashboard/mining_dashboard/web/static/chart.mjs
@@ -45,7 +45,6 @@ const withAlpha = (hex, aa) => (/^#[0-9a-fA-F]{6}$/.test(hex) ? hex + aa : hex);
 
 // The chart's colours, read from the active theme's CSS variables (Issue #43) so the chart
 // matches light/dark/auto. Re-read on every sync() so a theme switch recolours it in place.
-// Fills are fairly solid now that the areas stack cleanly rather than overlapping.
 function paletteColors() {
     const cs = getComputedStyle(document.documentElement);
     const v = (name, fallback) => cs.getPropertyValue(name).trim() || fallback;
@@ -53,13 +52,43 @@ function paletteColors() {
     const purple = v('--purple', '#a371f7');
     return {
         accent, purple,
-        accentFill: withAlpha(accent, '33'),   // ≈ 0.2 alpha
-        purpleFill: withAlpha(purple, '4d'),   // ≈ 0.3 alpha
         shares: v('--bad', '#da3633'),
         grid: v('--border', '#30363d'),
         ticks: v('--text-muted', '#8b949e'),
         band: withAlpha(accent, '26'),         // drag-to-zoom selection band (≈ 0.15 alpha)
     };
+}
+
+// Area-fill gradient stops (Issue #145): strong near the line, fading toward the axis, so a flat
+// series reads as a solid mass instead of a thin strip. Line a touch thicker than the default so
+// the top edge pops against the fill.
+const FILL_TOP = '59';   // ≈ 0.35 alpha at the line
+const FILL_BOTTOM = '0d';  // ≈ 0.05 alpha at the axis
+const AREA_BORDER_WIDTH = 3.5;
+
+// A vertical gradient fill for a stacked area, keyed to the live chart area (pixels, not data) so
+// it spans the visible card regardless of the y-range. Scriptable: re-evaluated on resize/zoom.
+// Before the first layout `chartArea` is undefined, so fall back to the flat top tint.
+function areaFill(baseHex) {
+    return (ctx) => {
+        const area = ctx.chart.chartArea;
+        if (!area) return withAlpha(baseHex, FILL_TOP);
+        const g = ctx.chart.ctx.createLinearGradient(0, area.top, 0, area.bottom);
+        g.addColorStop(0, withAlpha(baseHex, FILL_TOP));
+        g.addColorStop(1, withAlpha(baseHex, FILL_BOTTOM));
+        return g;
+    };
+}
+
+// Pad the auto-fitted y-range so a near-flat line fills the card instead of hugging the bottom
+// (Issue #145). Pads by a fraction of the visible span, with a floor tied to the magnitude so a
+// dead-flat series isn't magnified into pure noise; never drops below zero.
+function padYAxis(scale) {
+    const { min, max } = scale;
+    if (!isFinite(min) || !isFinite(max)) return;   // all series hidden / no data
+    const pad = Math.max((max - min) * 0.2, max * 0.03);
+    scale.min = Math.max(0, min - pad);
+    scale.max = max + pad;
 }
 
 export class ChartCard extends Component {
@@ -105,16 +134,17 @@ export class ChartCard extends Component {
             type: 'line',
             data: {
                 datasets: [
-                    { label: 'P2Pool', data: d.p2pool, borderColor: c.accent, tension, fill: true,
-                      hidden: vis.p2pool === false,
-                      stack: 'hr', backgroundColor: c.accentFill, pointRadius: 0, pointHitRadius: 20 },
-                    { label: 'XvB', data: d.xvb, borderColor: c.purple, tension, fill: true,
-                      hidden: vis.xvb === false,
-                      stack: 'hr', backgroundColor: c.purpleFill, pointRadius: 0, pointHitRadius: 20 },
-                    // Own stack group so the scatter's y isn't summed onto the areas.
+                    { label: 'P2Pool', data: d.p2pool, borderColor: c.accent, borderWidth: AREA_BORDER_WIDTH,
+                      tension, fill: true, hidden: vis.p2pool === false,
+                      stack: 'hr', backgroundColor: areaFill(c.accent), pointRadius: 0, pointHitRadius: 20 },
+                    { label: 'XvB', data: d.xvb, borderColor: c.purple, borderWidth: AREA_BORDER_WIDTH,
+                      tension, fill: true, hidden: vis.xvb === false,
+                      stack: 'hr', backgroundColor: areaFill(c.purple), pointRadius: 0, pointHitRadius: 20 },
+                    // On its own hidden 0–1 axis (yAxisID) so the markers ride near the top edge and
+                    // never inflate the hashrate y-range (Issue #145).
                     { label: 'Shares', data: d.shares, borderColor: c.shares, backgroundColor: c.shares,
-                      hidden: vis.shares === false,
-                      stack: 'shares', pointStyle: 'triangle', rotation: 180, pointRadius: d.shares.map((s) => s.r),
+                      hidden: vis.shares === false, yAxisID: 'shares',
+                      pointStyle: 'triangle', rotation: 180, pointRadius: d.shares.map((s) => s.r),
                       pointHoverRadius: 15, pointHitRadius: 100, showLine: false },
                 ],
             },
@@ -150,9 +180,12 @@ export class ChartCard extends Component {
                 scales: {
                     // Linear x positions points by real elapsed time (gaps occupy proportional
                     // space); axis hidden as before. y is stacked (P2Pool+XvB = total) and
-                    // grid/ticks follow the theme.
+                    // grid/ticks follow the theme; padYAxis keeps a flat line off the floor.
                     x: { type: 'linear', display: false },
-                    y: { stacked: true, grid: { color: c.grid }, ticks: { color: c.ticks } },
+                    y: { stacked: true, grid: { color: c.grid }, ticks: { color: c.ticks }, afterDataLimits: padYAxis },
+                    // Hidden 0–1 axis the Shares scatter rides on; markers pin near the top (0.93,
+                    // set server-side) so they never affect the hashrate y-range (Issue #145).
+                    shares: { type: 'linear', display: false, min: 0, max: 1 },
                 },
             },
         });
@@ -172,8 +205,8 @@ export class ChartCard extends Component {
         const tension = d.tension ?? 0.3;
         this.shareCounts = d.shares.map((s) => s.c);
         const ds = this.chart.data.datasets;
-        ds[0].data = d.p2pool; ds[0].borderColor = c.accent; ds[0].backgroundColor = c.accentFill; ds[0].tension = tension;
-        ds[1].data = d.xvb;    ds[1].borderColor = c.purple; ds[1].backgroundColor = c.purpleFill; ds[1].tension = tension;
+        ds[0].data = d.p2pool; ds[0].borderColor = c.accent; ds[0].backgroundColor = areaFill(c.accent); ds[0].tension = tension;
+        ds[1].data = d.xvb;    ds[1].borderColor = c.purple; ds[1].backgroundColor = areaFill(c.purple); ds[1].tension = tension;
         ds[2].data = d.shares; ds[2].borderColor = c.shares; ds[2].backgroundColor = c.shares;
         ds[2].pointRadius = d.shares.map((s) => s.r);
         this.chart.options.scales.y.grid.color = c.grid;

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -203,10 +203,17 @@ def _downsample_history(filtered_history, duration_s):
     return downsampled
 
 
+# Where the share markers ride on their own hidden 0–1 axis on the client: a constant near the
+# top, so they form a "rug" along the top edge instead of riding the hashrate line. Pinning them
+# off the hashrate axis keeps a single tall marker from inflating the y-range and burying a flat
+# line at the bottom of the card (Issue #145).
+_SHARE_MARKER_Y = 0.93
+
+
 def _share_points(filtered_history, filtered_shares):
     """Sparse share markers: bucket each share onto its nearest history sample and emit one
-    ``{x, y, r, c}`` point per sample that has shares (x = sample time ms, y = lifted above the
-    line, r = radius scaled by count, c = count)."""
+    ``{x, y, r, c}`` point per sample that has shares (x = sample time ms, y = the fixed top-of-
+    chart position on the client's dedicated share axis, r = radius scaled by count, c = count)."""
     if not (filtered_history and filtered_shares):
         return []
 
@@ -225,12 +232,11 @@ def _share_points(filtered_history, filtered_shares):
     points = []
     for idx in sorted(counts):
         count = counts[idx]
-        v = filtered_history[idx].get('v', 0)
-        # Lift the marker 10% above the line so it doesn't sit on the curve; floor to 100 for
-        # zero-hashrate samples so it stays visible.
+        # y is fixed (a fraction of the dedicated 0–1 share axis): the marker no longer tracks the
+        # hashrate, so it never stretches the y-range. Radius still scales with the share count.
         points.append({
             "x": int(hist_ts[idx] * 1000),
-            "y": v * 1.1 if v > 0 else 100,
+            "y": _SHARE_MARKER_Y,
             "r": min(6 + (count * 3), 15),
             "c": count,
         })

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -144,7 +144,9 @@ class TestChart:
         chart = build_chart([{"timestamp": 1, "v": 5, "v_p2pool": 5, "v_xvb": 0, "t": "a"}], [], "all")
         assert len(chart["p2pool"]) == 1
 
-    def test_share_points_sparse_and_lifted(self):
+    def test_share_points_sparse_and_top_pinned(self):
+        # Markers ride a dedicated 0–1 axis pinned near the top, independent of hashrate, so they
+        # don't inflate the y-range and bury a flat line (Issue #145). Radius still scales by count.
         history = [
             {"timestamp": 1000, "v": 500, "v_p2pool": 500, "v_xvb": 0, "t": "a"},
             {"timestamp": 1030, "v": 600, "v_p2pool": 600, "v_xvb": 0, "t": "b"},
@@ -152,14 +154,15 @@ class TestChart:
         shares = [{"ts": 1001}, {"ts": 1029}]   # one near each sample
         pts = build_chart(history, shares, "all")["shares"]
         assert pts == [
-            {"x": 1_000_000, "y": 550.0, "r": 9, "c": 1},   # 500 * 1.1, radius 6+3
-            {"x": 1_030_000, "y": 660.0, "r": 9, "c": 1},
+            {"x": 1_000_000, "y": 0.93, "r": 9, "c": 1},   # fixed top position, radius 6+3
+            {"x": 1_030_000, "y": 0.93, "r": 9, "c": 1},
         ]
 
-    def test_share_offset_floor_when_value_zero(self):
+    def test_share_marker_top_pinned_when_value_zero(self):
+        # Same fixed position even at zero hashrate — the marker stays visible without a floor hack.
         pts = build_chart([{"timestamp": 1000, "v": 0, "v_p2pool": 0, "v_xvb": 0, "t": "a"}],
                           [{"ts": 1000}], "all")["shares"]
-        assert pts == [{"x": 1_000_000, "y": 100, "r": 9, "c": 1}]
+        assert pts == [{"x": 1_000_000, "y": 0.93, "r": 9, "c": 1}]
 
     def test_no_shares_no_points(self):
         assert build_chart([{"timestamp": 1, "v": 5, "v_p2pool": 5, "v_xvb": 0, "t": "a"}], [], "all")["shares"] == []


### PR DESCRIPTION
Closes #145.

## Problem

When hashrate is steady, the chart wasted most of its vertical space — the area line sat glued to the bottom under a large empty band, so small variations were invisible and the card read as broken/empty.

The empty band was **mostly the share markers, not padding.** Each Shares triangle was plotted at `y = v * 1.1` on the shared hashrate axis — a *multiplicative* 10% lift. On a tall, flat baseline (~47.6 kH/s) that lift is ~4.8 kH/s of dead space, and since the marker shared the y-axis, Chart.js stretched the ceiling up to contain it while the real data sat at the bottom.

## Changes

1. **Decouple share markers from the hashrate scale.** Shares now ride a dedicated hidden `0–1` axis pinned near the top (`0.93`, set server-side in `_share_points`) — a "rug" of triangles along the top edge. They stay visible at zero hashrate, keep their count-scaled radius, and no longer inflate the y-range.
2. **Tighten the y-axis to the data band.** A new `afterDataLimits` pad brackets the axis to the visible stacked min/max — a fraction of the span with a magnitude-based floor — so a near-flat line fills the card without magnifying noise.
3. **Make the area pop.** A vertical gradient fill (strong at the line, fading toward the axis) plus a slightly thicker line, so flat data reads as a solid, intentional mass.

## Visual

Verified against the real vendored Chart.js v4.4.6 with a stable ~47.6 kH/s series:

- **Before:** line glued to the bottom, axis 47.5k–52.5k (the lone share triangle at `v*1.1` ≈ 52.4k stretching the ceiling), large empty band.
- **After:** axis tightened to ~46k–49.5k, the area fills the card as a blue gradient mass, the small wiggle is visible, and the share triangle sits as a top-edge "rug" without affecting the range.

## Files

- `build/dashboard/mining_dashboard/web/static/chart.mjs` — gradient fill, padded y-axis, dedicated share axis, thicker line.
- `build/dashboard/mining_dashboard/web/views.py` — `_share_points` emits a fixed top-pinned `y` instead of `v*1.1`.
- `build/dashboard/tests/web/test_views.py` — updated share-point assertions.

## Testing

- `pytest` (full dashboard suite): 404 passing.
- `node --test` frontend logic tests: 27 passing.
- `node --check` on `chart.mjs`: clean.
- Manual render of the Chart.js config against stable data (the chart component itself has no automated DOM harness — rendering is covered by the manual browser smoke test, per the repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)