### PR TITLE
fix(pithead): reliable apply/upgrade config lifecycle (#125, #128)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Secrets and Env
 .env
 .env.new
+.env.apply-incomplete
 config.json
 /data/
 /build/monero/bitmonero.conf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,13 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Fixed
 
+- `pithead upgrade` now re-renders the generated config (`.env`, Caddyfile, Tari config) before
+  rebuilding, so a release that changes a config template, restructures the Caddyfile, or adds an
+  `.env` var takes effect — `upgrade` was previously just `up --build`, running new images against
+  the stale generated config from the last setup/apply (#128).
+- `pithead apply` no longer silently strands the stack after a failed `docker compose up`: it leaves
+  an "apply incomplete" marker so a re-run re-attempts the recreate (instead of no-opping on the
+  already-committed `.env`) and prints explicit recovery guidance on failure (#125).
 - `pithead backup` no longer aborts when `du`/`df` exit non-zero on an unreadable file or a
   transient FS error — the disk-space pre-check now degrades gracefully (its "proceeding without
   a space check" fallback was previously unreachable under `set -e`) (#127).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -12,7 +12,7 @@ the full list.
 | `./pithead up` | Start the stack. |
 | `./pithead down` | Stop the stack. |
 | `./pithead restart` | Restart the stack. |
-| `./pithead upgrade` | Rebuild and restart the containers (run after a `git pull`). |
+| `./pithead upgrade` | Re-render the generated config, then rebuild and restart the containers (run after a `git pull`). |
 | `./pithead logs [service]` | Follow logs for all containers, or a single service (e.g. `logs p2pool`). |
 | `./pithead status` | Show container status **and health-check every expected service** — warns about anything down/unhealthy and exits non-zero if so (handy for cron/monitoring). Profile-aware, and treats a stopped `p2pool`/`xmrig-proxy` as intentional during a node-down failover or while the miner is held until the chains sync. |
 | `./pithead doctor` | Read-only diagnostics: deps, Docker, AVX2, HugePages, RAM/disk, `.env`/onion state, and container status — a paste-able health report. |
@@ -71,8 +71,11 @@ git pull
 ./pithead upgrade
 ```
 
-`upgrade` rebuilds the container images and restarts the stack. Your data directories and
-`config.json` are untouched, so your blockchain sync and settings are preserved across upgrades.
+`upgrade` re-renders the generated config (`.env`, the Caddyfile, and the Tari config) for the
+current release, then rebuilds the container images and restarts the stack — so a release that
+changes a config template or adds an `.env` var takes effect, not just the new image. Your data
+directories and `config.json` are untouched, so your blockchain sync and settings are preserved
+across upgrades.
 
 ---
 

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 418 dashboard unit tests · 12 contract tests · 25 frontend
-tests · 23 `pithead` shell sections · 15 harness self-test sections ·
+tests · 25 `pithead` shell sections · 15 harness self-test sections ·
 8 live config scenarios (15 axis values) · 6 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 23 `pithead` shell sections · 15 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 418 |
 | 1 — Unit | frontend (node --test) | 25 |
-| 1 — Unit | `pithead` shell suite | 23 sections |
+| 1 — Unit | `pithead` shell suite | 25 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 6 |
@@ -518,7 +518,7 @@ tests · 23 `pithead` shell sections · 15 harness self-test sections ·
 - heroKpis: mode colour follows the server mode_variant token
 - heroKpis: total is accent-coloured; blocks and tier carry no colour class
 
-### `pithead` shell suite (tests/stack/run.sh) — 23 sections
+### `pithead` shell suite (tests/stack/run.sh) — 25 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_ipv4
@@ -538,6 +538,8 @@ tests · 23 `pithead` shell sections · 15 harness self-test sections ·
 - black-box: config validation
 - black-box: apply preserves secrets + propagates
 - black-box: local node creds auto-generated + persisted (#50)
+- black-box: upgrade re-renders generated config (#128)
+- black-box: apply recovers from a failed 'compose up' (#125)
 - black-box: status health check
 - black-box: doctor exit code (#127)
 - black-box: reset-dashboard targets .env dirs, not config.json (#139)
@@ -669,5 +671,5 @@ tests · 23 `pithead` shell sections · 15 harness self-test sections ·
 
 ---
 
-_Grand total: **507** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **509** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/pithead
+++ b/pithead
@@ -123,6 +123,21 @@ stack_restart() {
 
 stack_upgrade() {
     log "Upgrading stack (rebuilding containers)..."
+    # A release (git pull) may change config templates, add/rename .env vars, or restructure the
+    # Caddyfile / Tari config — all GENERATED files mounted into containers. Re-render them before
+    # rebuilding so new images don't run against the stale generated config from the last
+    # setup/apply (#128). Mirrors apply's render preamble; renders to a temp + swaps so preserved
+    # secrets (Tor onions, RPC creds, proxy token) survive.
+    require_env
+    parse_and_validate_config
+    load_preserved_state
+    ensure_directories
+    resolve_dashboard_host        # non-interactive; sets HOST_IP for the render
+    render_env "${ENV_FILE}.new"
+    mv "${ENV_FILE}.new" "$ENV_FILE"
+    inject_service_configs
+    generate_caddyfile
+    log "Re-rendered generated config for the current release."
     migrate_compose_project
     docker compose up -d --build
     log "Stack upgraded."
@@ -1818,54 +1833,73 @@ apply() {
         [ -n "$key" ] && changed+=("$key")
     done < <(env_changed_keys "$ENV_FILE" "$newenv")
 
-    if [ "${#changed[@]}" -eq 0 ]; then
-        rm -f "$newenv"
-        log "No configuration changes detected. Nothing to apply."
-        return 0
-    fi
+    # A marker left by a previous apply whose `docker compose up` failed AFTER the new config was
+    # committed (#125): the stack then runs OLD containers against NEW config files, and because a
+    # re-apply diffs the (already-committed) .env it would see no change and silently no-op. While
+    # the marker is present, re-apply re-attempts the recreate even when the rendered config matches.
+    local apply_marker="${ENV_FILE}.apply-incomplete" incomplete=0
+    [ -f "$apply_marker" ] && incomplete=1
 
     local destructive=0 caddy_changed=0 line flag msg old new
-    echo ""
-    log "The following changes will be applied:"
-    for key in "${changed[@]}"; do
-        old=$(env_get_file "$ENV_FILE" "$key")
-        new=$(env_get_file "$newenv" "$key")
-        case "$key" in HOST_IP|DASHBOARD_SECURE) caddy_changed=1 ;; esac
-        line=$(describe_change "$key" "$old" "$new")
-        flag=${line%%$'\t'*}
-        msg=${line#*$'\t'}
-        if [ "$flag" == "DEST" ]; then
-            echo -e "  ${C_YELLOW}⚠ ${msg}${C_RESET}"
-            destructive=1
-        else
-            echo "  • ${msg}"
-        fi
-    done
-    echo ""
+    if [ "${#changed[@]}" -gt 0 ]; then
+        echo ""
+        log "The following changes will be applied:"
+        for key in "${changed[@]}"; do
+            old=$(env_get_file "$ENV_FILE" "$key")
+            new=$(env_get_file "$newenv" "$key")
+            case "$key" in HOST_IP|DASHBOARD_SECURE) caddy_changed=1 ;; esac
+            line=$(describe_change "$key" "$old" "$new")
+            flag=${line%%$'\t'*}
+            msg=${line#*$'\t'}
+            if [ "$flag" == "DEST" ]; then
+                echo -e "  ${C_YELLOW}⚠ ${msg}${C_RESET}"
+                destructive=1
+            else
+                echo "  • ${msg}"
+            fi
+        done
+        echo ""
 
-    if [ "$destructive" -eq 1 ] && [ "$assume_yes" -eq 0 ]; then
-        warn "Some of the changes above (⚠) are disruptive."
-        read -r -p "Proceed with applying these changes? (y/N): " CONFIRM || true
-        if [[ ! "$CONFIRM" =~ ^[Yy] ]]; then
-            rm -f "$newenv"
-            log "Apply cancelled. No changes were made."
+        if [ "$destructive" -eq 1 ] && [ "$assume_yes" -eq 0 ]; then
+            warn "Some of the changes above (⚠) are disruptive."
+            read -r -p "Proceed with applying these changes? (y/N): " CONFIRM || true
+            if [[ ! "$CONFIRM" =~ ^[Yy] ]]; then
+                rm -f "$newenv"
+                log "Apply cancelled. No changes were made."
+                return 0
+            fi
+        fi
+
+        mv "$newenv" "$ENV_FILE"
+        inject_service_configs
+        generate_caddyfile
+    else
+        rm -f "$newenv"
+        if [ "$incomplete" -eq 0 ]; then
+            log "No configuration changes detected. Nothing to apply."
             return 0
         fi
+        warn "A previous apply updated the config but did not finish recreating containers — retrying."
     fi
-
-    mv "$newenv" "$ENV_FILE"
-    inject_service_configs
-    generate_caddyfile
 
     log "Updating containers..."
     migrate_compose_project
+    # Mark the recreate in-flight: cleared only after a SUCCESSFUL `up`, so a failure here (image
+    # build error, a port already bound, a failed health/dependency gate, daemon hiccup) leaves the
+    # marker for the next apply to retry instead of no-opping on the already-committed config (#125).
+    : > "$apply_marker"
     # Compose recreates only the services whose resolved config changed; --remove-orphans
     # drops monerod when a local→remote switch deactivates the local_node profile.
-    docker compose up -d --remove-orphans
+    if ! docker compose up -d --remove-orphans; then
+        warn "Config files were updated but containers were NOT recreated ('docker compose up' failed)."
+        warn "Fix the cause shown above, then re-run '$0 apply' (it will retry the recreate) — or '$0 up'."
+        exit 1   # leave $apply_marker in place so the retry re-attempts the recreate
+    fi
     # Caddy mounts the Caddyfile read-only, so a content change alone won't recreate it.
     if [ "$caddy_changed" -eq 1 ]; then
         docker compose restart caddy
     fi
+    rm -f "$apply_marker"
     log "Configuration applied."
     announce_dashboard_url
 }

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -390,6 +390,67 @@ out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -
 assert_eq "remote username left blank" "$(run_sourced "$V" env_get_file "$V/.env" MONERO_NODE_USERNAME)" ""
 assert_eq "remote creds not persisted" "$(jq -r '.monero.node_username' "$V/config.json")" ""
 
+echo "== black-box: upgrade re-renders generated config (#128) =="
+# `upgrade` used to be just `up --build`, leaving the generated .env/Caddyfile/Tari config stale
+# after a git pull. It must now re-render them while preserving secrets.
+U="$SANDBOX/upgrade"; mkdir -p "$U/build/tari" "$U/data/monero" "$U/data/tari" "$U/data/p2pool/stats" "$U/data/tor" "$U/data/dashboard"
+cp "$STACK" "$U/pithead"; make_stubs "$U/bin"; cp "$ROOT/build/tari/config.toml.template" "$U/build/tari/"
+# Stale .env: secrets present, but STRATUM_BIND (a rendered var) is missing — the upgrade must fill it.
+cat > "$U/.env" <<EOF
+MONERO_ONION_ADDRESS=mona.onion
+TARI_ONION_ADDRESS=taria.onion
+P2POOL_ONION_ADDRESS=p2pa.onion
+PROXY_AUTH_TOKEN=ORIGINALTOKEN
+HOST_IP=box.lan
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+EOF
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" > "$U/config.json"
+UL="$U/docker.log"; : > "$UL"
+out="$(cd "$U" && DOCKER_LOG="$UL" PATH="$U/bin:$PATH" ./pithead upgrade 2>&1)"; rc=$?
+assert_rc "upgrade exits 0" "$rc" "0"
+assert_eq "upgrade re-renders a missing var (STRATUM_BIND)" "$(run_sourced "$U" env_get_file "$U/.env" STRATUM_BIND)" "0.0.0.0"
+assert_eq "upgrade preserves the proxy token"               "$(run_sourced "$U" env_get_file "$U/.env" PROXY_AUTH_TOKEN)" "ORIGINALTOKEN"
+assert_contains "upgrade still rebuilds images"             "$(cat "$UL")" "compose up -d --build"
+
+echo "== black-box: apply recovers from a failed 'compose up' (#125) =="
+# A docker stub that fails `compose up -d --remove-orphans` only when FAIL_UP=1 (else succeeds).
+A="$SANDBOX/applyfail"; mkdir -p "$A/build/tari" "$A/bin" "$A/data/monero" "$A/data/tari" "$A/data/p2pool/stats" "$A/data/tor" "$A/data/dashboard"
+cp "$STACK" "$A/pithead"; cp "$ROOT/build/tari/config.toml.template" "$A/build/tari/"
+cat > "$A/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+echo "[docker] $*" >> "${DOCKER_LOG:-/dev/null}"
+case "$*" in
+  "compose version"|"info") exit 0 ;;
+  "exec tor cat /var/lib/tor/monero/hostname") echo "mona.onion"; exit 0 ;;
+  "exec tor cat /var/lib/tor/tari/hostname")   echo "taria.onion"; exit 0 ;;
+  "exec tor cat /var/lib/tor/p2pool/hostname") echo "p2pa.onion"; exit 0 ;;
+  "compose up -d --remove-orphans") [ "${FAIL_UP:-0}" = "1" ] && exit 1 || exit 0 ;;
+esac
+exit 0
+EOF
+printf '#!/usr/bin/env bash\nexit 0\n' > "$A/bin/sudo"; chmod +x "$A/bin/docker" "$A/bin/sudo"
+cat > "$A/.env" <<EOF
+MONERO_ONION_ADDRESS=mona.onion
+TARI_ONION_ADDRESS=taria.onion
+P2POOL_ONION_ADDRESS=p2pa.onion
+PROXY_AUTH_TOKEN=ORIGINALTOKEN
+HOST_IP=box.lan
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+EOF
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" > "$A/config.json"
+# First apply: real config delta committed, but `compose up` FAILS -> marker left, rc 1, guidance.
+out="$(cd "$A" && FAIL_UP=1 PATH="$A/bin:$PATH" ./pithead apply -y 2>&1)"; rc=$?
+assert_rc "apply fails (rc 1) when compose up fails" "$rc" "1"
+assert_contains "apply prints recovery guidance"     "$out" "were NOT recreated"
+if [ -f "$A/.env.apply-incomplete" ]; then mk=present; else mk=absent; fi; assert_eq "apply leaves the incomplete marker" "$mk" "present"
+# Second apply: config already committed (no delta), but the marker forces a retry, not a silent no-op.
+out="$(cd "$A" && FAIL_UP=0 PATH="$A/bin:$PATH" ./pithead apply -y 2>&1)"; rc=$?
+assert_rc "re-apply retries and succeeds (rc 0)"          "$rc" "0"
+assert_contains "re-apply re-attempts the recreate"      "$out" "retrying"
+if [ -f "$A/.env.apply-incomplete" ]; then mk=present; else mk=absent; fi; assert_eq "marker cleared after a successful retry" "$mk" "absent"
+
 echo "== black-box: status health check =="
 # A docker stub driven by FAKE_STATES ("svc=state:health ..."; state "missing" = no container)
 # so we can script each service's state and assert how `status` reports it.


### PR DESCRIPTION
Two closely-related correctness bugs in pithead's **generated-config + apply/upgrade lifecycle** — same subsystem (`render_env` / `apply` / `stack_upgrade`), so grouped into one review.

## #128 — `upgrade` ran new images against stale generated config
`stack_upgrade` was just `docker compose up -d --build`. `render_env` / `inject_service_configs` / `generate_caddyfile` are called only by `setup`/`apply`, so the documented `git pull && ./pithead upgrade` flow rebuilt images but kept the **old** rendered `.env` / Caddyfile / Tari config — a release that changes a template or adds an `.env` var silently had no effect.

**Fix:** `upgrade` now re-renders the generated config (temp file + swap, so Tor onions / RPC creds / proxy token survive) before rebuilding.

## #125 — a failed `compose up` stranded the stack, and re-apply silently no-opped
`apply` commits the rendered `.env`/Caddyfile/Tari **before** recreating containers. If `docker compose up` then failed, the stack kept running **old** containers against **new** config files — and because re-apply diffs the already-committed `.env`, it saw no change and printed *"No configuration changes detected"*, exiting 0 without retrying. The obvious recovery command was a no-op.

**Fix:** `apply` writes an *"apply incomplete"* marker, cleared **only after a successful `up`**. While present, re-apply re-attempts the recreate even with no config delta; on `up` failure it prints explicit recovery guidance (re-run `apply` / `up`) and exits non-zero with the marker intact.

## Tests
New black-box tests in `tests/stack/run.sh` (+10 assertions), **verified to fail when the fixes are reverted** (4 behavioral guards):
- `upgrade` re-renders a previously-missing var, preserves the proxy token, still rebuilds.
- A failed `compose up` (scripted docker stub) → recovery guidance + marker left + rc 1; the follow-up `apply` retries to success (not a no-op) and clears the marker.

`make test-stack` → **138 passed, 0 failed**; shellcheck clean; inventory regenerated.

## Docs
`docs/operations.md` upgrade description updated; CHANGELOG `Fixed` entries; `.gitignore` the marker.

Closes #125
Closes #128