### PR TITLE
Fix dashboard pruned/full label: accept MONERO_PRUNE=1 (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,11 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   deployment) instead of re-reading `config.json` — editing a `*.data_dir` in `config.json`
   before resetting (without an `apply`) can no longer wipe a directory the stack never used. It
   also refuses to run rather than guess if `.env` doesn't name them (#139).
+- Dashboard pruned/full label (#32) always showed **Full** for a local node: the dashboard parsed
+  `MONERO_PRUNE` with `== "true"`, but pithead renders `config.json`'s `monero.prune` as `1`/`0`
+  (the form monerod's CLI wants), so a correctly **pruned** node read as Full. The label is purely
+  cosmetic (the node is pruned either way); the parser now accepts `1`/`true`/`yes`/`on`. Surfaced
+  on a live pruned deployment whose badge read "XMR Full".
 
 ### Security
 

--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -127,7 +127,10 @@ MONERO_NODE_PASSWORD = os.environ.get("MONERO_NODE_PASSWORD", "")
 # Whether the bundled monerod is configured to prune the blockchain (config.json
 # monero.prune → MONERO_PRUNE). Used to label the node Pruned/Full in the UI (Issue #32);
 # only meaningful for a local node (we don't control a remote node's pruning).
-MONERO_PRUNE = os.environ.get("MONERO_PRUNE", "true").strip().lower() == "true"
+# pithead renders this as 1/0 (the form monerod's CLI wants), so accept the numeric/boolean
+# truthy forms — not just "true", which silently read pruned nodes as Full before (the
+# pruned/full label is purely display, #32).
+MONERO_PRUNE = os.environ.get("MONERO_PRUNE", "true").strip().lower() in ("true", "1", "yes", "on")
 
 # --- Tari Configuration ---
 # Connection details for the Tari Base Node and Block Explorer

--- a/build/dashboard/tests/config/test_config.py
+++ b/build/dashboard/tests/config/test_config.py
@@ -27,6 +27,18 @@ class TestConfig:
             cfg = _reload_config()
             assert cfg.XVB_DONATION_LEVEL == "auto"  # normalized to lowercase
 
+    def test_monero_prune_accepts_truthy_forms(self):
+        # pithead writes MONERO_PRUNE=1, so "1" (and friends) must read as pruned — not just
+        # the literal "true". Regression for the Pruned/Full label always showing Full (#32).
+        for v in ("true", "1", "yes", "On", " 1 ", "TRUE"):
+            with patch.dict(os.environ, {"MONERO_PRUNE": v}):
+                assert _reload_config().MONERO_PRUNE is True, f"{v!r} should be pruned"
+
+    def test_monero_prune_accepts_falsy_forms(self):
+        for v in ("false", "0", "no", "off", ""):
+            with patch.dict(os.environ, {"MONERO_PRUNE": v}):
+                assert _reload_config().MONERO_PRUNE is False, f"{v!r} should be full"
+
     def test_tier_config_env_override_valid(self):
         custom = {"donor_ultra": 5_000_000, "donor_basic": 500}
         # deploy injects the JSON wrapped in single quotes


### PR DESCRIPTION
## Problem

The dashboard's Monero **Pruned/Full** badge always showed **Full** on a local node, even when the node was correctly pruned.

`config.py` parsed the env var as:

```python
MONERO_PRUNE = os.environ.get("MONERO_PRUNE", "true").strip().lower() == "true"
```

…but pithead renders `config.json`'s `monero.prune` into `.env` as **`MONERO_PRUNE=1`** (the numeric form monerod's CLI requires). `"1" == "true"` is `False`, so a correctly **pruned** node read as Full.

This is purely a **display** bug — the node prunes either way — but it's misleading (it confused a real deployment whose header read "XMR Full" despite `prune-blockchain=1`).

## Fix

Accept the numeric/boolean truthy forms `1`/`true`/`yes`/`on` (and the falsy `0`/`false`/`no`/`off`/empty).

## Tests

- `test_monero_prune_accepts_truthy_forms` / `test_monero_prune_accepts_falsy_forms` in `tests/config/test_config.py`, covering case + whitespace variants.
- Full dashboard suite green locally: **424 passed**, 93% coverage (`config.py` 100%).

## Scope

Standalone, general fix — **independent of #114**. It belongs in `main` so a clean deploy labels pruned nodes correctly.

Fixes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
