### PR TITLE
Dashboard: optional Caddy basic-auth login, opt-in + off by default (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- **Optional dashboard login (#8).** A new `dashboard.auth` block puts a Caddy HTTP basic-auth prompt
+  in front of the dashboard. It's **opt-in and off by default** — an empty `dashboard.auth.password`
+  keeps today's behavior (no login), which is right for a private LAN appliance; set a password when
+  the box is **shared or reachable beyond the LAN**. pithead bcrypt-hashes the password with the
+  **already-pinned Caddy image** (`caddy hash-password`) and persists **only the hash** in `.env`
+  (base64-encoded so bcrypt's `$` doesn't spam compose interpolation warnings) — the plaintext lives
+  solely in your owner-only `config.json`. A sha256 fingerprint of the plaintext keeps the hash
+  **stable across `apply` runs** (re-hashed only when the password actually changes, so the Caddyfile
+  doesn't churn). The username/password are validated before render, the secret is **never echoed**
+  in the change preview, and `apply` **warns** if a password is set without `dashboard.secure: true`
+  (basic-auth is cleartext over plain HTTP). Documented in
+  `docs/configuration.md#exposing-the-dashboard-safely`.
 - **Explicit "VIP" win-eligibility indicator on the dashboard** (#158). To *collect* an XvB raffle
   win you must be a **VIP** — have a share in the P2Pool PPLNS window. This is universal across **all**
   tiers and independent of donation amount: a Mega donor pushing 1 MH/s with **no** PPLNS share is

--- a/config.advanced.example.json
+++ b/config.advanced.example.json
@@ -53,7 +53,11 @@
         "host": "auto",
         "timezone": "auto",
         "data_dir": "auto",
-        "tari_required": true
+        "tari_required": true,
+        "auth": {
+            "username": "admin",
+            "password": ""
+        }
     },
 
     "network": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,8 @@ plain HTTP, edit `config.json` and run `./pithead apply`.
 | `tor.data_dir` | `auto` | Where Tor's state (including onion keys) lives. `auto` = `./data/tor`. |
 | `dashboard.secure` | `true` | `true` serves the dashboard over HTTPS (Caddy `tls internal`); `false` uses plain HTTP. |
 | `dashboard.host` | `auto` | Hostname you use to reach the dashboard. `auto` = this machine's hostname. |
+| `dashboard.auth.username` | `admin` | Login name for the dashboard when a password is set (see below). Letters, digits, and `. _ @ -`, 1–64 chars. Ignored while `dashboard.auth.password` is empty. |
+| `dashboard.auth.password` | `""` _(off)_ | Optional **password to open the dashboard** — turns on a Caddy [HTTP basic-auth](https://caddyserver.com/docs/caddyfile/directives/basic_auth) prompt in front of every page. `""` (default) = **no login**, anyone who can reach the dashboard sees it (fine for a private LAN appliance). Any 8–128-character string (no double-quotes) turns the prompt on. The plaintext lives **only in your owner-only `config.json`**; pithead bcrypt-hashes it with the pinned Caddy image and stores **only the hash** in `.env`, so the password itself is never persisted in rendered state. Basic-auth credentials travel in cleartext over HTTP, so keep `dashboard.secure: true` (the default) — pithead warns if you set a password with `secure: false`. See [Exposing the dashboard safely](#exposing-the-dashboard-safely). |
 | `dashboard.timezone` | `auto` | Timezone for the dashboard's timestamps and charts. `auto` = **the host machine's timezone** (auto-detected, falling back to `Etc/UTC`); set an IANA name (e.g. `America/Chicago`) to override. |
 | `dashboard.data_dir` | `auto` | Where the dashboard's database lives. `auto` = `./data/dashboard`. |
 | `dashboard.tari_required` | `true` | How much a Tari problem holds up the rest of the stack. Monero is **required** to mine, so its behavior isn't configurable: a monerod outage always rejects workers (stops `xmrig-proxy` so miners **fail over to their backup pools**), and the miner is always held until monerod finishes syncing. Tari is **only needed for merge mining**, so this one flag decides how much it blocks. **`true` (default):** a Tari outage also rejects workers, the miner waits for Tari's initial sync too, and a Tari-only (re)sync shows the full-screen Sync view. **`false` (non-blocking):** keep mining Monero through a Tari outage, start mining as soon as Monero is synced (Tari finishes in the background), and keep the normal dashboard — with a `Tari syncing` indicator — instead of the takeover screen. |
@@ -129,6 +131,53 @@ and sets ownership automatically (Monero/Tari/P2Pool to your user, Tor to the co
 > **Note:** `apply` does **not** copy your existing data into a new location — it only points the
 > container at the new path. If you're relocating data you already have, move the files yourself
 > first (with the stack stopped), then update `data_dir` and run `apply`.
+
+---
+
+## Exposing the dashboard safely
+
+The dashboard is designed for a **trusted private network** — the home or office LAN the appliance
+sits on. By default it has no login: anyone who can reach the host can open it. That's the right
+trade-off for a single-user box behind your router, and it stays the default.
+
+You should add a login (and keep HTTPS on) whenever the dashboard is reachable by anyone you don't
+fully trust — for example:
+
+- the machine is **shared** (a co-hosted home server other people use), or
+- you've **port-forwarded / reverse-proxied** the dashboard so it's reachable from outside the LAN, or
+- you simply want a second layer in front of it.
+
+Turn it on by setting a password in `config.json` and running `./pithead apply`:
+
+```json
+{
+    "dashboard": {
+        "secure": true,
+        "auth": { "username": "admin", "password": "a-long-passphrase" }
+    }
+}
+```
+
+How it works and what to keep in mind:
+
+- **The password is bcrypt-hashed, never stored in cleartext.** pithead hashes it with the **same
+  pinned Caddy image** the stack already runs (`caddy hash-password`) and writes **only the hash** to
+  `.env`. The plaintext exists only in your owner-only `config.json` — treat that file like any other
+  secret (it's already git-ignored). The hash is stable across `apply` runs and only re-computed when
+  you actually change the password, so the Caddyfile doesn't churn.
+- **Keep `dashboard.secure: true`.** Basic-auth sends the credentials with every request; over plain
+  HTTP (`secure: false`) they'd travel in cleartext. pithead **warns** if you set a password without
+  HTTPS, but won't stop you. With the default `tls internal`, Caddy serves a locally-trusted
+  certificate — your browser will warn the first time unless you trust Caddy's local CA.
+- **A login is access control for the *dashboard*, not the miner.** It gates the web UI only. The
+  stratum port miners connect to is a separate surface — gate that with
+  [`p2pool.stratum_password`](#configuration-reference) and `p2pool.stratum_bind`.
+- **Exposing to the public internet is still discouraged.** A password plus HTTPS is the right
+  baseline, but the safest remote-access path remains a VPN / SSH tunnel / Tailscale back to the LAN
+  rather than a forwarded port. Basic-auth has no rate-limiting or lockout on its own.
+
+To remove the login again, clear the password (`"password": ""`) and `apply` — pithead drops the
+`basic_auth` block and the dashboard is open on the LAN as before.
 
 ---
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -202,6 +202,10 @@ estimate. It is deliberately scoped to P2Pool — it is **not** an XvB or a Tari
   `./pithead apply`.
 - **Reaching it from another machine.** Use the hostname/IP of the stack server. If your hostname
   doesn't resolve on your LAN, set `dashboard.host` in `config.json` to an address that does.
+- **Adding a login.** By default the dashboard has no password — fine for a private LAN appliance.
+  If the box is shared or reachable beyond your LAN, set `dashboard.auth.password` (keep
+  `dashboard.secure: true`) and run `./pithead apply` to put a login prompt in front of it. See
+  [Configuration › Exposing the dashboard safely](configuration.md#exposing-the-dashboard-safely).
 - **On your phone.** The dashboard is responsive — open the same URL on a phone and the layout
   reflows to a single column with a stacked header, so you can check on the stack from the couch.
 - **Stuck on Sync Mode?** That usually just means the chain is still downloading. Check

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 454 dashboard unit tests · 12 contract tests · 28 frontend
-tests · 30 `pithead` shell sections · 15 harness self-test sections ·
+tests · 32 `pithead` shell sections · 15 harness self-test sections ·
 8 live config scenarios (15 axis values) · 6 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 30 `pithead` shell sections · 15 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 454 |
 | 1 — Unit | frontend (node --test) | 28 |
-| 1 — Unit | `pithead` shell suite | 30 sections |
+| 1 — Unit | `pithead` shell suite | 32 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 6 |
@@ -557,7 +557,7 @@ tests · 30 `pithead` shell sections · 15 harness self-test sections ·
 - bandBorderWidth: zero-height segments get no border, real ones keep full width
 - uptimeCell: online shows uptime, offline shows DOWN
 
-### `pithead` shell suite (tests/stack/run.sh) — 30 sections
+### `pithead` shell suite (tests/stack/run.sh) — 32 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -566,6 +566,7 @@ tests · 30 `pithead` shell sections · 15 harness self-test sections ·
 - unit: docker_boot_enabled (#137)
 - unit: is_valid_host (#130)
 - unit: describe_change
+- unit: dashboard auth (#8)
 - unit: explain_subnet_collision (#180)
 - unit: env helpers
 - unit: export_build_provenance (Issue #58)
@@ -578,6 +579,7 @@ tests · 30 `pithead` shell sections · 15 harness self-test sections ·
 - black-box: CLI dispatch
 - black-box: guards
 - black-box: config validation
+- black-box: dashboard auth lifecycle (#8)
 - black-box: apply preserves secrets + propagates
 - black-box: xmrig-proxy knobs (#152 stratum auth, #173 donate-level)
 - black-box: local node creds auto-generated + persisted (#50)
@@ -722,5 +724,5 @@ tests · 30 `pithead` shell sections · 15 harness self-test sections ·
 
 ---
 
-_Grand total: **553** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **555** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/pithead
+++ b/pithead
@@ -1368,6 +1368,40 @@ parse_and_validate_config() {
     # (auto-detected; falls back to Etc/UTC). Set an IANA name (e.g. America/Chicago) to
     # override. Rendered into .env as DASHBOARD_TZ.
     DASHBOARD_TZ=$(resolve_default "$(jq -r '.dashboard.timezone // empty' "$CONFIG_FILE")" "$(detect_host_timezone)")
+
+    # Optional dashboard login (#8): Caddy basic_auth in front of the dashboard. OPT-IN — an empty
+    # password (the default) leaves it open, today's behavior, which is fine for the LAN appliance;
+    # turn it on before exposing/co-hosting the dashboard. The plaintext lives only in config.json
+    # (owner-only); pithead bcrypt-hashes it with the pinned Caddy image and stores the hash
+    # base64-encoded in .env (raw bcrypt's '$' spams compose interpolation warnings). A sha256
+    # fingerprint of the plaintext keeps the hash STABLE across applies — re-hash only when the
+    # password actually changes (bcrypt is salted, so re-hashing every apply would churn the Caddyfile).
+    DASHBOARD_AUTH_USER=$(jq -r '.dashboard.auth.username // "admin"' "$CONFIG_FILE")
+    DASHBOARD_AUTH_HASH_B64=""
+    DASHBOARD_AUTH_PW_FP=""
+    local dash_pw; dash_pw=$(jq -r '.dashboard.auth.password // ""' "$CONFIG_FILE")
+    if [ -n "$dash_pw" ]; then
+        if ! printf '%s' "$DASHBOARD_AUTH_USER" | grep -qE '^[A-Za-z0-9._@-]{1,64}$'; then
+            error "dashboard.auth.username must be 1–64 chars of letters, digits, and . _ @ - (got \"$DASHBOARD_AUTH_USER\")."
+        fi
+        if ! printf '%s' "$dash_pw" | grep -qE '^[[:print:]]{8,128}$' || printf '%s' "$dash_pw" | grep -q '"'; then
+            error "dashboard.auth.password must be 8–128 printable characters with no double-quotes."
+        fi
+        DASHBOARD_AUTH_PW_FP=$(printf '%s' "$dash_pw" | sha256_hex)
+        local prev_fp prev_hash
+        prev_fp=$(env_get DASHBOARD_AUTH_PW_FP)
+        prev_hash=$(env_get DASHBOARD_AUTH_HASH_B64)
+        if [ "$DASHBOARD_AUTH_PW_FP" = "$prev_fp" ] && [ -n "$prev_hash" ]; then
+            DASHBOARD_AUTH_HASH_B64="$prev_hash"          # password unchanged — keep the stable hash
+        else
+            DASHBOARD_AUTH_HASH_B64=$(caddy_hash_password_b64 "$dash_pw") \
+                || error "Could not hash dashboard.auth.password (is Docker running and the Caddy image pulled? Run '$0 setup' first)."
+        fi
+        # basic_auth credentials are only safe over TLS; warn (don't fail) on plain HTTP.
+        if [ "$DASHBOARD_SECURE" != "true" ]; then
+            warn "dashboard.auth is set but dashboard.secure is false — login credentials would travel over plain HTTP. Set dashboard.secure: true for HTTPS."
+        fi
+    fi
 }
 
 # Load secrets and one-time-provisioned values from an existing .env so that re-rendering
@@ -1656,6 +1690,9 @@ MONERO_ZMQ_PORT=$zmq_port
 COMPOSE_PROFILES=$profiles
 DASHBOARD_SECURE=$DASHBOARD_SECURE
 DASHBOARD_TZ=$DASHBOARD_TZ
+DASHBOARD_AUTH_USER=$DASHBOARD_AUTH_USER
+DASHBOARD_AUTH_HASH_B64=$DASHBOARD_AUTH_HASH_B64
+DASHBOARD_AUTH_PW_FP=$DASHBOARD_AUTH_PW_FP
 HOST_IP=$HOST_IP
 DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false}
 EOF
@@ -1674,19 +1711,47 @@ inject_service_configs() {
     safe_sed "s/172\.28\.0/$NETWORK_PREFIX/g" build/tari/config.toml
 }
 
+# sha256 of stdin as lowercase hex — portable across the sha256sum / shasum split.
+sha256_hex() {
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum | cut -d' ' -f1
+    else shasum -a 256 | cut -d' ' -f1; fi
+}
+
+# bcrypt-hash a dashboard password with the PINNED Caddy image (read straight from docker-compose.yml
+# so it tracks the digest), returned base64-encoded so the raw bcrypt '$' never lands in .env (#8).
+# Returns non-zero if Docker / the image isn't available.
+caddy_hash_password_b64() {
+    local pw="$1" img hash
+    img=$(grep -oE 'caddy:[0-9.]+@sha256:[a-f0-9]+' docker-compose.yml | head -1)
+    [ -n "$img" ] || return 1
+    hash=$(docker run --rm "$img" caddy hash-password --plaintext "$pw" 2>/dev/null) || return 1
+    [ -n "$hash" ] || return 1
+    printf '%s' "$hash" | openssl base64 -A
+}
+
 generate_caddyfile() {
+    # Optional basic_auth block (#8), rendered only when a dashboard password is configured. The
+    # hash is decoded from its base64 .env form back to the raw bcrypt string Caddy expects; it
+    # protects every route, so the dashboard prompts for login before anything is served.
+    local auth=""
+    if [ -n "$DASHBOARD_AUTH_HASH_B64" ]; then
+        local hash; hash=$(printf '%s' "$DASHBOARD_AUTH_HASH_B64" | openssl base64 -d -A)
+        auth=$(printf '    basic_auth {\n        %s %s\n    }' "$DASHBOARD_AUTH_USER" "$hash")
+    fi
     if [ "$DASHBOARD_SECURE" == "true" ]; then
-        log "Generating Caddyfile for automatic HTTPS ($HOST_IP)..."
+        log "Generating Caddyfile for automatic HTTPS ($HOST_IP)$([ -n "$auth" ] && echo ' with login')..."
         cat <<EOF > "Caddyfile"
 https://$HOST_IP {
     tls internal
+$auth
     reverse_proxy 127.0.0.1:8000
 }
 EOF
     else
-        log "Generating Caddyfile for HTTP ($HOST_IP)..."
+        log "Generating Caddyfile for HTTP ($HOST_IP)$([ -n "$auth" ] && echo ' with login')..."
         cat <<EOF > "Caddyfile"
 http://$HOST_IP {
+$auth
     reverse_proxy 127.0.0.1:8000
 }
 EOF
@@ -2022,6 +2087,21 @@ describe_change() {
             msg="Monero memory cap: $old → $new — the monerod container is recreated (brief restart; the blockchain on disk is preserved)." ;;
         DASHBOARD_SECURE)
             msg="Dashboard scheme → $([ "$new" == "true" ] && echo HTTPS || echo HTTP) (secure=$new)." ;;
+        DASHBOARD_AUTH_HASH_B64)
+            # Secret — never echo the hash into the change preview / logs.
+            if [ -z "$new" ]; then
+                msg="Dashboard login DISABLED (#8) — the dashboard is reachable without a password again."
+            elif [ -z "$old" ]; then
+                flag=DEST; msg="Dashboard login ENABLED (#8) — Caddy now requires the configured username/password; the caddy container is recreated."
+            else
+                flag=DEST; msg="Dashboard login password CHANGED (#8) — use the new credentials; the caddy container is recreated."
+            fi ;;
+        DASHBOARD_AUTH_USER)
+            msg="Dashboard login username: $old → $new (#8)." ;;
+        DASHBOARD_AUTH_PW_FP)
+            # Internal fingerprint — always co-changes with DASHBOARD_AUTH_HASH_B64, which already
+            # carries the user-facing message. Emit no message so the preview shows one line, not two.
+            msg="" ;;
         HOST_IP)
             msg="Dashboard hostname: $old → $new." ;;
         MONERO_PREP_THREADS)
@@ -2076,10 +2156,11 @@ apply() {
         for key in "${changed[@]}"; do
             old=$(env_get_file "$ENV_FILE" "$key")
             new=$(env_get_file "$newenv" "$key")
-            case "$key" in HOST_IP|DASHBOARD_SECURE) caddy_changed=1 ;; esac
+            case "$key" in HOST_IP|DASHBOARD_SECURE|DASHBOARD_AUTH_USER|DASHBOARD_AUTH_HASH_B64) caddy_changed=1 ;; esac
             line=$(describe_change "$key" "$old" "$new")
             flag=${line%%$'\t'*}
             msg=${line#*$'\t'}
+            [ -z "$msg" ] && continue   # internal-only keys (e.g. the auth fingerprint) stay silent
             if [ "$flag" == "DEST" ]; then
                 echo -e "  ${C_YELLOW}⚠ ${msg}${C_RESET}"
                 destructive=1

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -43,6 +43,12 @@ case "$*" in
   "exec tor cat /var/lib/tor/monero/hostname") echo "mona.onion" ;;
   "exec tor cat /var/lib/tor/tari/hostname")   echo "taria.onion" ;;
   "exec tor cat /var/lib/tor/p2pool/hostname") echo "p2pa.onion" ;;
+  *hash-password*)
+    # Fake `caddy hash-password` (#8): a per-password digest so enable/change paths differ, and it
+    # never echoes the plaintext back (real bcrypt doesn't either) — keeps the leak checks honest.
+    _pw="${*##*--plaintext }"
+    _d="$(printf '%s' "$_pw" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-22)"
+    printf '$2y$14$%s\n' "$_d" ;;
 esac
 exit 0
 EOF
@@ -143,6 +149,42 @@ assert_contains "data_dir is DEST"   "$(run_sourced "$SANDBOX" describe_change M
 assert_contains "tari mem is INFO"   "$(run_sourced "$SANDBOX" describe_change TARI_MEM_LIMIT 2048m 4g)" "INFO"
 assert_contains "monero mem is INFO" "$(run_sourced "$SANDBOX" describe_change MONERO_MEM_LIMIT 4g 6g)"  "INFO"
 assert_contains "monero mem recreate note" "$(run_sourced "$SANDBOX" describe_change MONERO_MEM_LIMIT 4g 6g)" "monerod container is recreated"
+
+echo "== unit: dashboard auth (#8) =="
+# Dashboard login (#8): enabling/changing is DEST (caddy is recreated), disabling is INFO. The bcrypt
+# hash is a secret and must never surface in the change preview; the internal fingerprint stays silent.
+assert_contains "dash login enable is DEST"  "$(run_sourced "$SANDBOX" describe_change DASHBOARD_AUTH_HASH_B64 '' aGFzaA==)" "DEST"
+assert_contains "dash login disable is INFO" "$(run_sourced "$SANDBOX" describe_change DASHBOARD_AUTH_HASH_B64 aGFzaA== '')" "INFO"
+case "$(run_sourced "$SANDBOX" describe_change DASHBOARD_AUTH_HASH_B64 b2xkSA== bmV3SA==)" in
+    *b2xkSA==*|*bmV3SA==*) bad "dash login change hides the hash" "hash value leaked into the change preview" ;;
+    *DEST*)                ok  "dash login change hides the hash (DEST, no value shown)" ;;
+    *)                     bad "dash login change hides the hash" "expected DEST" ;;
+esac
+assert_contains "dash login username change is shown" "$(run_sourced "$SANDBOX" describe_change DASHBOARD_AUTH_USER admin bob)" "admin → bob"
+case "$(run_sourced "$SANDBOX" describe_change DASHBOARD_AUTH_PW_FP aaa bbb)" in
+    *PW_FP*|*updated*|*fingerprint*) bad "dash login fingerprint stays silent" "internal fingerprint surfaced in the preview" ;;
+    INFO*)                           ok  "dash login fingerprint stays silent (no preview line)" ;;
+    *)                               bad "dash login fingerprint stays silent" "unexpected message emitted" ;;
+esac
+
+# generate_caddyfile renders a basic_auth block ONLY when a hash is configured, carrying the username
+# and the *decoded* bcrypt string Caddy expects; with no hash the dashboard stays open (no basic_auth).
+auth_hb64="$(printf '%s' '$2y$14$UNITTESTbcrypthashvalue000000000000000000000000000000' | openssl base64 -A)"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_on="$( cd "$SANDBOX" && source "$STACK" 2>/dev/null; set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_USER=admin DASHBOARD_AUTH_HASH_B64="$auth_hb64" \
+        generate_caddyfile >/dev/null 2>&1; cat Caddyfile )"
+assert_contains "caddy renders basic_auth when login set" "$caddy_on" "basic_auth"
+assert_contains "caddy basic_auth carries the username"   "$caddy_on" "admin"
+assert_contains "caddy basic_auth carries decoded hash"   "$caddy_on" '$2y$14$UNITTESTbcrypthashvalue'
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_off="$( cd "$SANDBOX" && source "$STACK" 2>/dev/null; set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_USER=admin DASHBOARD_AUTH_HASH_B64="" \
+        generate_caddyfile >/dev/null 2>&1; cat Caddyfile )"
+case "$caddy_off" in
+    *basic_auth*) bad "caddy stays open when no login set" "basic_auth rendered without a password" ;;
+    *)            ok  "caddy stays open when no login set (no basic_auth)" ;;
+esac
 
 echo "== unit: explain_subnet_collision (#180) =="
 ov="$(run_sourced "$SANDBOX" explain_subnet_collision "invalid pool request: Pool overlaps with other one on this address space" 2>&1)"
@@ -402,6 +444,71 @@ printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","n
 out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"; rc=$?
 assert_rc "unsafe stratum_password rejected" "$rc" "1"
 assert_contains "stratum_password message" "$out" "p2pool.stratum_password"
+
+# Dashboard login (#8): a username with a Caddyfile-unsafe character (a space) is rejected before any
+# hashing; the password is validated for length/charset too. Both fail fast on apply.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan","auth":{"username":"bad user","password":"longenough1"}} }\n' "$WALLET" > "$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"; rc=$?
+assert_rc "invalid dashboard.auth.username rejected" "$rc" "1"
+assert_contains "dashboard.auth.username message" "$out" "dashboard.auth.username"
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan","auth":{"username":"admin","password":"short"}} }\n' "$WALLET" > "$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"; rc=$?
+assert_rc "too-short dashboard.auth.password rejected" "$rc" "1"
+assert_contains "dashboard.auth.password message" "$out" "dashboard.auth.password"
+
+echo "== black-box: dashboard auth lifecycle (#8) =="
+# The hashing reads the pinned Caddy image out of docker-compose.yml and shells out to the stubbed
+# `caddy hash-password`, so the whole enable → reuse → change → disable path runs offline.
+cp "$ROOT/docker-compose.yml" "$V/docker-compose.yml"
+AUTH_LOG="$V/auth-docker.log"
+
+# (1) ENABLE: a password turns on basic_auth — hash + fingerprint persisted, plaintext never stored.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "proxy":{"donate_level":0}, "dashboard":{"secure":true,"host":"box.lan","auth":{"username":"admin","password":"hunter2hunter2"}} }\n' "$WALLET" > "$V/config.json"
+: > "$AUTH_LOG"
+out="$(cd "$V" && DOCKER_LOG="$AUTH_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"; rc=$?
+assert_rc "auth enable applies cleanly" "$rc" "0"
+assert_eq "auth username persisted" "$(run_sourced "$V" env_get_file "$V/.env" DASHBOARD_AUTH_USER)" "admin"
+hash1="$(run_sourced "$V" env_get_file "$V/.env" DASHBOARD_AUTH_HASH_B64)"
+fp1="$(run_sourced "$V" env_get_file "$V/.env" DASHBOARD_AUTH_PW_FP)"
+[ -n "$hash1" ] && ok "auth hash persisted (base64)" || bad "auth hash persisted (base64)" "empty"
+[ -n "$fp1" ]   && ok "auth fingerprint persisted"   || bad "auth fingerprint persisted"   "empty"
+assert_contains "auth hashed via the pinned caddy image" "$(cat "$AUTH_LOG")" "hash-password"
+assert_contains "Caddyfile gains basic_auth"             "$(cat "$V/Caddyfile")" "basic_auth"
+case "$(cat "$V/.env" "$V/Caddyfile")" in
+    *hunter2hunter2*) bad "auth plaintext never persisted" "password leaked into .env/Caddyfile" ;;
+    *)                ok  "auth plaintext never persisted" ;;
+esac
+
+# (2) REUSE: re-applying (here nudging an unrelated knob) keeps the SAME hash and does NOT re-hash —
+# bcrypt is salted, so a stable fingerprint is what keeps the Caddyfile from churning every apply.
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "proxy":{"donate_level":1}, "dashboard":{"secure":true,"host":"box.lan","auth":{"username":"admin","password":"hunter2hunter2"}} }\n' "$WALLET" > "$V/config.json"
+: > "$AUTH_LOG"
+out="$(cd "$V" && DOCKER_LOG="$AUTH_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_eq "unchanged password keeps the same hash" "$(run_sourced "$V" env_get_file "$V/.env" DASHBOARD_AUTH_HASH_B64)" "$hash1"
+case "$(cat "$AUTH_LOG")" in
+    *hash-password*) bad "unchanged password is not re-hashed" "caddy hash-password was called again" ;;
+    *)               ok  "unchanged password is not re-hashed (stable hash)" ;;
+esac
+
+# (3) CHANGE: a new password re-hashes (fingerprint changes) and recreates the caddy container.
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "proxy":{"donate_level":1}, "dashboard":{"secure":true,"host":"box.lan","auth":{"username":"admin","password":"freshpass99"}} }\n' "$WALLET" > "$V/config.json"
+: > "$AUTH_LOG"
+out="$(cd "$V" && DOCKER_LOG="$AUTH_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_contains "changed password re-hashes"     "$(cat "$AUTH_LOG")" "hash-password"
+assert_eq "changed password updates fingerprint" "$([ "$(run_sourced "$V" env_get_file "$V/.env" DASHBOARD_AUTH_PW_FP)" != "$fp1" ] && echo changed)" "changed"
+assert_contains "auth change recreates caddy"     "$(cat "$AUTH_LOG")" "restart caddy"
+
+# (4) DISABLE: clearing the password drops basic_auth — hash cleared, dashboard reachable again.
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "proxy":{"donate_level":1}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" > "$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$AUTH_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_eq "auth disable clears the hash" "$(run_sourced "$V" env_get_file "$V/.env" DASHBOARD_AUTH_HASH_B64)" ""
+case "$(cat "$V/Caddyfile")" in
+    *basic_auth*) bad "auth disable drops basic_auth" "basic_auth still present in the Caddyfile" ;;
+    *)            ok  "auth disable drops basic_auth" ;;
+esac
 
 echo "== black-box: apply preserves secrets + propagates =="
 seed_env


### PR DESCRIPTION
Closes #8.

## What

Adds an optional login in front of the dashboard. A new `dashboard.auth` block:

```json
"dashboard": {
    "secure": true,
    "auth": { "username": "admin", "password": "a-long-passphrase" }
}
```

turns on a Caddy [HTTP basic-auth](https://caddyserver.com/docs/caddyfile/directives/basic_auth) prompt over every route. It is **opt-in and OFF by default** — an empty `password` keeps today's no-login behavior, which is the right default for a private LAN appliance. Set a password when the box is **shared** (co-hosted home server) or **reachable beyond the LAN**.

## How

- **Hashing.** pithead bcrypt-hashes the password with the **already-pinned Caddy image** (`caddy hash-password`) — no new dependency. Only the **hash** is persisted, in `.env`, **base64-encoded** so bcrypt's `$` doesn't spam compose interpolation warnings. The plaintext lives solely in the owner-only `config.json`.
- **Stability.** A sha256 fingerprint of the plaintext is stored alongside the hash; the password is re-hashed **only when it actually changes**. Because bcrypt is salted, re-hashing every apply would churn the Caddyfile and needlessly recreate Caddy — the fingerprint avoids that.
- **Safety.** Username/password are validated before render. The secret is **never echoed** in the `apply` change preview (the hash key prints a generic enabled/changed/disabled message; the internal fingerprint key is silent, so the preview shows one line, not two). `apply` **warns** if a password is set with `dashboard.secure: false` (basic-auth is cleartext over plain HTTP).
- **Rendering.** `generate_caddyfile` emits the `basic_auth` block only when a hash is present; `DASHBOARD_AUTH_HASH_B64` / `DASHBOARD_AUTH_USER` changes recreate the caddy container.

## Tests (23 new stack tests, all green)

- `describe_change`: enable→DEST, disable→INFO, change hides the hash, username change shown, fingerprint stays silent.
- `generate_caddyfile`: basic_auth rendered with the decoded hash + username when set; no basic_auth when off.
- Validation: bad username (space) and too-short password rejected before any hashing.
- Full **enable → reuse → change → disable** lifecycle via a stubbed `caddy hash-password` — including proof the hash is **reused** (no re-hash) when the password is unchanged, and that the plaintext never lands in `.env`/Caddyfile.

## Live validation (gouda, real Docker + the actual pinned Caddy image)

- `caddy hash-password` produces a valid cost-14 bcrypt; base64 round-trips; `caddy validate` accepts the generated Caddyfile.
- End-to-end gate proven with a real Caddy container: **no creds → 401, wrong password → 401, correct creds → 200**. The real deployment's config/`.env`/wallets were untouched (tested in a scratch dir, cleaned up).

## Docs

- `docs/configuration.md`: `dashboard.auth.username` / `dashboard.auth.password` reference rows + a new **"Exposing the dashboard safely"** section.
- `docs/dashboard.md`: a Tips entry pointing to it.
- `CHANGELOG.md`: `### Added` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)