### PR TITLE
fix(pithead): warn on relocated/missing data dirs instead of silently re-syncing (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,9 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Fixed
 
+- `pithead up` and `pithead doctor` now warn when a data directory named in `.env` doesn't exist —
+  the tell-tale of a relocated/copied install or a second checkout, which would otherwise silently
+  start a fresh sync and orphan the dashboard history (data dirs are absolute paths in `.env`) (#126).
 - `pithead upgrade` now re-renders the generated config (`.env`, Caddyfile, Tari config) before
   rebuilding, so a release that changes a config template, restructures the Caddyfile, or adds an
   `.env` var takes effect — `upgrade` was previously just `up --build`, running new images against

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -77,6 +77,12 @@ changes a config template or adds an `.env` var takes effect, not just the new i
 directories and `config.json` are untouched, so your blockchain sync and settings are preserved
 across upgrades.
 
+> **Moving the install?** Data directories are stored as absolute paths in `.env`, so relocating or
+> copying the stack to a different path (or running a second checkout) points it at a *different,
+> empty* `data/` — a full re-sync, and the dashboard history is orphaned. If you move the install,
+> move its `data/` with it, or set absolute `data_dir` paths in `config.json` and run `./pithead
+> apply`. `pithead up` and `pithead doctor` now warn when a data directory named in `.env` is missing.
+
 ---
 
 ## Backups

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 418 dashboard unit tests · 12 contract tests · 25 frontend
-tests · 25 `pithead` shell sections · 15 harness self-test sections ·
+tests · 26 `pithead` shell sections · 15 harness self-test sections ·
 8 live config scenarios (15 axis values) · 6 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 25 `pithead` shell sections · 15 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 418 |
 | 1 — Unit | frontend (node --test) | 25 |
-| 1 — Unit | `pithead` shell suite | 25 sections |
+| 1 — Unit | `pithead` shell suite | 26 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 6 |
@@ -518,7 +518,7 @@ tests · 25 `pithead` shell sections · 15 harness self-test sections ·
 - heroKpis: mode colour follows the server mode_variant token
 - heroKpis: total is accent-coloured; blocks and tier carry no colour class
 
-### `pithead` shell suite (tests/stack/run.sh) — 25 sections
+### `pithead` shell suite (tests/stack/run.sh) — 26 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_ipv4
@@ -540,6 +540,7 @@ tests · 25 `pithead` shell sections · 15 harness self-test sections ·
 - black-box: local node creds auto-generated + persisted (#50)
 - black-box: upgrade re-renders generated config (#128)
 - black-box: apply recovers from a failed 'compose up' (#125)
+- black-box: up warns about missing (relocated) data dirs (#126)
 - black-box: status health check
 - black-box: doctor exit code (#127)
 - black-box: reset-dashboard targets .env dirs, not config.json (#139)
@@ -671,5 +672,5 @@ tests · 25 `pithead` shell sections · 15 harness self-test sections ·
 
 ---
 
-_Grand total: **509** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **510** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/pithead
+++ b/pithead
@@ -102,6 +102,7 @@ migrate_compose_project() {
 
 stack_up() {
     log "Starting stack..."
+    warn_missing_data_dirs
     migrate_compose_project
     # Docker Compose automatically picks up COMPOSE_PROFILES from .env
     docker compose up -d
@@ -392,6 +393,18 @@ doctor() {
     fi
     check_disk_grouped doctor "$doctor_prune" \
         "$mono_dir" "$tari_dir" "$p2pool_dir" "$dash_dir" "$tor_dir"
+
+    # Data dirs named in .env that don't exist => a relocated/copied install (or a second checkout)
+    # will re-sync from scratch and orphan the dashboard history (#126).
+    local _stale _l
+    _stale=$(missing_data_dirs)
+    if [ -n "$_stale" ]; then
+        while IFS= read -r _l; do
+            dr_warn "Data dir from .env not found: ${_l%%=*}=${_l#*=} — a relocated/copied install re-syncs from scratch. Move the data here, or set the data_dir in config.json and run 'apply'."
+        done <<< "$_stale"
+    elif [ "$(env_get DEPLOYMENT_COMPLETED 2>/dev/null)" = "true" ]; then
+        dr_ok "Data directories named in .env are present."
+    fi
 
     # --- .env / deployment state ---
     echo ""
@@ -1223,6 +1236,31 @@ prepare_directories() {
     sudo chown -R "$REAL_USER":"$REAL_USER" "$MONERO_DIR" "$TARI_DIR" "$P2POOL_DIR"
     mkdir -p "$P2POOL_DIR/stats"
     sudo chmod -R 755 "$P2POOL_DIR/stats"
+}
+
+# List "*_DATA_DIR=path" lines from .env whose directory is MISSING — the signature of a relocated
+# or copied install, or a second checkout, where the stack would silently start a FRESH sync and
+# orphan the dashboard SQLite history (#126). Data dirs are stored as absolute paths in .env, so a
+# moved install leaves .env naming the old path; Docker then auto-creates an empty dir and re-syncs.
+# Empty unless the stack has been deployed (on first setup the dirs legitimately don't exist yet).
+missing_data_dirs() {
+    [ "$(env_get DEPLOYMENT_COMPLETED 2>/dev/null)" = "true" ] || return 0
+    local var dir
+    for var in MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR DASHBOARD_DATA_DIR TOR_DATA_DIR; do
+        dir=$(env_get "$var" 2>/dev/null)
+        [ -n "$dir" ] && [ ! -d "$dir" ] && printf '%s=%s\n' "$var" "$dir"
+    done
+    return 0
+}
+
+# Loud warning (on `up`) when .env names data dirs that don't exist — see missing_data_dirs (#126).
+warn_missing_data_dirs() {
+    local stale line; stale=$(missing_data_dirs)
+    [ -n "$stale" ] || return 0
+    warn "Data directories named in .env are MISSING — did you relocate, copy, or run a different checkout of this install?"
+    while IFS= read -r line; do warn "  ${line%%=*} → ${line#*=} (not found)"; done <<< "$stale"
+    warn "The stack will start a FRESH sync and the dashboard history will be orphaned. To keep your synced chains,"
+    warn "move the data to these paths, or set the data_dir(s) in config.json (absolute) and run './pithead apply'."
 }
 
 # Lightweight directory check for `apply`: create any missing data dir and chown only the

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -451,6 +451,42 @@ assert_rc "re-apply retries and succeeds (rc 0)"          "$rc" "0"
 assert_contains "re-apply re-attempts the recreate"      "$out" "retrying"
 if [ -f "$A/.env.apply-incomplete" ]; then mk=present; else mk=absent; fi; assert_eq "marker cleared after a successful retry" "$mk" "absent"
 
+echo "== black-box: up warns about missing (relocated) data dirs (#126) =="
+RL="$SANDBOX/reloc"; mkdir -p "$RL/bin"; cp "$STACK" "$RL/pithead"; make_stubs "$RL/bin"
+# Deployed, but .env names data dirs that don't exist — as if the install was moved/copied or a
+# second checkout is being run. The stack would silently re-sync; `up` must warn first.
+cat > "$RL/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+HOST_IP=box.lan
+MONERO_DATA_DIR=/no/such/data/monero
+TARI_DATA_DIR=/no/such/data/tari
+P2POOL_DATA_DIR=/no/such/data/p2pool
+DASHBOARD_DATA_DIR=/no/such/data/dashboard
+TOR_DATA_DIR=/no/such/data/tor
+EOF
+out="$(cd "$RL" && PATH="$RL/bin:$PATH" ./pithead up 2>&1)"; rc=$?
+assert_rc "up still starts (rc 0)"               "$rc" "0"
+assert_contains "up warns about a fresh re-sync" "$out" "start a FRESH sync"
+assert_contains "up names the missing monero dir" "$out" "MONERO_DATA_DIR → /no/such/data/monero"
+# A healthy deployment (dirs present) must NOT warn.
+mkdir -p "$RL/d/monero" "$RL/d/tari" "$RL/d/p2pool" "$RL/d/dashboard" "$RL/d/tor"
+cat > "$RL/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+HOST_IP=box.lan
+MONERO_DATA_DIR=$RL/d/monero
+TARI_DATA_DIR=$RL/d/tari
+P2POOL_DATA_DIR=$RL/d/p2pool
+DASHBOARD_DATA_DIR=$RL/d/dashboard
+TOR_DATA_DIR=$RL/d/tor
+EOF
+out="$(cd "$RL" && PATH="$RL/bin:$PATH" ./pithead up 2>&1)"
+case "$out" in *"FRESH sync"*) bad "no false warning when data dirs exist" "got: $out" ;; *) ok "no false warning when data dirs exist" ;; esac
+# Gating: before the first deploy (no DEPLOYMENT_COMPLETED) the dirs are legitimately absent -> silent.
+printf 'MONERO_DATA_DIR=/no/such/monero\n' > "$RL/.env"
+assert_eq "missing_data_dirs silent before first deploy" "$(run_sourced "$RL" missing_data_dirs)" ""
+
 echo "== black-box: status health check =="
 # A docker stub driven by FAKE_STATES ("svc=state:health ..."; state "missing" = no container)
 # so we can script each service's state and assert how `status` reports it.


### PR DESCRIPTION
## Problem (#126)
Data directories default to `$PWD/data/...` and are written as **absolute** paths into `.env`. Relocating or copying the install to a different path — or running a **second checkout** — points the stack at a *different, empty* `data/`, so it silently starts a **full re-sync** and orphans the dashboard SQLite history (which doesn't re-sync). Nothing warned.

## Fix
Took the issue's **warn** option (not the riskier relative-path rewrite, which would touch `rm -rf`/`chown -R`-sensitive paths):
- `missing_data_dirs()` lists any `*_DATA_DIR` named in `.env` whose directory doesn't exist — gated on `DEPLOYMENT_COMPLETED=true`, so a legitimate first run (dirs not created yet) stays quiet.
- **`pithead up`** warns loudly before starting (what's missing + how to keep your chains).
- **`pithead doctor`** flags it as a `dr_warn`.

## Tests
`tests/stack/run.sh` (+5 assertions, **verified to fail when the fix is reverted**): a relocated deployment makes `up` warn and name the missing dir; a healthy deployment does **not** warn; `missing_data_dirs` is silent before the first deploy. `make test-stack` → **143 passed, 0 failed**; shellcheck clean.

## Docs
`docs/operations.md` gains a "Moving the install?" note; CHANGELOG `Fixed` entry.

Closes #126