### PR TITLE
fix: change transparent_hugepages to transparent_hugepage in GRUB kernel param

### DIFF
--- a/pithead
+++ b/pithead
@@ -1430,7 +1430,7 @@ optimize_kernel() {
                 fi
                 log "Updating GRUB configuration for persistent HugePages..."
                 sudo cp /etc/default/grub /etc/default/grub.bak
-                sudo sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="/GRUB_CMDLINE_LINUX_DEFAULT="hugepagesz=2M hugepages=3072 transparent_hugepages=never /' /etc/default/grub
+                sudo sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="/GRUB_CMDLINE_LINUX_DEFAULT="hugepagesz=2M hugepages=3072 transparent_hugepage=never /' /etc/default/grub
                 if command -v update-grub >/dev/null; then
                     sudo update-grub
                     REBOOT_REQUIRED=true


### PR DESCRIPTION
## Summary

Fix typo in `pithead` line 1433: the kernel boot parameter for disabling Transparent HugePages is `transparent_hugepage=never` (singular), not `transparent_hugepages=never` (plural).

## Bug

The incorrect parameter `transparent_hugepages=never` silently takes no effect because the Linux kernel expects `transparent_hugepage` (singular).

## Fix

Changed to the correct kernel parameter `transparent_hugepage=never`.

Fixes [#176](https://github.com/p2pool-starter-stack/pithead/issues/176).