### PR TITLE
feat(setup): warn when the host has a public IP — unauthenticated stratum :3333 (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- `pithead setup` and `doctor` now **warn when the host has a public IP** and stratum `:3333` is
+  bound to all interfaces (#113). The stratum port is plain, unauthenticated stratum and must never
+  face the public internet: a NAT'd home host has no public IP on its interfaces and stays silent,
+  while a VPS/cloud or publicly-addressed host gets a clear nudge to firewall `:3333` to the LAN or
+  narrow `p2pool.stratum_bind` (it also stays quiet if the bind is already narrowed). Warn-only,
+  never fatal; `doctor` prints a ✓ when not exposed. A pure, unit-tested `is_public_ip` classifier
+  handles the RFC1918 / CGNAT / ULA / link-local / loopback exclusions (IPv4 + IPv6).
 - A four-tier test strategy for simulating every runtime situation (#54), documented in
   `docs/testing-strategy.md` with a full scenario catalog:
   - **Live config-matrix suite** (`tests/integration/`, tier 4) that drives a real, synced

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 432 dashboard unit tests · 12 contract tests · 25 frontend
-tests · 27 `pithead` shell sections · 15 harness self-test sections ·
+tests · 28 `pithead` shell sections · 15 harness self-test sections ·
 8 live config scenarios (15 axis values) · 6 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 27 `pithead` shell sections · 15 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 432 |
 | 1 — Unit | frontend (node --test) | 25 |
-| 1 — Unit | `pithead` shell suite | 27 sections |
+| 1 — Unit | `pithead` shell suite | 28 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 6 |
@@ -532,9 +532,10 @@ tests · 27 `pithead` shell sections · 15 harness self-test sections ·
 - heroKpis: mode colour follows the server mode_variant token
 - heroKpis: total is accent-coloured; blocks and tier carry no colour class
 
-### `pithead` shell suite (tests/stack/run.sh) — 27 sections
+### `pithead` shell suite (tests/stack/run.sh) — 28 sections
 - unit: resolve_default
 - unit: assert_safe_dir
+- unit: is_public_ip classifier (#113)
 - unit: is_ipv4
 - unit: resolve_dashboard_host (dashboard.host 'auto' revert, 247c5a0)
 - unit: docker_boot_enabled (#137)
@@ -687,5 +688,5 @@ tests · 27 `pithead` shell sections · 15 harness self-test sections ·
 
 ---
 
-_Grand total: **525** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **526** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -60,6 +60,9 @@ it connects through a proxy). Any reasonably recent **XMRig (5.0+, which introdu
   there. Lock it down two ways, which complement each other: narrow the **bind address** with
   [`p2pool.stratum_bind`](configuration.md#configuration-reference), and/or restrict the **source
   range** with a host firewall.
+- **`pithead setup` and `doctor` flag this for you**: when the host has a public IP and stratum is
+  bound to all interfaces, they print a warning pointing back here. A NAT'd home host — no public IP
+  on its own interfaces — sees nothing, so this only nudges the hosts that are actually exposed.
 
 #### `p2pool.stratum_bind` — which interface to listen on
 

--- a/pithead
+++ b/pithead
@@ -368,6 +368,11 @@ doctor() {
         fi
     fi
 
+    # --- Network: public-IP exposure of the unauthenticated stratum port (#113) ---
+    echo ""
+    echo "Network:"
+    check_stratum_exposure doctor
+
     # --- Disk: free space per underlying filesystem ---
     echo ""
     echo "Disk:"
@@ -854,6 +859,77 @@ is_ipv4() {
     for o in "${BASH_REMATCH[@]:1}"; do
         [ "$o" -le 255 ] || return 1
     done
+    return 0
+}
+
+# True if $1 is a globally-routable (public) IP literal — i.e. NOT loopback/private/link-local/
+# CGNAT/ULA. Pure + testable (#113): the stratum port is unauthenticated, so setup/doctor warn when
+# the host is publicly addressable. IPv4 excluded ranges: 0/8, 10/8, 127/8, 169.254/16, 172.16/12,
+# 192.168/16, 100.64/10 (CGNAT). IPv6: only 2000::/3 (global unicast) is treated as public.
+is_public_ip() {
+    local addr="$1" a b h
+    case "$addr" in
+        *:*)  # IPv6 — public only within 2000::/3 (first hextet 0x2000-0x3fff).
+            h="${addr%%:*}"
+            case "$h" in ""|*[!0-9a-fA-F]*) return 1 ;; esac
+            h=$(( 16#$h ))
+            [ "$h" -ge 8192 ] && [ "$h" -le 16383 ]
+            ;;
+        *.*)  # IPv4 dotted-quad.
+            is_ipv4 "$addr" || return 1
+            IFS=. read -r a b _ _ <<<"$addr"
+            case "$a" in
+                0|10|127) return 1 ;;
+                169) [ "$b" = 254 ] && return 1 ;;
+                172) { [ "$b" -ge 16 ] && [ "$b" -le 31 ]; } && return 1 ;;
+                192) [ "$b" = 168 ] && return 1 ;;
+                100) { [ "$b" -ge 64 ] && [ "$b" -le 127 ]; } && return 1 ;;
+            esac
+            return 0
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+# Echo the host's globally-routable IP addresses, one per line (empty if none, or if `ip` is absent
+# — it's Linux-only). Parses `ip -o addr show`; used by check_stratum_exposure (#113).
+host_public_ips() {
+    command -v ip >/dev/null 2>&1 || return 0
+    local fam addr
+    while read -r _ _ fam addr _; do
+        case "$fam" in inet|inet6) ;; *) continue ;; esac
+        addr="${addr%%/*}"
+        if is_public_ip "$addr"; then printf '%s\n' "$addr"; fi
+    done < <(ip -o addr show 2>/dev/null)
+}
+
+# Non-fatal heads-up that the unauthenticated stratum port :3333 may face the public internet (#113):
+# warn only when the host has a public IP AND stratum listens on all interfaces (the default bind).
+# Home/NAT hosts (no public IP on an interface) and hosts that narrowed p2pool.stratum_bind stay
+# quiet in setup. $1 = "setup" (emit via warn, only on exposure) or "doctor" (emit OK/WARN/skip).
+check_stratum_exposure() {
+    local mode="$1" bind pub msg
+    bind="${STRATUM_BIND:-}"
+    if [ -z "$bind" ] && [ -f "${ENV_FILE:-.env}" ]; then bind="$(env_get STRATUM_BIND 2>/dev/null || true)"; fi
+    [ -n "$bind" ] || bind="0.0.0.0"
+
+    if ! command -v ip >/dev/null 2>&1; then
+        [ "$mode" = doctor ] && dr_info "Skipped public-IP exposure check (no 'ip' command; Linux-only)."
+        return 0
+    fi
+    case "$bind" in
+        0.0.0.0|"") ;;   # all interfaces — the exposed case
+        *) [ "$mode" = doctor ] && dr_ok "Stratum :3333 bound to $bind (not all interfaces) — not publicly exposed."
+           return 0 ;;
+    esac
+
+    pub="$(host_public_ips)"; pub="${pub//$'\n'/, }"
+    if [ -n "$pub" ]; then
+        msg="This host appears to have a public IP ($pub). The stratum port 3333 is unauthenticated — firewall it to your LAN, or set p2pool.stratum_bind to a LAN IP / 127.0.0.1. See docs/workers.md#firewall."
+        if [ "$mode" = doctor ]; then dr_warn "$msg"; else warn "$msg"; fi
+    else
+        [ "$mode" = doctor ] && dr_ok "No public IP on host interfaces — stratum :3333 isn't directly internet-exposed."
+    fi
     return 0
 }
 
@@ -1760,6 +1836,7 @@ setup() {
     ensure_config_exists
     parse_and_validate_config
     preflight_resources   # WARN-only: low disk/RAM heads-up before committing to a sync (#87)
+    check_stratum_exposure setup  # WARN-only: public-IP host => unauthenticated stratum :3333 exposed (#113)
     load_preserved_state
     resolve_dashboard_host "interactive"
     prepare_directories

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -63,6 +63,17 @@ run_sourced "$SANDBOX" assert_safe_dir "/home"   >/dev/null 2>&1; assert_rc "rej
 run_sourced "$SANDBOX" assert_safe_dir ""        >/dev/null 2>&1; assert_rc "rejects empty"    "$?" "1"
 run_sourced "$SANDBOX" assert_safe_dir "/srv/p2pool/data" >/dev/null 2>&1; assert_rc "allows real dir" "$?" "0"
 
+echo "== unit: is_public_ip classifier (#113) =="
+# Globally-routable -> rc 0 (public). Includes boundaries just OUTSIDE each excluded range.
+for ip in 8.8.8.8 1.1.1.1 172.15.0.1 172.32.0.1 100.128.0.1 169.1.1.1 2606:4700:4700::1111 2001:db8::1; do
+    run_sourced "$SANDBOX" is_public_ip "$ip" >/dev/null 2>&1; assert_rc "public: $ip" "$?" "0"
+done
+# Private / loopback / link-local / CGNAT / ULA / multicast / unspecified / garbage -> rc 1.
+for ip in 10.0.0.5 172.16.0.1 172.31.255.1 192.168.1.50 127.0.0.1 169.254.1.1 100.64.0.1 0.0.0.0 \
+          ::1 fe80::1 fc00::1 fd12:3456::1 ff02::1 999.1.1.1 not-an-ip ""; do
+    run_sourced "$SANDBOX" is_public_ip "$ip" >/dev/null 2>&1; assert_rc "non-public: ${ip:-<empty>}" "$?" "1"
+done
+
 echo "== unit: is_ipv4 =="
 run_sourced "$SANDBOX" is_ipv4 "0.0.0.0"      >/dev/null 2>&1; assert_rc "accepts 0.0.0.0"     "$?" "0"
 run_sourced "$SANDBOX" is_ipv4 "127.0.0.1"    >/dev/null 2>&1; assert_rc "accepts 127.0.0.1"   "$?" "0"


### PR DESCRIPTION
The "safe by default" follow-up to the `p2pool.stratum_bind` work (#90/PR #108). The stratum port is plain, **unauthenticated** stratum and must never face the public internet — and it's the remote-trigger gate for the SSRF in #122. Rather than change the default `0.0.0.0` bind (which works everywhere and survives IP changes), we **warn the minority of hosts that are actually exposed**.

## Why warn, not re-bind
- A **NAT'd home host** has no public IP on its interfaces — inbound `:3333` isn't routed, so `0.0.0.0` is already local-only. It stays **silent**.
- The genuine exposure is the **minority**: a directly-assigned public IP (VPS/cloud, some fiber, public IPv6 without an inbound firewall). Those get a clear nudge.
- Auto-picking "the LAN IP" was rejected upstream (multi-NIC ambiguity, breaks on DHCP/IP-change with `cannot assign requested address`, and a VPS often has *no* private IP to bind to). A warn-only check has none of those downsides.

## What's added
- **`is_public_ip`** — a pure, unit-tested classifier (mirrors the existing `is_ipv4` helper). IPv4 excludes `0/8, 10/8, 127/8, 169.254/16, 172.16/12, 192.168/16, 100.64/10` (CGNAT); IPv6 treats only `2000::/3` (global unicast) as public, so ULA/link-local/loopback are out.
- **`host_public_ips`** — parses `ip -o addr show` (Linux-only; no-ops elsewhere) and classifies each address.
- **`check_stratum_exposure <setup|doctor>`** — warns **only** when a public IP exists **and** stratum is bound to all interfaces. Stays quiet if `p2pool.stratum_bind` is already narrowed, or there's no public IP.
  - `setup`: warn-only, never fatal (mirrors the AVX2/HugePages/low-disk heads-ups).
  - `doctor`: a new **Network** section — `⚠` when exposed, `✓` when bound-narrowed or no public IP, `•` skip where `ip` is absent.

The warning message points at the two documented fixes:
> ⚠ This host appears to have a public IP (`<addr>`). The stratum port `3333` is unauthenticated — firewall it to your LAN, or set `p2pool.stratum_bind` to a LAN IP / `127.0.0.1`. See docs/workers.md#firewall.

## Tests
- **24 classifier cases** in `tests/stack/run.sh` incl. range boundaries (`172.15`/`172.32`, `100.128`, `169.1` → public; the excluded ranges, ULA/link-local/multicast/garbage → not).
- Verified end-to-end with a fake `ip` command: the warn fires on a public v4+v6 host, a narrowed bind suppresses it, and loopback/link-local/docker-bridge addresses are filtered out.
- **176 pithead tests**, shellcheck clean, full `make test` green, inventory regenerated.
- Docs: `workers.md#firewall` cross-reference + CHANGELOG.

Closes #113