### PR TITLE
Dashboard: reorder cards by operator relevance — "mine" first, "the world" last (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,15 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Changed
 
+- **Dashboard cards reordered by operator relevance** (#159, completing the #156→#159 chain). Cards
+  rendered in the order they were added, so pool-wide and network-wide context (Global P2Pool Stats,
+  XMR Network) sat *above and between* the things that matter for running *this* stack. The board now
+  leads with the fleet at-a-glance — the hashrate **chart** and the **Workers** table go full-width up
+  top (this stack may drive many machines) — then this stack's own detail cards (my P2Pool node, my
+  XvB tier/VIP/routed, my earnings, my Tari), with **Global P2Pool Stats and XMR Network demoted to
+  reference position at the bottom**. The Simple Overview's stats are likewise reordered to lead with
+  the decision-relevant numbers (total hashrate, mode, workers, tier, VIP, shares) before the routed
+  split and reference fields. "Mine" first, "the world" last — and a cleaner hero shot for launch.
 - **Dashboard now shows *routed* hashrate everywhere for display, *credited* only where XvB's verdict
   matters** (#156). Two different XvB numbers were being conflated: **routed** = what the xmrig-proxy
   actually sent to a pool (`v_xvb`/`v_p2pool`, a common basis for both pools that sums to your total),

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -187,23 +187,25 @@ function SyncView({ sync }) {
 
 function Overview({ state }) {
     const hr = state.hashrate, st = state.stratum, t = state.tari;
+    // Stat order (#159): fleet headline (total / mode / workers) → raffle status (tier / VIP /
+    // shares / target) → routed split → reference (last share / Tari / wallets).
     return html`
     <div class="card card-simple" id="card-overview">
         <h3>Overview</h3>
         <div class="stat-grid">
-            <${StatCard} label="Mining Mode" value=${hr.mode_name} cls=${cVar(hr.mode_variant)} />
             <${StatCard} label="Total Hashrate" value=${hr.total} cls="text-accent" />
+            <${StatCard} label="Mining Mode" value=${hr.mode_name} cls=${cVar(hr.mode_variant)} />
+            <${StatCard} label="Workers Alive" value=${state.proxy_workers} />
+            <${StatCard} label="Current Tier" value=${hr.tier} />
+            <${StatCard} label="VIP (win eligible)" value=${state.vip.label} cls=${state.vip.is_vip ? 'status-ok' : 'status-bad'} />
             <${SharesStat} sw=${state.shares_window} />
-            <${StatCard} label="Last Share" value=${st.last_share} />
+            <${StatCard} label="Target Tier" value=${hr.target_tier} />
             <${StatCard} label="P2Pool 1h (routed)" value=${hr.p2p_1h} cls=${cVar(hr.p2p_variant)} />
             <${StatCard} label="P2Pool 24h (routed)" value=${hr.p2p_24h} cls=${cVar(hr.p2p_variant)} />
             <${StatCard} label="XvB 1h (routed)" value=${hr.xvb_routed_1h} cls=${cVar(hr.xvb_variant)} />
             <${StatCard} label="XvB 24h (routed)" value=${hr.xvb_routed_24h} cls=${cVar(hr.xvb_variant)} />
-            <${StatCard} label="Current Tier" value=${hr.tier} />
-            <${StatCard} label="VIP (win eligible)" value=${state.vip.label} cls=${state.vip.is_vip ? 'status-ok' : 'status-bad'} />
-            <${StatCard} label="Target Tier" value=${hr.target_tier} />
+            <${StatCard} label="Last Share" value=${st.last_share} />
             <div class="stat-card"><h5>Tari Mining</h5><${TariStatus} tari=${t} /></div>
-            <${StatCard} label="Workers Alive" value=${state.proxy_workers} />
             <${StatCard} label="Wallet XMR" value=${st.wallet_short} cls="font-mono text-xs" />
             <${StatCard} label="Wallet TARI" value=${t.wallet_short} cls="font-mono text-xs" />
         </div>
@@ -415,6 +417,9 @@ function WorkersTable({ workers, summary, ui, onSort }) {
 
 function DashboardView({ state, ui, onRange, onSort, onView, onZoom, onResetZoom, onToggleSeries }) {
     const advanced = ui.view === 'advanced';
+    // Layout by operator relevance (#159): the at-a-glance chart and the rigs themselves lead (this
+    // stack may drive many machines), then this stack's own detail cards, then pool-wide and network
+    // context as reference at the bottom — "mine" first, "the world" last.
     return html`
     <div id="dashboard-view" class=${advanced ? 'mode-advanced' : ''}>
         <div class="view-controls">
@@ -427,15 +432,17 @@ function DashboardView({ state, ui, onRange, onSort, onView, onZoom, onResetZoom
             <${ChartCard} chart=${state.chart} range=${ui.range} window=${ui.window} series=${ui.series}
                           onRange=${onRange} onZoom=${onZoom} onResetZoom=${onResetZoom}
                           onToggleSeries=${onToggleSeries} />
-            <${Overview} state=${state} />
-            <${NodeStats} state=${state} />
-            <${GlobalStats} state=${state} />
-            <${XvBStats} state=${state} />
-            <${NetworkCard} state=${state} />
-            <${EarningsCard} earnings=${state.earnings} />
-            <${TariCard} tari=${state.tari} />
         </div>
         <${WorkersTable} workers=${state.workers} summary=${state.proxy_summary} ui=${ui} onSort=${onSort} />
+        <div class="grid">
+            <${Overview} state=${state} />
+            <${NodeStats} state=${state} />
+            <${XvBStats} state=${state} />
+            <${EarningsCard} earnings=${state.earnings} />
+            <${TariCard} tari=${state.tari} />
+            <${GlobalStats} state=${state} />
+            <${NetworkCard} state=${state} />
+        </div>
     </div>`;
 }
 


### PR DESCRIPTION
Last of the **#156→#159** chain. The dashboard's information hierarchy now matches what a pithead operator cares about.

## Problem
Cards rendered in the order they were *added*, so pool-wide / network-wide context (**Global P2Pool Stats**, **XMR Network**) sat **above and between** the things relevant to running *this* stack — your own node, your XvB status, your earnings, your workers.

## Reorganized — optimized for an operator mining on many machines
**Both views** now read "mine" first, "the world" last:

1. **Chart** (hashrate at-a-glance) — now **full-width** up top
2. **Workers** (the rigs themselves) — full-width; for a multi-machine operator the fleet view is the primary concern
3. This stack's detail cards — **My P2Pool Node**, **XvB tier/VIP/routed**, **My Earnings**, **My Tari**
4. **Global P2Pool Stats** + **XMR Network** — demoted to **reference** position at the bottom

The **Simple Overview** stats are likewise reordered: fleet headline (total / mode / workers) → raffle status (tier / VIP / shares / target) → routed split → reference (last share / Tari / wallets).

## Notes
- **Pure layout / DOM-order change** — no logic, no new state. (The chart moving to its own single-item `.grid` makes it full-width via `auto-fit 1fr`.)
- Builds on the now-final card *content* from #156 (routed display), #157 (tier accuracy), #158 (VIP) — so the XvB card is both correct and well-placed.
- Directly improves the launch hero screenshot (#80).
- Dashboard suite green at 94.18%, frontend 30 pass, `node --check` clean. **Visual eyeballing of the final board is folded into the end-of-chain screenshot pass** (per your call to do screenshots/docs at the end).

Closes #159