### PR TITLE
doctor: warn when Docker isn't enabled to start at boot (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   (`3333`) is published on (default `0.0.0.0`; set a LAN IP or `127.0.0.1` to narrow it).
 - Liveness healthcheck for the p2pool container (probes the stratum port), so a stalled
   p2pool is now visible in `pithead status` and the dashboard.
+- `pithead doctor` now checks that Docker is enabled to start at boot (systemd) and warns if not —
+  `restart: unless-stopped` only brings the stack back after a reboot when the daemon does too,
+  which matters for an unattended miner (#137).
 
 ### Changed
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -54,6 +54,12 @@ chains finish their initial sync — check the dashboard to see which.
 **Change a setting:** edit `config.json`, then `./pithead apply`. See
 [Configuration › Changing settings later](configuration.md#changing-settings-later).
 
+**Reboot resilience:** every service runs with `restart: unless-stopped`, so the whole stack
+comes back **on its own after a reboot or power loss** — *provided the Docker daemon itself starts
+at boot*. On Ubuntu's packaged Docker that's the default, but a custom/rootless install (or
+`setup --skip-deps`) may leave it disabled. `./pithead doctor` checks this and warns if Docker
+isn't boot-enabled; the fix is `sudo systemctl enable --now docker`.
+
 ---
 
 ## Updating the stack

--- a/pithead
+++ b/pithead
@@ -197,6 +197,13 @@ dr_fail() { DR_FAIL=$((DR_FAIL + 1)); printf '  %b✗ FAIL%b %s\n'   "$C_RED"   
 # Neutral note for context lines that aren't pass/fail (e.g. a skipped Linux-only check).
 dr_info() { printf '  %b•%b      %s\n' "$C_YELLOW" "$C_RESET" "$1"; }
 
+# True if Docker is set to start at boot (docker.service OR docker.socket enabled). systemd only —
+# the caller checks that systemctl exists. Checking docker.socket too covers socket-activated
+# installs where docker.service is "static" but Docker still comes up at boot.
+docker_boot_enabled() {
+    systemctl is-enabled docker.service >/dev/null 2>&1 || systemctl is-enabled docker.socket >/dev/null 2>&1
+}
+
 doctor() {
     DR_OK=0; DR_WARN=0; DR_FAIL=0
     detect_os
@@ -237,6 +244,21 @@ doctor() {
         dr_ok "Docker daemon is reachable."
     else
         dr_fail "Docker daemon is not reachable — start it (e.g. 'sudo systemctl start docker') and ensure your user is in the 'docker' group."
+    fi
+
+    # --- Docker boot persistence (Linux/systemd) ---
+    # `restart: unless-stopped` only brings the stack back after a reboot if the Docker daemon
+    # itself starts at boot. Ubuntu's docker.io/docker-ce enables it by default, but --skip-deps,
+    # rootless, or a manually-disabled unit won't come back after a power loss — surface that, since
+    # the documented use case is an unattended miner (#137).
+    if [ "$OS_TYPE" != "Darwin" ] && command -v systemctl >/dev/null 2>&1; then
+        echo ""
+        echo "Boot persistence:"
+        if docker_boot_enabled; then
+            dr_ok "Docker is enabled to start at boot — the stack will come back after a reboot."
+        else
+            dr_warn "Docker is NOT enabled to start at boot — after a power loss/reboot the stack won't restart. Fix: 'sudo systemctl enable --now docker'."
+        fi
     fi
 
     # --- CPU: AVX2 (performance only) ---

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -73,6 +73,23 @@ run_sourced "$SANDBOX" is_ipv4 "192.168.1.0/24" >/dev/null 2>&1; assert_rc "reje
 run_sourced "$SANDBOX" is_ipv4 "example.com"  >/dev/null 2>&1; assert_rc "rejects hostname"    "$?" "1"
 run_sourced "$SANDBOX" is_ipv4 ""             >/dev/null 2>&1; assert_rc "rejects empty"       "$?" "1"
 
+echo "== unit: docker_boot_enabled (#137) =="
+# A systemctl stub on PATH; FAKE_BOOT picks which unit reports "enabled". Docker counts as
+# boot-enabled if EITHER docker.service or docker.socket is enabled.
+BOOT="$SANDBOX/boot"; mkdir -p "$BOOT/bin"
+cat > "$BOOT/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "is-enabled docker.service") [ "${FAKE_BOOT:-}" = "service" ] && exit 0 || exit 1 ;;
+  "is-enabled docker.socket")  [ "${FAKE_BOOT:-}" = "socket"  ] && exit 0 || exit 1 ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$BOOT/bin/systemctl"
+PATH="$BOOT/bin:$PATH" FAKE_BOOT=service run_sourced "$SANDBOX" docker_boot_enabled; assert_rc "docker.service enabled -> 0" "$?" "0"
+PATH="$BOOT/bin:$PATH" FAKE_BOOT=socket  run_sourced "$SANDBOX" docker_boot_enabled; assert_rc "docker.socket enabled -> 0"  "$?" "0"
+PATH="$BOOT/bin:$PATH" FAKE_BOOT=none    run_sourced "$SANDBOX" docker_boot_enabled; assert_rc "neither enabled -> 1"        "$?" "1"
+
 echo "== unit: describe_change =="
 assert_contains "prune is DEST"      "$(run_sourced "$SANDBOX" describe_change MONERO_PRUNE 1 0)"        "DEST"
 assert_contains "rpc lan is DEST"    "$(run_sourced "$SANDBOX" describe_change MONERO_RPC_BIND 127.0.0.1 0.0.0.0)" "DEST"


### PR DESCRIPTION
## Why
Every service uses `restart: unless-stopped`, but that only brings the stack back after a reboot or power loss **if the Docker daemon itself starts at boot**. Ubuntu's packaged Docker enables it by default, but a custom/rootless install or `setup --skip-deps` can leave it disabled — and on an unattended miner you'd only discover it as zero hashrate hours later.

## What
- `pithead doctor` gains a **Boot persistence** check (Linux/systemd only): `✓ OK` when Docker is boot-enabled, `⚠ WARN` with the fix (`sudo systemctl enable --now docker`) when it isn't. Warnings still exit 0.
- Checks **docker.service OR docker.socket** so socket-activated installs (where `docker.service` is `static`) aren't false-flagged.
- Logic lives in a small testable helper `docker_boot_enabled()`; the doctor caller guards on non-macOS + `systemctl` present.

## Tests & docs
- Unit test in `tests/stack/run.sh` driving the helper with a `systemctl` stub (service-enabled / socket-enabled / neither). Suite green, shellcheck clean.
- `docs/operations.md` gains a **Reboot resilience** note explaining the behavior and pointing at `doctor`.

Closes #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)