### PR TITLE
docs: record the p2pool argv RPC-credential limitation (#57, wontfix)

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -116,6 +116,26 @@ mining through Tor and pins `--donate-level 0`.
 
 ---
 
+## Local trust boundary & known limitations
+
+Everything above is about **network** egress — what leaves the host. On the **host itself**, the
+stack assumes the local machine and the private Docker bridge are trusted, which is the right model
+for a single-purpose appliance. One consequence is worth recording explicitly:
+
+- **The monerod RPC credential appears in the p2pool container's process arguments (#57).** p2pool
+  accepts the monerod RPC login (`--rpc-login`) **only** as a command-line argument — it has no
+  environment-variable or config-file equivalent — so the username/password are visible in the
+  p2pool process's argv to any local process that can read it (`ps`, `/proc/<pid>/cmdline`). This is
+  **local-only** (never remotely reachable) and the credential is an **auto-generated random secret**
+  guarding a `restricted-rpc` (read-only, public-safe) endpoint that by default is bound to localhost
+  plus the Docker bridge — **not** the LAN (set `monero.rpc_lan_access: true` to expose it, in which
+  case the credential matters more). Moving it off argv isn't possible without removing RPC
+  authentication (a worse trade-off — it's defense-in-depth on the internal path) or an upstream
+  p2pool change, so it's **accepted as a known limitation** rather than fixed. Practical guidance: on
+  a single-user appliance this is a non-issue; if you **co-host** the stack on a machine shared with
+  other local users, treat the monerod RPC credential as visible to them and prefer a single-purpose
+  host for stronger isolation.
+
 ## Maximum-privacy checklist
 
 - [ ] Keep `:3333` off the public internet — firewall it to your LAN, set `p2pool.stratum_bind`,


### PR DESCRIPTION
Closes #57.

## Decision: wontfix, rationale recorded in the repo

#57 is a tracking issue whose acceptance criteria are: *"adopt an upstream non-argv mechanism, or **consciously decide to close as wontfix with the rationale recorded**."* This PR does the latter.

## Why wontfix

p2pool accepts the monerod RPC login (`--rpc-login`) **only** as a command-line argument — no env-var or config-file equivalent exists upstream. So the credential is visible in the p2pool container's argv (`ps`, `/proc/<pid>/cmdline`). But:

- **Local-only.** Reading another process's argv requires being on the host already; it's never remotely reachable.
- **Low-value target.** The credential is an **auto-generated random secret** guarding a **`restricted-rpc`** (read-only, public-safe) endpoint that by default is bound to **localhost + the Docker bridge, not the LAN**.
- **No clean fix.** Moving it off argv would mean removing RPC auth entirely — *worse*, since the auth is defense-in-depth on the internal path — or an upstream p2pool change. (A conditional "drop auth when not LAN-exposed" was considered and rejected for v1.0: it removes a security layer and the issue itself calls for a network-trust-boundary review.)

## What this PR does

Adds a **"Local trust boundary & known limitations"** section to `docs/privacy.md` that records the exposure, why it's accepted, the `monero.rpc_lan_access` interaction, and a **co-hosting caveat** (on a shared host, treat the credential as visible to other local users). Docs-only — no behavior change.

Part of the v1.0 Wave-2 close-out (#167); #165/#166/#91/#183 were deferred to v1.1 in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)