### PR TITLE
fix(node-config): close clearnet DNS leaks in monerod + Tari (#161, #162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,8 +184,13 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   Tor-node anonymity hygiene (`pad-transactions`, `hide-my-port`). **Tari** disables DNS seeds
   (`dns_seeds = []`, bootstrapping from onion `peer_seeds` over Tor), prunes the clearnet
   `/ip4//ip6/` peer seeds, corrects a comment that implied DNS-over-TLS (it was plaintext UDP/53),
-  and drops the inert `check_for_updates` gRPC method. *(Tari's ~120 s `checkpoints.tari.com` Pulse
-  lookup is the remaining leak — it needs the #160 decision-4 DNS sinkhole, tracked separately.)*
+  and drops the inert `check_for_updates` gRPC method. The last clearnet DNS path — the Tari Pulse
+  service's ~120 s `checkpoints.tari.com` TXT lookup (an advisory deep-reorg check with no in-binary
+  off-switch) — is closed by pointing the container's resolver at a dead local address (`dns:
+  127.0.0.1`); the lookup fails without a packet leaving the host and Tari tolerates it (returns
+  "passed", verified in `tari_pulse_service`), so zero clearnet DNS and no functional impact. The
+  container already overrode Docker's `127.0.0.11`, so no service discovery is broken. Trade-off:
+  loses the Pulse deep-reorg advisory, the same class as monerod's `disable-dns-checkpoints`.
 - The dashboard's XvB stats fetch (`xmrvsbeast.com`, with the wallet as a query param) now routes
   over **Tor** (`socks5h`, so the hostname resolves via Tor too) instead of clearnet from the
   host-networked container — closing a real-IP ↔ wallet correlation leak. It's also gated behind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,15 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Security
 
+- Closed clearnet DNS leaks in the node configs (#161, #162). **monerod** drops its priority-node
+  HOSTNAMES (resolved by the local resolver *before* `--proxy`), disables DNS checkpoints
+  (`disable-dns-checkpoints`, since removing `enforce-dns-checkpointing` alone doesn't stop the
+  `checkpoints.moneropulse.*` lookups) and the update check (`check-updates=disabled`), and adds
+  Tor-node anonymity hygiene (`pad-transactions`, `hide-my-port`). **Tari** disables DNS seeds
+  (`dns_seeds = []`, bootstrapping from onion `peer_seeds` over Tor), prunes the clearnet
+  `/ip4//ip6/` peer seeds, corrects a comment that implied DNS-over-TLS (it was plaintext UDP/53),
+  and drops the inert `check_for_updates` gRPC method. *(Tari's ~120 s `checkpoints.tari.com` Pulse
+  lookup is the remaining leak — it needs the #160 decision-4 DNS sinkhole, tracked separately.)*
 - The dashboard's XvB stats fetch (`xmrvsbeast.com`, with the wallet as a query param) now routes
   over **Tor** (`socks5h`, so the hostname resolves via Tor too) instead of clearnet from the
   host-networked container — closing a real-IP ↔ wallet correlation leak. It's also gated behind

--- a/build/monero/bitmonero.conf.template
+++ b/build/monero/bitmonero.conf.template
@@ -35,13 +35,22 @@ in-peers=64
 # verification on multi-core hosts while leaving headroom for the system and p2pool.
 prep-blocks-threads=${MONERO_PREP_THREADS}
 
-# Priority Nodes (High uptime public nodes for faster initial sync)
-add-priority-node=p2pmd.xmrvsbeast.com:18080
-add-priority-node=nodes.hashvault.pro:18080
+# Priority-node HOSTNAMES were resolved by the local resolver BEFORE --proxy, leaking a clearnet
+# DNS lookup tied to this host's IP (#161). Dropped — monerod still bootstraps from its compiled-in
+# IP seed nodes, dialed over Tor. Re-add only as IP:port or .onion if you want specific peers.
 
-# Checkpointing & DNS Security
-enforce-dns-checkpointing=true
-enable-dns-blocklist=true
+# Privacy: close the remaining clearnet DNS paths (#161).
+# - disable-dns-checkpoints: stops the hourly checkpoints.moneropulse.* TXT lookups (removing
+#   `enforce-dns-checkpointing` alone does NOT). Trades MoneroPulse deep-reorg defense for zero
+#   DNS; the compiled-in checkpoints still apply — acceptable for a Tor node.
+# - check-updates=disabled: the default `notify` does an updates.moneropulse.* TXT lookup.
+# - enable-dns-blocklist=0: the DNS blocklist (already auto-disabled by --proxy) made explicit.
+disable-dns-checkpoints=1
+check-updates=disabled
+enable-dns-blocklist=0
+# Anonymity hygiene for a Tor-only node.
+pad-transactions=1
+hide-my-port=1
 
 # --- RPC Security ---
 # Restrict RPC access and enforce authentication

--- a/build/tari/config.toml.template
+++ b/build/tari/config.toml.template
@@ -6,12 +6,10 @@
 base_path = "/var/tari/node"
 
 [p2p.seeds]
-# Resolve DNS seeds over DNS-over-TLS (port 853). The seeds.tari.com TXT answer is 15
-# records (~1KB), which overflows a 512-byte UDP packet; Docker's embedded resolver
-# (127.0.0.11) has no EDNS0 and truncates it ("received truncated response"), and Tari's
-# resolver doesn't retry over TCP. DoT is TCP-based (no truncation) and encrypted. Mirrors
-# the Tari upstream default. If port 853 is filtered on your host, fall back to "1.1.1.1:53"
-# (plain UDP, but Cloudflare honours EDNS0 so the full answer still fits).
+# DNS seeds are DISABLED for privacy (dns_seeds = [] below), so the node does ZERO seed DNS and
+# bootstraps purely from the onion peer_seeds over Tor (#162). The name servers below are now inert,
+# kept only for reference. NOTE: despite the ":853/host" form, this was never DNS-over-TLS — with
+# dns_seeds_use_dnssec = false the suffix is dropped and Tari queries plaintext UDP/53.
 dns_seed_name_servers = [
     "1.1.1.1:853/cloudflare-dns.com",
     "8.8.8.8:853/dns.google",
@@ -20,26 +18,14 @@ dns_seed_name_servers = [
 dns_seeds_use_dnssec = false
 
 [mainnet.p2p.seeds]
-# DNS seeds: the v5.3.1 binary defaults to `seeds.mainnet.tari.com` (+ ip4./ip6./tor.
-# variants), but those hostnames have NO DNS records — mainnet's live seed list is
-# published at the bare `seeds.tari.com`. Without this override the node logs
-# "DNS seed ... failed to resolve" on every start and falls back to peer_seeds only.
-dns_seeds = ["seeds.tari.com"]
+# No DNS seeds: a seeds.tari.com TXT lookup leaks a clearnet DNS query from this host's IP (#162).
+# Bootstrap from the onion peer_seeds below instead (refresh them periodically as seeds rotate).
+dns_seeds = []
 
-# Hardcoded peer seeds (bootstrap fallback). Mirror of the live `seeds.tari.com` TXT
-# records — re-sync periodically as seeds rotate.
+# Hardcoded ONION peer seeds (bootstrap over Tor). The clearnet /ip4//ip6/ variants are inert under
+# `transport = tor` and were dropped for a strict no-clearnet audit (#162) — onion-only.
 # Source of truth: `dig TXT seeds.tari.com`. Last synced 2026-05-30 (minotari_node v5.3.1).
 peer_seeds = [
-    "94a4b29148621479b1c1dffb1a2f5680dcf2c0cfb901152e245d6ec299821f61::/ip4/91.134.83.67/tcp/18189",
-    "1069fb56a3aaba45b9aa9839714251a4dfeb850e8d79d6ac9ca180377120fe1c::/ip4/51.75.116.227/tcp/18189",
-    "7c8e6530294e8bb7ff45b0f39e8bf8ea4e461b3df15a2df1ba3fa3a9bcc9ef71::/ip4/15.235.224.202/tcp/18189",
-    "54e491e0d88633170a98898f5d89ccc6b4f7ec22252afc23fe645d5bab453734::/ip4/198.244.203.249/tcp/18189",
-    "94b0e12289ed6a39c898d13048026a0b5ab939bd52544574d61da88f3deb5c70::/ip4/147.135.213.176/tcp/18189",
-    "54e491e0d88633170a98898f5d89ccc6b4f7ec22252afc23fe645d5bab453734::/ip6/2001:41d0:803:f900::/tcp/18189",
-    "94a4b29148621479b1c1dffb1a2f5680dcf2c0cfb901152e245d6ec299821f61::/ip6/2001:41d0:40d:4300::/tcp/18189",
-    "1069fb56a3aaba45b9aa9839714251a4dfeb850e8d79d6ac9ca180377120fe1c::/ip6/2001:41d0:303:83e3::1/tcp/18189",
-    "7c8e6530294e8bb7ff45b0f39e8bf8ea4e461b3df15a2df1ba3fa3a9bcc9ef71::/ip6/2402:1f00:8005:ca00::/tcp/18189",
-    "94b0e12289ed6a39c898d13048026a0b5ab939bd52544574d61da88f3deb5c70::/ip6/2001:41d0:303:6fb0::1/tcp/18189",
     "1069fb56a3aaba45b9aa9839714251a4dfeb850e8d79d6ac9ca180377120fe1c::/onion3/urvwskrhqa52km46xt2oevblebmylleglph6dythhndmctwdzl6cuoqd:18141",
     "54e491e0d88633170a98898f5d89ccc6b4f7ec22252afc23fe645d5bab453734::/onion3/b5zgqd6emm6p2zmj7gdniysbxvmtvltrwshsyfxjoq26xqfjoicge5id:18141",
     "7c8e6530294e8bb7ff45b0f39e8bf8ea4e461b3df15a2df1ba3fa3a9bcc9ef71::/onion3/5husjyv2zskwjh2wzbuirbq4gk5uiyx4gnn277r3yoxv4oucn72tmeyd:18141",
@@ -58,7 +44,6 @@ grpc_address = "/ip4/0.0.0.0/tcp/18142"
 # Allowed gRPC methods for interaction with the dashboard and miner
 grpc_server_allow_methods = [
     "get_version",
-    "check_for_updates",
     "get_sync_info",
     "get_sync_progress",
     "get_tip_info",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,12 +91,16 @@ services:
     # value for a 16 GB host with HugePages on, until the next `pithead apply`).
     mem_limit: ${TARI_MEM_LIMIT:-7680m}
     memswap_limit: ${TARI_MEM_LIMIT:-7680m}
+    # Tari needs NO clearnet DNS: dns_seeds = [] (config.toml), onion peer_seeds resolve via Tor, and
+    # the Tor SOCKS is reached by IP (this container already overrode Docker's 127.0.0.11, so nothing
+    # here depends on service discovery). The one OS-resolver lookup left is the Tari Pulse service's
+    # checkpoints.tari.com TXT (~every 120 s) — an ADVISORY deep-reorg check, no in-binary off-switch,
+    # that TOLERATES a DNS failure (returns "passed", verified in tari_pulse_service/mod.rs). Point the
+    # resolver at a dead local address so that lookup fails WITHOUT a packet leaving the host — zero
+    # clearnet DNS, no functional impact (#162; #160 decision-4). Trade-off: lose the Pulse deep-reorg
+    # advisory, the same class as monerod's disable-dns-checkpoints (#161).
     dns:
-      - 1.1.1.1
-      - 8.8.8.8
-    dns_search: .
-    dns_opt:
-      - use-vc
+      - 127.0.0.1
     environment:
       - WAIT_FOR_TOR=1
     volumes:

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 430 dashboard unit tests · 12 contract tests · 25 frontend
-tests · 26 `pithead` shell sections · 15 harness self-test sections ·
+tests · 27 `pithead` shell sections · 15 harness self-test sections ·
 8 live config scenarios (15 axis values) · 6 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 26 `pithead` shell sections · 15 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 430 |
 | 1 — Unit | frontend (node --test) | 25 |
-| 1 — Unit | `pithead` shell suite | 26 sections |
+| 1 — Unit | `pithead` shell suite | 27 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 6 |
@@ -530,7 +530,7 @@ tests · 26 `pithead` shell sections · 15 harness self-test sections ·
 - heroKpis: mode colour follows the server mode_variant token
 - heroKpis: total is accent-coloured; blocks and tier carry no colour class
 
-### `pithead` shell suite (tests/stack/run.sh) — 26 sections
+### `pithead` shell suite (tests/stack/run.sh) — 27 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_ipv4
@@ -545,6 +545,7 @@ tests · 26 `pithead` shell sections · 15 harness self-test sections ·
 - unit: grub heal + boot-param insert (#176)
 - unit: disk_component_gib
 - unit: check_disk_grouped (mocked df)
+- node configs: no clearnet DNS egress (#161 monerod, #162 tari)
 - black-box: CLI dispatch
 - black-box: guards
 - black-box: config validation
@@ -684,5 +685,5 @@ tests · 26 `pithead` shell sections · 15 harness self-test sections ·
 
 ---
 
-_Grand total: **522** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **523** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -291,6 +291,16 @@ case "$(grep -E 'check_for_updates' "$TARC" || true)" in
     "") ok "tari: check_for_updates dropped from gRPC allow-list (#162)" ;;
     *)  bad "tari: check_for_updates dropped from gRPC allow-list (#162)" "still present" ;;
 esac
+# The Pulse (checkpoints.tari.com TXT, ~120s) is the last clearnet DNS path: the tari container's
+# resolver is pointed at a dead local address so the lookup fails without a packet leaving the host
+# (Tari tolerates it — returns "passed"). The container already overrode Docker's 127.0.0.11, so no
+# service-discovery dependency is broken. Assert no clearnet resolvers remain on the tari service.
+TARI_SVC="$(awk '/^  tari:/{f=1;print;next} f&&/^  [a-z]/{f=0} f' "$ROOT/docker-compose.yml")"
+case "$TARI_SVC" in
+    *1.1.1.1*|*8.8.8.8*) bad "tari: clearnet DNS resolvers removed from compose (#162)" "1.1.1.1/8.8.8.8 present" ;;
+    *)                   ok "tari: clearnet DNS resolvers removed from compose (#162)" ;;
+esac
+assert_contains "tari: resolver pointed at dead local sinkhole (#162)" "$TARI_SVC" "127.0.0.1"
 
 # ---------------------------------------------------------------------------
 echo "== black-box: CLI dispatch =="

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -267,6 +267,31 @@ PATH="$DISK/bin:$PATH" DF_MAP="$fresh_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G
   _ "$STACK" "$DM" >/dev/null 2>&1
 assert_rc "check_disk_grouped survives not-yet-created data dirs under set -e (#179)" "$?" "0"
 
+echo "== node configs: no clearnet DNS egress (#161 monerod, #162 tari) =="
+MONC="$ROOT/build/monero/bitmonero.conf.template"
+TARC="$ROOT/build/tari/config.toml.template"
+# monerod (#161): hostname priority-nodes dropped; DNS checkpoints + update check off.
+case "$(cat "$MONC")" in
+    *xmrvsbeast.com:18080*|*nodes.hashvault.pro*) bad "monerod: priority-node hostnames dropped (#161)" "still present" ;;
+    *) ok "monerod: priority-node hostnames dropped (#161)" ;;
+esac
+case "$(grep -E '^enforce-dns-checkpointing' "$MONC" || true)" in
+    "") ok "monerod: enforce-dns-checkpointing removed (#161)" ;;
+    *)  bad "monerod: enforce-dns-checkpointing removed (#161)" "still present" ;;
+esac
+assert_contains "monerod: DNS checkpoints disabled (#161)" "$(cat "$MONC")" "disable-dns-checkpoints=1"
+assert_contains "monerod: update check disabled (#161)"    "$(cat "$MONC")" "check-updates=disabled"
+# tari (#162): no DNS seeds; peer_seeds onion-only; the inert check_for_updates gRPC method dropped.
+assert_contains "tari: DNS seeds disabled (#162)" "$(cat "$TARC")" "dns_seeds = []"
+case "$(grep -E '::/ip4/|::/ip6/' "$TARC" || true)" in
+    "") ok "tari: peer_seeds are onion-only (#162)" ;;
+    *)  bad "tari: peer_seeds are onion-only (#162)" "clearnet /ip4//ip6/ peer seeds present" ;;
+esac
+case "$(grep -E 'check_for_updates' "$TARC" || true)" in
+    "") ok "tari: check_for_updates dropped from gRPC allow-list (#162)" ;;
+    *)  bad "tari: check_for_updates dropped from gRPC allow-list (#162)" "still present" ;;
+esac
+
 # ---------------------------------------------------------------------------
 echo "== black-box: CLI dispatch =="
 "$STACK" help >/dev/null 2>&1; assert_rc "help exits 0" "$?" "0"


### PR DESCRIPTION
The DNS-leak pair from the privacy-egress epic #160. monerod and Tari route P2P/tx over Tor, but several paths still did **clearnet DNS** from the host IP. With this PR, **both nodes do zero clearnet DNS.**

## monerod (#161 — `bitmonero.conf.template`)
- **Dropped the priority-node HOSTNAMES** (`p2pmd.xmrvsbeast.com`, `nodes.hashvault.pro`) — resolved by the local resolver *before* `--proxy`, leaking a DNS lookup tied to the host IP. Compiled-in IP seed nodes still bootstrap over Tor.
- `disable-dns-checkpoints=1` (removing `enforce-dns-checkpointing` alone does **not** stop the hourly `checkpoints.moneropulse.*` TXT lookups), `check-updates=disabled` (kills the `updates.moneropulse.*` lookup), `enable-dns-blocklist=0`.
- Anonymity hygiene: `pad-transactions=1`, `hide-my-port=1`.

## Tari (#162 — `config.toml.template` + `docker-compose.yml`)
- `dns_seeds = []` — no `seeds.tari.com` TXT lookup; bootstrap from the **onion** `peer_seeds` over Tor.
- Pruned `peer_seeds` to `/onion3/`-only (clearnet `/ip4//ip6/` are inert under `transport = tor`).
- Corrected a misleading comment (it implied DNS-over-TLS on `:853`; with `dns_seeds_use_dnssec=false` it was plaintext UDP/53).
- Dropped the inert `check_for_updates` gRPC method (coordinates with #91's allow-list).
- **Closed the last clearnet DNS path — the Tari Pulse service** (`checkpoints.tari.com` TXT, ~every 120 s). It has **no in-binary off-switch**, so the container's resolver is pointed at a **dead local address** (`dns: 127.0.0.1`): the lookup fails without a packet leaving the host, and Tari **tolerates the failure** — `tari_pulse_service` returns `Ok(true)` ("passed") on a DNS error/timeout, so sync, mining, and gRPC are unaffected. The container already overrode Docker's `127.0.0.11`, so no service discovery breaks.

### Why a black-hole and not a `*.tari.com` sinkhole sidecar
The Tari base node needs **no** clearnet DNS at all (`dns_seeds=[]`, onion seeds via Tor, Tor SOCKS by IP), and it doesn't use Docker service discovery (its `dns:` already overrode `127.0.0.11`). So a dead-address resolver is the simplest correct fix — **zero DNS egress, no new container** — versus a coredns/dnsmasq sidecar that would NXDOMAIN `*.tari.com` but still forward (and potentially leak) everything else. Verified upstream that Pulse is **advisory** (a deep-reorg heads-up) and degrades cleanly.

**Trade-off:** we lose the Pulse deep-reorg advisory — the exact same class of trade as monerod's `disable-dns-checkpoints`. Acceptable for a privacy-first Tor node.

## Tests
`tests/stack/run.sh` asserts the leaks are gone — no priority-node hostnames / DNS checkpoints / update-check in monerod; `dns_seeds = []` + onion-only `peer_seeds` + no `check_for_updates` + **no clearnet DNS resolvers on the tari service** in Tari. **152 pithead tests passing**, shellcheck clean, `test-compose` config + hardening invariants pass. The full Tari TOML render + live sync-while-hidden is validated by the integration matrix.

Closes #161
Closes #162