### PR TITLE
fix(pithead): disk check crashes setup on first run (missing data dirs) (#179)

### DIFF
--- a/pithead
+++ b/pithead
@@ -1543,7 +1543,7 @@ check_disk_grouped() {
     # Group by mount point: accumulate required GiB and the component list per mount, and remember
     # one representative path per mount so we can read its free space once. Parallel arrays keyed by
     # a positional index (portable to Bash 3.2 on macOS — no associative arrays).
-    local mounts=() req_gib=() comp_list=() rep_path=()
+    local mounts=() req_gib=() comp_list=()
     local i mount comp gib idx
     for i in "${!components[@]}"; do
         comp="${components[$i]}"
@@ -1560,7 +1560,7 @@ check_disk_grouped() {
             if [ "${mounts[$j]}" = "$mount" ]; then idx="$j"; break; fi
         done
         if [ "$idx" -lt 0 ]; then
-            mounts+=("$mount"); req_gib+=("$gib"); comp_list+=("$comp"); rep_path+=("$dir")
+            mounts+=("$mount"); req_gib+=("$gib"); comp_list+=("$comp")
         else
             req_gib[idx]=$(( req_gib[idx] + gib ))
             comp_list[idx]="${comp_list[idx]}, $comp"
@@ -1578,8 +1578,10 @@ check_disk_grouped() {
         mount="${mounts[$i]}"
         comps="${comp_list[$i]}"
         need_kb=$(( req_gib[i] * 1048576 ))          # GiB -> KiB (df -P is 1K-blocks)
-        avail_kb=$(df -P "${rep_path[$i]}" 2>/dev/null | awk 'NR==2{print $4}')
-        avail_h=$(df -Ph "${rep_path[$i]}" 2>/dev/null | awk 'NR==2{print $4}')
+        # df the resolved MOUNT POINT (always exists), not the data dir — on first run the dir isn't
+        # created yet and `df` on a missing path fails the pipe, tripping `set -Eeuo pipefail` (#179).
+        avail_kb=$(df -P "$mount" 2>/dev/null | awk 'NR==2{print $4}')
+        avail_h=$(df -Ph "$mount" 2>/dev/null | awk 'NR==2{print $4}')
         if [ "$mode" = "doctor" ]; then
             if [ -n "$avail_kb" ] && [ "$avail_kb" -ge "$need_kb" ] 2>/dev/null; then
                 dr_ok "Data on $mount ($comps): ${avail_h:-?} free — needs ~${req_gib[i]} GB."

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -159,9 +159,11 @@ assert_eq "tari -> 50"           "$(run_sourced "$SANDBOX" disk_component_gib ta
 assert_eq "tor -> 1"             "$(run_sourced "$SANDBOX" disk_component_gib tor)"      "1"
 
 echo "== unit: check_disk_grouped (mocked df) =="
-# A df stub on PATH so check_disk_grouped sees a scripted filesystem layout. DF_MAP maps each data
-# dir to a mount point ("path=mount" space-separated); DF_AVAIL_KB / DF_AVAIL_H give the (single)
-# free figure every mount reports. Real temp dirs make disk_fs_mount resolve without walking up.
+# A df stub on PATH so check_disk_grouped sees a scripted filesystem layout. DF_MAP maps each path
+# df is queried for to a mount point ("path=mount" space-separated): the data dirs (disk_fs_mount
+# resolves the mount from these) AND the mount points themselves (check_disk_grouped reads free
+# space via the mount, not the possibly-missing dir — #179). DF_AVAIL_KB / DF_AVAIL_H give the
+# (single) free figure every mount reports. Real temp dirs make disk_fs_mount resolve without walking up.
 DISK="$SANDBOX/disk"; mkdir -p "$DISK/bin"
 cat > "$DISK/bin/df" <<'EOF'
 #!/usr/bin/env bash
@@ -179,7 +181,7 @@ md="$DM/monero" td="$DM/tari" pd="$DM/p2pool" dd="$DM/dashboard" rd="$DM/tor"
 
 # All five dirs on ONE filesystem with plenty of space -> a SINGLE grouped OK line naming every
 # component, with the combined pruned requirement (95+50+5+2+1 = 153 GB).
-one_map="$md=/data $td=/data $pd=/data $dd=/data $rd=/data"
+one_map="$md=/data $td=/data $pd=/data $dd=/data $rd=/data /data=/data"
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
        run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "one fs -> single line" "$(printf '%s\n' "$out" | grep -c 'Data on')" "1"
@@ -194,7 +196,7 @@ assert_eq "one small fs -> single line" "$(printf '%s\n' "$out" | grep -c 'Data 
 assert_contains "small fs warns below need" "$out" "below the ~153 GB"
 
 # Two filesystems: monero+tari on /big, the rest on /small -> ONE line per filesystem.
-two_map="$md=/big $td=/big $pd=/small $dd=/small $rd=/small"
+two_map="$md=/big $td=/big $pd=/small $dd=/small $rd=/small /big=/big /small=/small"
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$two_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
        run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "two fs -> two lines" "$(printf '%s\n' "$out" | grep -c 'Data on')" "2"
@@ -208,6 +210,16 @@ assert_eq "preflight silent when ample" "$out" ""
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=104857600 DF_AVAIL_H=100G \
        run_sourced "$SANDBOX" check_disk_grouped preflight 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_contains "preflight warns once when low" "$out" "Low disk on /data (hosts monero, tari, p2pool, dashboard, tor)"
+
+# Regression #179: on first run the data dirs don't exist yet; check_disk_grouped must resolve to the
+# nearest existing ancestor's mount and read free space THERE, not df the missing dir (which fails the
+# pipe and trips pithead's `set -Eeuo pipefail`). Run under strict mode — NOT run_sourced, which does
+# `set +e` and would mask the crash — so a re-introduced df-on-missing-dir would actually abort here.
+fresh_map="$DM=/data /data=/data"
+PATH="$DISK/bin:$PATH" DF_MAP="$fresh_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
+  bash -c 'source "$1" 2>/dev/null; check_disk_grouped preflight 1 "$2/fresh/monero" "$2/fresh/tari" "$2/fresh/p2pool" "$2/fresh/dashboard" "$2/fresh/tor"' \
+  _ "$STACK" "$DM" >/dev/null 2>&1
+assert_rc "check_disk_grouped survives not-yet-created data dirs under set -e (#179)" "$?" "0"
 
 # ---------------------------------------------------------------------------
 echo "== black-box: CLI dispatch =="


### PR DESCRIPTION
## Problem (#179)

On a fresh `./pithead setup`, the script aborts with exit 1 during "Parsing configuration…". `check_disk_grouped` reads free space with `df -P "$dir"` on each of the five data dirs — but on a first run those dirs **don't exist yet**, so `df` fails the pipe and `set -Eeuo pipefail` (+ the ERR trap) aborts before the stack ever starts:

```
++ df -P /path/to/pithead/data/monero
+++ on_err
[ERROR] pithead aborted unexpectedly (exit 1).
```

## Fix

`disk_fs_mount` already resolves each path to its **nearest existing ancestor's mount point** (it has to — `df` needs a real path). So read free space from that resolved **mount** instead of the possibly-not-yet-created dir. Same filesystem, identical free figure, but the path always exists. The now-redundant `rep_path` array is dropped.

## Test

Adds a **strict-mode** regression test to `tests/stack/run.sh`. The existing `check_disk_grouped` tests run via `run_sourced`, which does `set +e` — masking exactly this crash. The new test sources `pithead` under its real `set -Eeuo pipefail` and calls `check_disk_grouped` with **not-yet-created** dirs, asserting it returns 0. Verified it fails (113 passed / 1 failed) when the fix is reverted.

`make test-stack` → **114 passed, 0 failed**.

Closes #179