### PR TITLE
ci: build all images, shellcheck build scripts, add hadolint (#124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,36 @@ jobs:
       - name: Build the dashboard test stage (installs package + runs the suite in-container)
         run: docker build --target test ./build/dashboard
 
+  build-images:
+    # Build every build/* image so a broken Dockerfile / COPY path / entrypoint / pinned-digest is
+    # caught in CI instead of at deploy time (#124). Previously only the dashboard test stage was
+    # built, so e.g. the Tor image's entrypoint restructure (#180) shipped with no CI safety net.
+    # Tari is an upstream image (no Dockerfile here), so it's excluded. fail-fast: false so one
+    # broken image doesn't hide the others; empty build-args keep the dashboard build working bare.
+    name: Build image (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [monero, p2pool, tor, xmrig-proxy, dashboard]
+    steps:
+      - uses: actions/checkout@v4
+      - name: docker build ./build/${{ matrix.service }}
+        run: docker build -t "pithead-${{ matrix.service }}:ci" "./build/${{ matrix.service }}"
+
+  hadolint:
+    name: Dockerfile lint (hadolint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install hadolint
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/hadolint \
+            https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+          sudo chmod +x /usr/local/bin/hadolint
+      - name: Lint all build/* Dockerfiles (config in .hadolint.yaml)
+        run: hadolint build/*/Dockerfile
+
   shell:
     name: Shell tests (shellcheck + pithead suite)
     runs-on: ubuntu-latest
@@ -55,9 +85,12 @@ jobs:
       # Avoid `apt-get update`, which refreshes every configured source (incl.
       # unrelated third-party mirrors like dl.google.com) and intermittently fails
       # the job when one is briefly out of sync — see issue #64.
-      - name: Lint pithead and test scripts
-        # Gate on warnings+errors (real issues); info-level style nits vary by shellcheck version.
-        run: shellcheck --severity=warning pithead tests/stack/run.sh tests/stack/test_compose.sh tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh
+      - name: Lint pithead, build/* container scripts, and test scripts
+        # Single source of truth: the Makefile `lint` target (so the file list can't drift between
+        # here and `make lint`). Now also covers build/*/*.sh — the entrypoints + healthchecks that
+        # run in every container (#124). Gate on warnings+errors; info-level style nits vary by
+        # shellcheck version.
+        run: make lint
       - name: Run pithead test suite
         run: bash tests/stack/run.sh
       - name: Run integration harness self-test

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,15 @@
+# hadolint config (#124). CI lints every build/* Dockerfile for structure + best practices, but
+# ignores a handful of rules that conflict with this project's deliberate, documented choices:
+ignored:
+  - DL3008  # "pin apt package versions" — we pin the BASE image by @sha256 digest (#135) for
+            # reproducibility; pinning individual apt package versions is brittle (distro repos
+            # prune old versions, which would break the build with no security benefit here).
+  - DL3018  # same as DL3008 but for apk (the Alpine-based Tor image).
+  - DL3015  # "apt-get install --no-install-recommends" — left off deliberately so a needed
+            # recommended dependency isn't silently dropped from a node/proxy image.
+  - DL3047  # "wget without --progress" — purely cosmetic (build-log verbosity).
+  - DL4006  # "SHELL -o pipefail before a piped RUN" — the piped binary downloads are SHA256-verified
+            # immediately after, so a truncated download fails the hash check; pipefail would only be
+            # belt-and-suspenders. (Tracked as possible follow-up hardening.)
+
+failure-threshold: warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- **CI now builds every container image, shellchecks all container scripts, and runs hadolint**
+  (#124). Previously only the dashboard's *test* stage was built, so a broken Dockerfile / `COPY`
+  path / entrypoint in monerod, P2Pool, Tor, or xmrig-proxy would only surface at deploy time — e.g.
+  the Tor image's #180 entrypoint restructure shipped with no CI safety net. A `build-images` matrix
+  now `docker build`s all five `build/*` images on every PR; `make lint` (the CI shellcheck step)
+  gained the seven `build/*/*.sh` entrypoints + healthchecks; and a `hadolint` job lints the
+  Dockerfiles (with a documented `.hadolint.yaml` ignore list for rules that conflict with the
+  digest-pinning approach). CI shellcheck now runs via `make lint` so the file list can't drift.
+
 - **Memory ceilings on every service** (#132). Only Tari was bounded before; now monerod, P2Pool, the
   dashboard, Tor, xmrig-proxy, and both Docker socket proxies each carry a `mem_limit` (with
   `memswap_limit == mem_limit` for a clean, swap-free OOM-kill). A leak or spike now OOM-restarts the

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,6 @@ test-inventory-check: ## Fail if docs/test-inventory.md is stale (CI drift guard
 test-integration: ## Run the live config-matrix integration suite (requires a test box; pass ARGS=...)
 	bash tests/integration/run.sh $(ARGS)
 
-lint: ## shellcheck the stack scripts
-	shellcheck --severity=warning pithead tests/stack/run.sh tests/stack/test_compose.sh \
+lint: ## shellcheck the CLI, the build/* container scripts, and the test scripts
+	shellcheck --severity=warning pithead build/*/*.sh tests/stack/run.sh tests/stack/test_compose.sh \
 		tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh


### PR DESCRIPTION
Closes #124 — and directly motivated by the gouda validation: my Tor image's #180 entrypoint restructure shipped with **no CI safety net** (only a manual local build caught it). This closes the build-layer gap.

## The gap
CI built **only** the dashboard's *test* stage (`docker build --target test ./build/dashboard`). The other four images — monerod, P2Pool, Tor, xmrig-proxy — and the dashboard *prod* stage were **never built in CI**, and the **seven `build/*/*.sh`** entrypoints/healthchecks that run in every container were **never shellcheck'd**. So a broken `COPY` path, a bad entrypoint, a retired apt package, or a stale digest would only surface at deploy time.

## What's added
| Job | Covers |
|---|---|
| **`build-images`** (matrix: monero, p2pool, tor, xmrig-proxy, dashboard) | `docker build`s every `build/*` image on every PR. `fail-fast: false`. Tari is upstream (no Dockerfile), excluded. |
| **`make lint`** (the shellcheck step, now single-sourced) | Extended to **`build/*/*.sh`** — the 7 entrypoints + healthchecks. They were already clean. |
| **`hadolint`** | Lints all `build/*` Dockerfiles, with a documented **`.hadolint.yaml`** ignore list for rules that conflict with the project's choices (digest-pinned bases vs brittle apt/apk version pins; SHA256-verified downloads vs pipefail). |

CI's shellcheck step now calls `make lint` instead of a duplicated inline list, so the two can't drift.

## Validation (local)
- `make lint` clean (incl. `build/*/*.sh`).
- `hadolint` clean on all 5 Dockerfiles with `.hadolint.yaml`.
- `ci.yml` valid YAML; Tor image builds (verified earlier during #180).
- The other images are the production Dockerfiles already running on the test server, so the matrix exercises known-good builds — and from now on, regressions are caught here.

> Part of Wave-5 (CI/test hardening). The companion gap — the e2e harness never asserting `.sync.monero.state == "done"` — is a separate PR (it requires fixing the underlying synced-monerod "loading" bug first).