### PR TITLE
docs(privacy): add docs/privacy.md egress reference + correct IP-exposure overclaims (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- **`docs/privacy.md`** — a single source-of-truth network-egress reference (#164, the v1.0 close-out
+  of the #160 privacy epic). It maps every off-box connection: whether it's Tor-routed, its default,
+  and how to harden it — runtime egress (monerod/Tari over Tor with their clearnet DNS leaks closed;
+  the XvB stats fetch now over Tor) plus the two clearnet yield paths still open in v1.0 (P2Pool
+  outbound peers #165, XvB donation mining #166 — both Tor-by-default in v1.1) and the one-time
+  build/install IP exposure. The absolute "your home IP isn't exposed" claims in the README,
+  architecture, and FAQ are corrected to the honest **Tor-first, not yet Tor-only** reality, and all
+  three cross-link the new guide.
 - `pithead setup` and `doctor` now **warn when the host has a public IP** and stratum `:3333` is
   bound to all interfaces (#113). The stratum port is plain, unauthenticated stratum and must never
   face the public internet: a NAT'd home host has no public IP on its interfaces and stays silent,

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ coffee gets cold**.
 
 ## ✨ Why this stack?
 
-- 🧅 **Private by default.** A built-in Tor daemon gives Monero, Tari, and P2Pool hidden-service
-  (onion) addresses. No public port forwarding, no exposing your home IP.
+- 🧅 **Tor-first networking.** A built-in Tor daemon gives Monero, Tari, and P2Pool hidden-service
+  (onion) addresses — **no public port forwarding**, and Monero/Tari run over Tor. A couple of
+  outbound yield paths still touch clearnet today; the [privacy guide](docs/privacy.md) maps every
+  connection and how to harden it.
 - ⛏️ **Monero + Tari, merge-mined.** Earn on both chains at once — Tari is mined alongside Monero
   through P2Pool with zero extra effort.
 - 🧠 **Smart yield optimization.** An algorithmic engine continuously splits your hashrate between
@@ -84,6 +86,7 @@ addresses, provisions Tor, tunes the kernel for RandomX, and offers to start the
 | **[The Dashboard](docs/dashboard.md)** | Sync Mode and a tour of the live operational view. |
 | **[Connecting Miners](docs/workers.md)** | Point any existing rig at the stack, or spin up a tuned miner with [RigForge](https://github.com/p2pool-starter-stack/rigforge). |
 | **[Architecture](docs/architecture.md)** | The nine services, the privacy model, and the algorithmic XvB switching engine. |
+| **[Privacy & Network Egress](docs/privacy.md)** | Every off-box connection — what's Tor-routed, what's clearnet today, and how to harden it. |
 | **[Operations & Maintenance](docs/operations.md)** | Full command reference, upgrades, backups, and troubleshooting. |
 
 Browse the full index at **[docs/](docs/README.md)**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ deeper on individual topics once you're up and running.
 | [The Dashboard](dashboard.md) | **Sync Mode**, the live operational view, and how to read every panel. |
 | [Connecting Miners](workers.md) | Pointing any existing rig at the stack, plus [RigForge](https://github.com/p2pool-starter-stack/rigforge) for setting up new miners. |
 | [Architecture](architecture.md) | The nine services, how they fit together, the privacy model, and the algorithmic XvB switching engine. |
+| [Privacy & Network Egress](privacy.md) | Every connection the stack makes off-box — what's Tor-routed, what's clearnet today, and how to harden each path. |
 | [Operations & Maintenance](operations.md) | The full `pithead` command reference, upgrades, backups, and troubleshooting. |
 | [Testing Strategy](testing-strategy.md) | The four test tiers (unit → contract → fake-daemon mini-stack → live matrix), the full scenario catalog, and which tier proves each situation. |
 | [Testing Guide](testing-guide.md) | For developers: how to write and run tests, per-change recipes, conventions, and real-hardware gotchas. |
@@ -31,4 +32,5 @@ deeper on individual topics once you're up and running.
 - **Will my machine handle it?** → [Hardware Requirements](hardware.md)
 - **Change a setting?** → [Configuration › Changing settings later](configuration.md#changing-settings-later)
 - **Already have a synced Monero node?** → [Configuration › Reusing an existing node](configuration.md#reusing-an-existing-node)
+- **Worried about your IP / what leaves the box?** → [Privacy & Network Egress](privacy.md)
 - **Something's not working?** → [Operations › Troubleshooting](operations.md#troubleshooting)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,11 +87,18 @@ node instead.
 
 ## Privacy by design
 
-Privacy isn't bolted on — it's the default. A dedicated Tor daemon provides hidden services
-(onion addresses) for Monero, Tari, and P2Pool, so the stack participates in each network without
-exposing your home IP and **without any public IPv4 port forwarding**. Monero broadcasts
-transactions over Tor, and the node's RPC is bound to localhost by default (opt into LAN access
-explicitly via `monero.rpc_lan_access`).
+Privacy is a primary design goal, not an afterthought — the stack is **Tor-first**. A dedicated Tor
+daemon provides hidden services (onion addresses) for Monero, Tari, and P2Pool, so **inbound**
+connectivity needs **no public IPv4 port forwarding**. Monero and Tari route their P2P and
+transaction traffic over Tor, and the clearnet DNS lookups those nodes used to leak are closed
+(monerod checkpoints/blocklist/update-check, Tari DNS seeds + Pulse). The node's RPC is bound to
+localhost by default (opt into LAN access explicitly via `monero.rpc_lan_access`).
+
+It is **Tor-first, not yet Tor-only.** Two *outbound* yield paths still use clearnet in v1.0 and so
+**can reveal your home IP** — P2Pool's outbound sidechain peers and XvB donation mining — both slated
+to move to Tor-by-default (with a documented opt-out) in v1.1, and both hardenable today. Install and
+image pulls also reveal your IP once. See **[Privacy & network egress](privacy.md)** for the complete
+connection-by-connection map and how to lock down the rest.
 
 ## Security posture
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ the underlying projects ([monerod](https://www.getmonero.org/), [P2Pool](https:/
 maintaining each piece and the wiring between them:
 
 - A Monero full node with restricted RPC, ZMQ, and Tor transaction broadcasting.
-- P2Pool pointed at that node, with onion connectivity so you're not exposing your home IP.
+- P2Pool pointed at that node, with an onion address for inbound peers.
 - Tari (Minotari) merge-mining alongside Monero.
 - Each rig configured for the pool, plus a plan for what happens when the node goes down.
 - Some way to actually *see* hashrate, sync progress, and your PPLNS window.
@@ -24,9 +24,10 @@ maintaining each piece and the wiring between them:
 Pithead automates that whole stack in one command and adds the parts that are tedious to build
 yourself:
 
-- **Tor by default.** A built-in Tor daemon gives Monero, Tari, and P2Pool hidden-service (onion)
-  addresses — no public port forwarding, and your home IP isn't exposed. See
-  [Architecture › Privacy by design](architecture.md#privacy-by-design).
+- **Tor-first networking.** A built-in Tor daemon gives Monero, Tari, and P2Pool hidden-service
+  (onion) addresses — no public port forwarding, and Monero/Tari traffic runs over Tor. A couple of
+  outbound yield paths still use clearnet today; see [Privacy & network egress](privacy.md) for the
+  full map and how to harden them.
 - **One endpoint for every rig.** All workers point at a single `xmrig-proxy` endpoint on `:3333`.
   There's nothing per-rig to configure — no wallet address, no pool URL juggling. See
   [Connecting Miners](workers.md).
@@ -66,10 +67,21 @@ yourself. Different tools for different goals.
 
 ### Is my home IP exposed?
 
-No. A built-in Tor daemon gives Monero, Tari, and P2Pool hidden-service (onion) addresses, so the
-stack participates in each network without exposing your home IP. Monero also broadcasts
-transactions over Tor, and the node's RPC is bound to localhost by default. See
-[Architecture › Privacy by design](architecture.md#privacy-by-design).
+**Mostly not — with two clearnet exceptions today, plus a one-time exposure at install.** A built-in
+Tor daemon gives Monero, Tari, and P2Pool hidden-service (onion) addresses, so **inbound** connections
+need no port forwarding and don't reveal your IP. Monero and Tari route P2P and transaction traffic
+over Tor, and their old clearnet DNS lookups are closed.
+
+What still touches clearnet (and so can reveal your IP):
+
+- **P2Pool's outbound sidechain peers** — clearnet today; Tor-by-default is planned for v1.1 (#165),
+  and you can route it through Tor now (see the privacy guide).
+- **XvB donation mining** — only if XvB is enabled; clearnet to `xmrvsbeast.com`. Disable XvB to stop
+  it, or wait for the v1.1 Tor routing (#166). (The XvB *stats* fetch is already Tor-routed.)
+- **Install / build** fetches code and container images from GitHub, getmonero.org, and the image
+  registries once — inherent and integrity-pinned, but it reveals your IP at that moment.
+
+See **[Privacy & network egress](privacy.md)** for every connection and how to harden each one.
 
 ### Do I need to port-forward?
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,130 @@
+# Privacy & network egress
+
+This is the single source of truth for **every connection the stack makes off your box** — where it
+goes, whether it's routed over Tor, whether it's on by default, and how to lock it down.
+
+**North-star:** nothing should leave the host to the internet except through Tor. Where that isn't
+possible (or trades away yield), the connection must be **off or Tor-routed by default**, have a
+**documented toggle**, and be **listed here**.
+
+Honesty first: the stack is **Tor-first, not yet Tor-only**. Monero and Tari — including the DNS
+lookups they used to leak — are fully Tor-routed. But as of v1.0 **two outbound yield paths still
+use clearnet** (P2Pool's outbound peers and XvB donation mining), and **install/build reveals your
+IP once**. Those are called out below with how to mitigate each today, and both clearnet yield paths
+are slated to move to Tor-by-default (with an opt-out) in v1.1.
+
+---
+
+## Inbound — no port forwarding
+
+Every service that accepts inbound connections does so through a **Tor hidden service (onion
+address)**: monerod, Tari, and P2Pool each get one from the built-in Tor daemon. So:
+
+- **No public IPv4 port forwarding is required**, and your IP is not advertised to inbound peers.
+- The **only** LAN-facing port is the stratum endpoint **`:3333`** that your own rigs connect to. It
+  is plain, **unauthenticated** stratum and must never face the internet — `pithead setup`/`doctor`
+  warn if your host has a public IP, and you can narrow it with `p2pool.stratum_bind` or a firewall.
+  See [Connecting miners › Firewall](workers.md#firewall).
+
+---
+
+## Runtime egress
+
+What the running stack sends to the internet, connection by connection.
+
+| Connection | Destination | What it could reveal | Tor? | Default | How to control |
+|---|---|---|---|---|---|
+| **monerod** P2P + tx broadcast | Monero network | — | ✅ Tor (`proxy=` / `tx-proxy=`) | on | always Tor |
+| **monerod** DNS (checkpoints, blocklist, update check, priority-node hostnames) | DNS resolvers | "this IP runs Monero" | ✅ **closed** — `disable-dns-checkpoints`, `check-updates=disabled`, `enable-dns-blocklist=0`, hostname priority-nodes dropped (#161) | n/a | — |
+| **Tari** P2P | Tari network | — | ✅ Tor (`transport = "tor"`) | on | always Tor |
+| **Tari** DNS seeds + Pulse (`seeds.tari.com`, `checkpoints.tari.com`) | DNS resolvers | "this IP runs Tari" | ✅ **closed** — `dns_seeds = []`, onion `peer_seeds`, resolver pointed at a dead address (#162) | n/a | — |
+| **P2Pool** inbound peers | reach you via onion | — | ✅ onion hidden service | on | — |
+| **P2Pool** outbound sidechain peers | clearnet P2Pool peers | **your real home IP** | ❌ **clearnet** | **on** | ⏳ Tor-by-default in v1.1 (#165). Harden now → [below](#hardening-the-clearnet-paths) |
+| Dashboard **XvB stats** fetch | `xmrvsbeast.com` | your Monero **wallet** (no longer your IP) | ✅ Tor (`socks5h`, #163) | on, only if XvB enabled | `XVB_ENABLED=false` stops it |
+| **XvB donation mining** (only while donating) | `na.xmrvsbeast.com:4247` | **your real home IP** | ❌ **clearnet** | on while donating | ⏳ Tor-by-default in v1.1 (#166). Disable XvB to stop it |
+| **Caddy** TLS (dashboard HTTPS) | local only | — | n/a — `tls internal`, **no ACME / no external CA** | on | clean (no egress) |
+| **Telegram** alerts (#121) | Telegram API | your IP | ❌ | **off** | opt-in only |
+| **Healthchecks** pings (#79) | external | your IP | ❌ | **off** | opt-in only |
+
+`socks5h` (used for the XvB stats fetch) routes **DNS resolution through Tor too**, so the hostname
+isn't resolved on the clearnet either. The host-networked dashboard reaches the bridge's Tor SOCKS
+at `172.28.0.25:9050`.
+
+---
+
+## Build / setup-time egress
+
+These run **once**, at install or `pithead apply`, and inherently reveal your IP to the host you
+download from. They cannot be Tor-routed transparently, but they are **integrity-pinned** so a
+network attacker can't substitute what you receive.
+
+| What | Destination | When |
+|---|---|---|
+| Source clone / release assets | `github.com` | install / update |
+| Monero binaries | `downloads.getmonero.org` | image build (verified against a published **SHA256**) |
+| Container images | `quay.io`, Docker Hub | image build / pull (pinned by **`@sha256:` digest**, #135) |
+
+**Mitigation:** run the install/build behind a **VPN** or with `torsocks`, or pre-pull the images and
+clone on another machine and copy them over. The downloads are pinned (SHA256 + image digests), so
+the risk is the **one-time IP disclosure**, not tampering.
+
+---
+
+## Hardening the clearnet paths
+
+Two outbound yield paths use clearnet in v1.0. Here's how to close each one **today**; v1.1 will make
+the Tor routing the default.
+
+### P2Pool outbound peers (#165)
+
+P2Pool advertises its onion for *inbound* peers but dials *outbound* sidechain peers over clearnet,
+exposing your IP to the P2Pool network. **v1.0 has no config knob for this yet** (#165 adds a
+`p2pool.clearnet` toggle); to route those dials through Tor today, hand-edit P2Pool's `command:` in
+`docker-compose.yml`, adding the SOCKS flags just before `${P2POOL_FLAGS}`:
+
+```yaml
+# docker-compose.yml — the p2pool service `command:`
+      - --socks5
+      - 172.28.0.25:9050
+      - --socks5-proxy-type
+      - tor
+      # add '--no-clearnet-p2p' (its own line) to refuse clearnet peers entirely (onion-only)
+      - ${P2POOL_FLAGS}
+```
+
+Then `docker compose up -d p2pool`. **Trade-off:** Tor adds latency to share propagation, which can
+raise your orphan/uncle rate (most noticeable on mini/nano), and `--no-clearnet-p2p` shrinks your
+peer set to onion-only. Measure the effect on your earnings before keeping it — which is exactly why
+the Tor-by-default flip is a benchmarked **v1.1** change (#165), not a v1.0 default. (This hand-edit
+lives in `docker-compose.yml`, so re-apply it after a stack update until #165 lands.)
+
+### XvB donation mining (#166)
+
+When the optimizer donates to XMRvsBeast (XvB), it points the proxy at `na.xmrvsbeast.com:4247`
+over clearnet, exposing your IP to XvB. Pool stratum over Tor is high-latency and hurts share
+acceptance, so there's no clean Tor fix yet. To stop the egress entirely, **disable XvB**:
+
+```jsonc
+// config.json
+"xvb": { "enabled": false }
+```
+
+This also stops the (already Tor-routed) stats fetch. v1.1 adds an `xvb.tor` opt-in to route donation
+mining through Tor and pins `--donate-level 0`.
+
+---
+
+## Maximum-privacy checklist
+
+- [ ] Keep `:3333` off the public internet — firewall it to your LAN or set `p2pool.stratum_bind`
+  (`pithead doctor` flags this).
+- [ ] Route P2Pool outbound through Tor by editing its compose `command:` (above) if you accept the latency.
+- [ ] Set `xvb.enabled: false` if you don't want any XvB egress.
+- [ ] Run the initial install/build behind a VPN or `torsocks`.
+- [ ] Leave Telegram (#121) and Healthchecks (#79) **off** unless you accept the inherent IP exposure.
+- [ ] Run `pithead doctor` — it surfaces the public-IP exposure check among its diagnostics.
+
+---
+
+See also: [Architecture › Privacy by design](architecture.md#privacy-by-design) ·
+[Connecting miners › Firewall](workers.md#firewall) · the privacy-egress epic (#160).


### PR DESCRIPTION
The **v1.0 docs close-out** of the privacy epic #160. The launch docs made *absolute* privacy claims that the egress audit shows aren't true by default — README ("No public port forwarding, no exposing your home IP"), `architecture.md` ("Privacy isn't bolted on — it's the default"), `faq.md` ("Is my home IP exposed?" → *No*). This makes them honest and adds a single source-of-truth egress reference.

## `docs/privacy.md` (new)
One place a reader can find **every connection the stack makes off-box**, whether it's Tor'd, and how to harden it:
- **Inbound** — all onion hidden services → no public port forwarding; the only LAN-facing port is `:3333` (with the #113 public-IP warning).
- **Runtime egress table** — monerod & Tari P2P/tx over Tor with their **clearnet DNS leaks closed** (#161/#162), the XvB **stats** fetch now over Tor (#163), Caddy `tls internal` (no ACME). And the honest part: **P2Pool outbound peers** and **XvB donation mining** are **clearnet today** (reveal your IP), with Tor-by-default planned for **v1.1** (#165/#166). Telegram/Healthchecks stay opt-in.
- **Build/setup-time egress** — `github.com`, `downloads.getmonero.org`, `quay.io`/Docker Hub reveal the IP **once**; inherent but **integrity-pinned** (SHA256 + `@sha256:` digests). Mitigation: VPN/`torsocks`/pre-pull.
- **Hardening the clearnet paths** — exact steps to Tor-route P2Pool outbound *today* (a `docker-compose.yml` edit — there's no config knob until #165) and to stop XvB egress (`xvb.enabled: false`), each with its trade-off.
- A **maximum-privacy checklist**.

## Overclaims corrected → "Tor-first, not yet Tor-only"
- **README** — the privacy bullet now says Tor-first + no port-forwarding, and points to the guide instead of claiming the IP is never exposed.
- **architecture.md › Privacy by design** — keeps the (true) inbound/no-port-forward + Tor-routed-P2P/closed-DNS claims, adds the honest caveat about the two clearnet outbound paths + build-time exposure.
- **faq.md › Is my home IP exposed?** — rewritten to "mostly not, with two clearnet exceptions today + a one-time install exposure," enumerated.
- Cross-linked from README, FAQ, architecture, **and both doc indexes**.

## Accuracy notes
- Verified the current post-merge state in code: XvB stats **are** Tor-routed now (`socks5h`, #163); monerod/Tari DNS **are** closed (#161/#162); P2Pool outbound and XvB donation **are** still clearnet (#165/#166 are v1.1).
- The P2Pool mitigation documents a **direct compose edit** because `P2POOL_FLAGS` is derived from the pool type — there is no `p2pool.flags` config key today (that's what #165 adds). `xvb.enabled` is a real key.
- All internal links + anchors verified to resolve.

Closes #164