### PR TITLE
Expand the pithead bash test suite: backup/restore + caddyfile scheme + host helpers (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   Both render to
   xmrig-proxy CLI flags (`--access-password` / `--donate-level`), are validated before render, and
   are documented in `docs/configuration.md` + `docs/workers.md#authentication`.
+- **Expanded the `pithead` shell test suite over data-safety / security-relevant paths** (#140). The
+  `backup`/`restore` round-trip is now covered end to end (stubbed `tar`/`du`/`df`/`docker`/`sudo`):
+  archive layout (the irreplaceable bits in, blockchains out), the leading-`/` strip, a true
+  restore-in-place round-trip, and the low-free-space pre-check (cancel + `--yes` proceed). Added
+  `generate_caddyfile` HTTPS-vs-HTTP (`tls internal`) branch tests and unit tests for the previously
+  uncovered `detect_os` / `detect_host_timezone` / `deps_satisfied` host-detection helpers. Test-only
+  — would have caught the #127 `backup` errexit bug. (`upgrade` #128 and `doctor` #127 were already
+  covered.)
 - **CI now builds every container image, shellchecks all container scripts, and runs hadolint**
   (#124). Previously only the dashboard's *test* stage was built, so a broken Dockerfile / `COPY`
   path / entrypoint in monerod, P2Pool, Tor, or xmrig-proxy would only surface at deploy time — e.g.

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 467 dashboard unit tests · 12 contract tests · 30 frontend
-tests · 32 `pithead` shell sections · 15 harness self-test sections ·
+tests · 35 `pithead` shell sections · 15 harness self-test sections ·
 8 live config scenarios (15 axis values) · 6 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 32 `pithead` shell sections · 15 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 467 |
 | 1 — Unit | frontend (node --test) | 30 |
-| 1 — Unit | `pithead` shell suite | 32 sections |
+| 1 — Unit | `pithead` shell suite | 35 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 6 |
@@ -572,7 +572,7 @@ tests · 32 `pithead` shell sections · 15 harness self-test sections ·
 - bandBorderWidth: zero-height segments get no border, real ones keep full width
 - uptimeCell: online shows uptime, offline shows DOWN
 
-### `pithead` shell suite (tests/stack/run.sh) — 32 sections
+### `pithead` shell suite (tests/stack/run.sh) — 35 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -582,6 +582,8 @@ tests · 32 `pithead` shell sections · 15 harness self-test sections ·
 - unit: is_valid_host (#130)
 - unit: describe_change
 - unit: dashboard auth (#8)
+- unit: generate_caddyfile scheme (#140)
+- unit: host detection (#140)
 - unit: explain_subnet_collision (#180)
 - unit: env helpers
 - unit: export_build_provenance (Issue #58)
@@ -603,6 +605,7 @@ tests · 32 `pithead` shell sections · 15 harness self-test sections ·
 - black-box: up warns about missing (relocated) data dirs (#126)
 - black-box: status health check
 - black-box: doctor exit code (#127)
+- black-box: backup -> restore round-trip (#140)
 - black-box: reset-dashboard targets .env dirs, not config.json (#139)
 - black-box: reset-dashboard refuses to guess without .env dirs (#139)
 
@@ -739,5 +742,5 @@ tests · 32 `pithead` shell sections · 15 harness self-test sections ·
 
 ---
 
-_Grand total: **570** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **573** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -186,6 +186,52 @@ case "$caddy_off" in
     *)            ok  "caddy stays open when no login set (no basic_auth)" ;;
 esac
 
+echo "== unit: generate_caddyfile scheme (#140) =="
+# The HTTPS-vs-HTTP choice is security-relevant: secure -> https:// + `tls internal`; insecure ->
+# plain http:// and no TLS directive. (Auth on/off is covered in the dashboard-auth block above.)
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_https="$( cd "$SANDBOX" && source "$STACK" 2>/dev/null; set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_HASH_B64="" generate_caddyfile >/dev/null 2>&1; cat Caddyfile )"
+assert_contains "caddyfile secure uses https"  "$caddy_https" "https://box.lan"
+assert_contains "caddyfile secure enables TLS" "$caddy_https" "tls internal"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_http="$( cd "$SANDBOX" && source "$STACK" 2>/dev/null; set +e
+    DASHBOARD_SECURE=false HOST_IP=box.lan DASHBOARD_AUTH_HASH_B64="" generate_caddyfile >/dev/null 2>&1; cat Caddyfile )"
+assert_contains "caddyfile insecure uses http" "$caddy_http" "http://box.lan"
+case "$caddy_http" in
+    *"tls internal"*) bad "caddyfile insecure has no TLS" "'tls internal' present on a plain-HTTP site" ;;
+    *)                ok  "caddyfile insecure has no TLS" ;;
+esac
+
+echo "== unit: host detection (#140) =="
+# detect_os reads ID / VERSION_ID / PRETTY_NAME from an overridable os-release (drives the
+# 'supported on Ubuntu 24.04' check); a missing file leaves the fields empty (caller warns).
+osr="$SANDBOX/os-release"
+printf 'ID=ubuntu\nVERSION_ID="24.04"\nPRETTY_NAME="Ubuntu 24.04.1 LTS"\n' > "$osr"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+os_out="$( cd "$SANDBOX" && source "$STACK" 2>/dev/null; set +e; OS_RELEASE_FILE="$osr" detect_os; printf '%s|%s|%s' "$OS_ID" "$OS_VERSION" "$OS_PRETTY" )"
+assert_eq "detect_os parses os-release" "$os_out" "ubuntu|24.04|Ubuntu 24.04.1 LTS"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+os_missing="$( cd "$SANDBOX" && source "$STACK" 2>/dev/null; set +e; OS_RELEASE_FILE="$SANDBOX/nope" detect_os; printf '%s' "$OS_ID" )"
+assert_eq "detect_os tolerates a missing file" "$os_missing" ""
+
+# detect_host_timezone: an explicit IANA-shaped TZ wins; garbage falls back to Etc/UTC.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+tz_good="$( cd "$SANDBOX" && source "$STACK" 2>/dev/null; set +e; TZ="America/Chicago" detect_host_timezone )"
+assert_eq "detect_host_timezone honors a valid TZ" "$tz_good" "America/Chicago"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+tz_bad="$( cd "$SANDBOX" && source "$STACK" 2>/dev/null; set +e; TZ="not a zone!" detect_host_timezone )"
+assert_eq "detect_host_timezone rejects garbage -> Etc/UTC" "$tz_bad" "Etc/UTC"
+
+# deps_satisfied is true only when jq/openssl/docker are present AND `docker compose version` works
+# (the v2-plugin gate). A docker whose `compose version` fails makes it false.
+DEPS="$SANDBOX/deps"; make_stubs "$DEPS/bin"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+( cd "$SANDBOX" && PATH="$DEPS/bin:$PATH" && source "$STACK" 2>/dev/null; set +e; deps_satisfied ); assert_rc "deps_satisfied true with all deps" "$?" "0"
+printf '#!/usr/bin/env bash\n[ "$*" = "compose version" ] && exit 1\nexit 0\n' > "$DEPS/bin/docker"; chmod +x "$DEPS/bin/docker"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+( cd "$SANDBOX" && PATH="$DEPS/bin:$PATH" && source "$STACK" 2>/dev/null; set +e; deps_satisfied ); assert_rc "deps_satisfied false without compose v2" "$?" "1"
+
 echo "== unit: explain_subnet_collision (#180) =="
 ov="$(run_sourced "$SANDBOX" explain_subnet_collision "invalid pool request: Pool overlaps with other one on this address space" 2>&1)"
 assert_contains "subnet overlap -> network.subnet hint"  "$ov" "network"
@@ -775,6 +821,96 @@ out="$(cd "$DOC" && PATH="$DOC/bin:$PATH" ./pithead doctor 2>&1)"; rc=$?
 assert_contains "doctor runs to the summary"          "$out" "Diagnostics summary"
 assert_contains "doctor flags the unreachable daemon" "$out" "Docker daemon is not reachable"
 assert_rc       "doctor exits 1 on a critical FAIL"   "$rc" "1"
+
+echo "== black-box: backup -> restore round-trip (#140) =="
+# backup/restore touch irreplaceable state (onion keys, the dashboard DB) and have fiddly logic
+# (leading-'/' strip, the disk pre-check, stop->backup->start). They shell out only to tar/du/df/
+# docker/sudo, so a full round-trip is stubbable: the docker stub reports the stack NOT running, and
+# a smart sudo runs tar/du/df for real (so the archive is genuinely created/extracted) but no-ops
+# chown (we can't chown to 100:101 unprivileged). The archive stores paths relative to '/', and every
+# path is under the sandbox, so `restore`'s `tar -C /` can only write back inside it (asserted below).
+# Use the sandbox's PHYSICAL path (pwd -P): `restore` extracts at '/', and on macOS the /var ->
+# /private/var symlink would otherwise make BSD tar refuse to "extract through symlink" (Linux /tmp
+# isn't symlinked, so this is a no-op there).
+BK="$(cd "$SANDBOX" && pwd -P)/backup"; mkdir -p "$BK/build/tari" "$BK/data/tor" "$BK/data/dashboard" "$BK/bin"
+cp "$STACK" "$BK/pithead"; cp "$ROOT/build/tari/config.toml.template" "$BK/build/tari/"
+cat > "$BK/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "compose ps --status running -q") exit 0 ;;   # empty output -> stack treated as not running
+esac
+exit 0
+EOF
+cat > "$BK/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+# Run backup/restore's privileged commands as the test user, except chown (can't set 100:101
+# unprivileged) which is accepted as a no-op so restore doesn't abort.
+[ "$1" = "chown" ] && exit 0
+exec "$@"
+EOF
+chmod +x "$BK/bin/docker" "$BK/bin/sudo"
+cat > "$BK/.env" <<EOF
+MONERO_ONION_ADDRESS=mona.onion
+TARI_ONION_ADDRESS=taria.onion
+P2POOL_ONION_ADDRESS=p2pa.onion
+PROXY_AUTH_TOKEN=BKTOKEN
+HOST_IP=box.lan
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+EOF
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" > "$BK/config.json"
+printf 'CADDY-ORIG\n'    > "$BK/Caddyfile"
+printf 'ONIONKEY-ORIG\n' > "$BK/data/tor/hs_ed25519_secret_key"
+printf 'DBDATA-ORIG\n'    > "$BK/data/dashboard/dashboard.db"
+
+# 1) Backup creates a timestamped archive.
+out="$(cd "$BK" && PATH="$BK/bin:$PATH" ./pithead backup -y 2>&1)"; rc=$?
+assert_rc "backup exits 0" "$rc" "0"
+archive="$(ls "$BK"/backups/pithead-backup-*.tar.gz 2>/dev/null | head -1)"
+{ [ -n "$archive" ] && [ -f "$archive" ]; } && ok "backup archive created" || bad "backup archive created" "no archive under backups/"
+
+# 2) Archive layout: the irreplaceable bits are in it; blockchains are NOT (no --with-chains).
+listing="$(tar -tzf "$archive" 2>/dev/null)"
+assert_contains "archive has config.json"      "$listing" "config.json"
+assert_contains "archive has .env"             "$listing" ".env"
+assert_contains "archive has Caddyfile"        "$listing" "Caddyfile"
+assert_contains "archive has the tor onion key" "$listing" "hs_ed25519_secret_key"
+assert_contains "archive has the dashboard db" "$listing" "dashboard.db"
+case "$listing" in
+    *data/monero*|*data/p2pool/*|*data/tari*) bad "archive excludes blockchains by default" "chain data present without --with-chains" ;;
+    *)                                        ok  "archive excludes blockchains by default" ;;
+esac
+# Safety tripwire: every archived path is under the sandbox, so restore's `tar -C /` can't escape it.
+sandbox_rel="${BK#/}"
+escaped="$(printf '%s\n' "$listing" | grep -v '^$' | grep -v "^$sandbox_rel" || true)"
+assert_eq "archive paths stay inside the sandbox" "$escaped" ""
+
+# 3) Round-trip: corrupt/delete the live files, restore, assert the originals come back in place.
+printf 'CORRUPTED\n' > "$BK/Caddyfile"
+printf 'CORRUPTED\n' > "$BK/data/dashboard/dashboard.db"
+rm -f "$BK/data/tor/hs_ed25519_secret_key"
+out="$(cd "$BK" && PATH="$BK/bin:$PATH" ./pithead restore -y "$archive" 2>&1)"; rc=$?
+assert_rc "restore exits 0" "$rc" "0"
+assert_eq "restore brings back the Caddyfile"     "$(cat "$BK/Caddyfile")" "CADDY-ORIG"
+assert_eq "restore brings back the dashboard db"  "$(cat "$BK/data/dashboard/dashboard.db")" "DBDATA-ORIG"
+assert_eq "restore brings back the onion key"     "$(cat "$BK/data/tor/hs_ed25519_secret_key" 2>/dev/null)" "ONIONKEY-ORIG"
+
+# 4) Low-space pre-check (#127): a df reporting almost no free space makes backup prompt; answering
+# "no" cancels and writes nothing, while --yes proceeds with a warning. The check runs BEFORE the
+# stack is touched, so a cancel leaves everything as it was.
+cat > "$BK/bin/df" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'Filesystem 1024-blocks Used Available Capacity Mounted on' '/dev/fake 100 99 1 99% /'
+EOF
+chmod +x "$BK/bin/df"
+rm -f "$BK"/backups/pithead-backup-*.tar.gz
+out="$(cd "$BK" && printf 'n\n' | PATH="$BK/bin:$PATH" ./pithead backup 2>&1)"
+assert_contains "low-space prompt, then cancel" "$out" "ancelled"
+leftover="$(ls "$BK"/backups/pithead-backup-*.tar.gz 2>/dev/null | head -1)"
+assert_eq "cancelled backup writes no archive" "$leftover" ""
+out="$(cd "$BK" && PATH="$BK/bin:$PATH" ./pithead backup -y 2>&1)"; rc=$?
+assert_rc       "low-space backup proceeds with --yes" "$rc" "0"
+assert_contains "low-space backup warns first"         "$out" "Low free space"
 
 echo "== black-box: reset-dashboard targets .env dirs, not config.json (#139) =="
 # reset-dashboard must wipe the LIVE deployment's data dirs (from .env), not a path the user may


### PR DESCRIPTION
Closes #140.

Several data-safety / security-relevant `pithead` paths had no test coverage. This adds them — all sandboxed, no real nodes, stubbing only `tar`/`du`/`df`/`docker`/`sudo`.

## What's now covered

### `backup` → `restore` round-trip (the main gap)
A genuine end-to-end cycle, not a mock:
- **Backup** writes a timestamped archive; asserts its **layout** — config.json / .env / Caddyfile / the Tor **onion key** / the dashboard **DB** are in it, and blockchains are **out** (no `--with-chains`).
- **Restore** is run for real (a *smart* `sudo` stub `exec`s `tar`/`du`/`df` but no-ops `chown`, which can't set `100:101` unprivileged); after corrupting/deleting the live files, the originals come back **in place**.
- **Low-free-space pre-check:** a `df` stub reporting ~no space makes `backup` prompt — answering *no* cancels and writes nothing; `--yes` proceeds with a warning. (Would have caught the #127 `backup` errexit bug.)

Two safety details worth calling out for reviewers:
- The sandbox is resolved to its **physical path** (`pwd -P`) so `restore`'s `tar -C /` doesn't trip **BSD tar's symlink protection** on macOS (where `/var` → `/private/var`); on Linux CI (`/tmp`, no symlink) it's a no-op.
- A **tripwire** asserts every archived path is under the sandbox *before* `restore` runs, so the `tar -C /` can only ever write back inside it.

### `generate_caddyfile` scheme branch
Secure → `https://` + `tls internal`; insecure → `http://` and **no** TLS. (The auth/basic_auth on-off branch was already covered by #8.)

### Host-detection helpers (were 0%)
`detect_os` (os-release parse + missing-file tolerance), `detect_host_timezone` (valid `TZ` vs garbage → `Etc/UTC`), `deps_satisfied` (the docker-compose-v2 gate).

`upgrade` (#128) and `doctor` (#127) already had black-box coverage, so they're left as-is.

## Result
Test-only — no behavior change. Shell suite **224 → 251** assertions; `make lint` clean; `docs/test-inventory.md` regenerated. Full local suite green (dashboard 499, selftest 86, fakes 12).

Part of the v1.0 Wave-5 (CI/test hardening) push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)