### PR TITLE
gitignore: ignore the leftover top-level worker/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ config.json
 /build/tari/config.toml
 Caddyfile
 
+# Leftover worker-kit dir (tech debt). The worker/ kit was extracted to the RigForge repo (#71/#74);
+# a stale top-level worker/ can linger locally with miner runtime logs/state until that cutover is
+# finished. Ignore it so a stray `git add -A` can't pull those (sometimes huge) files into the repo.
+/worker/
+
 # Python
 __pycache__/
 *.pyc


### PR DESCRIPTION
The worker kit was extracted to the **RigForge** repo (#71 / #74), but a stale top-level `worker/` dir can linger locally with miner runtime logs/state until that cutover cleanup is finished. It wasn't in `.gitignore`, so a `git add -A` would happily sweep in those files — including, in practice, a ~1M-line `xmrig.log` and embedded git repos, which got rejected by GitHub's large-file hook.

This ignores `/worker/` (rooted, so only the top-level dir). Nothing under `worker/` is tracked (`git ls-files worker/` is empty), so this is purely a guard — no tracked files are affected.

Tech-debt note: the leftover `worker/` files should eventually be deleted locally once the RigForge cutover is complete; this just prevents accidental commits in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)