### PR TITLE
fix: pithead upgrade preserves deploy flag; dashboard Workers Alive gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,21 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Fixed
 
+- **`pithead upgrade` no longer marks an already-deployed stack as "not set up."** Each upgrade
+  re-renders `.env`, and `render_env` writes `DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false}`.
+  Because `load_preserved_state` doesn't carry that flag (unlike the Tor onions / RPC creds / proxy
+  token it preserves), the shell variable was unset and every `upgrade` silently rewrote it to
+  `false`. The next `require_deployed` command (`up`, `apply`, or another `upgrade`) then aborted with
+  "The stack isn't fully set up yet — run setup first," and a bare `pithead` dropped into setup
+  instead of help — forcing a needless, heavyweight `setup` (Tor re-provision, GRUB edit) before every
+  upgrade. `upgrade` now re-asserts `DEPLOYMENT_COMPLETED=true` before the render, mirroring `apply`;
+  it's only ever reached past `require_deployed`, so the stack is deployed by definition. A new
+  black-box test pins the behavior (it fails on the old code).
+- **Dashboard "Workers Alive" panel now has the standard gap beneath it.** Every dashboard section is
+  a `.card` wrapped in a `.grid`, and `.grid` supplies the consistent 20px bottom margin between
+  sections. The Workers Alive table was the one section rendered as a bare `.card` with no `.grid`
+  wrapper, so the space between it and the cards below collapsed to zero — out of step with the rest
+  of the layout. It's now wrapped in `.grid` like the chart above it, restoring even spacing.
 - **Dashboard "Current Tier" no longer overstates your XvB tier on a hashrate drop** (#157). The XvB
   raffle qualifies a tier on **both** the 1h and 24h credited average (and terminates a win if the 1h
   drops below the round minimum), but the dashboard resolved Current Tier from the 24h average alone.

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -434,7 +434,9 @@ function DashboardView({ state, ui, onRange, onSort, onView, onZoom, onResetZoom
                           onRange=${onRange} onZoom=${onZoom} onResetZoom=${onResetZoom}
                           onToggleSeries=${onToggleSeries} onAvgWindow=${onAvgWindow} />
         </div>
-        <${WorkersTable} workers=${state.workers} summary=${state.proxy_summary} ui=${ui} onSort=${onSort} />
+        <div class="grid">
+            <${WorkersTable} workers=${state.workers} summary=${state.proxy_summary} ui=${ui} onSort=${onSort} />
+        </div>
         <div class="grid">
             <${Overview} state=${state} />
             <${NodeStats} state=${state} />

--- a/pithead
+++ b/pithead
@@ -160,6 +160,11 @@ stack_upgrade() {
     load_preserved_state
     ensure_directories
     resolve_dashboard_host        # non-interactive; sets HOST_IP for the render
+    # render_env writes DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false}; load_preserved_state
+    # doesn't carry it, so re-assert it here (as apply does) — otherwise every upgrade rewrites the
+    # flag to false and the next require_deployed command (up/apply/upgrade) errors "run setup". We
+    # only reach here past require_deployed, so the stack IS deployed and the flag must stay true.
+    DEPLOYMENT_COMPLETED=true
     render_env "${ENV_FILE}.new"
     mv "${ENV_FILE}.new" "$ENV_FILE"
     inject_service_configs

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -666,6 +666,10 @@ out="$(cd "$U" && DOCKER_LOG="$UL" PATH="$U/bin:$PATH" ./pithead upgrade 2>&1)";
 assert_rc "upgrade exits 0" "$rc" "0"
 assert_eq "upgrade re-renders a missing var (STRATUM_BIND)" "$(run_sourced "$U" env_get_file "$U/.env" STRATUM_BIND)" "0.0.0.0"
 assert_eq "upgrade preserves the proxy token"               "$(run_sourced "$U" env_get_file "$U/.env" PROXY_AUTH_TOKEN)" "ORIGINALTOKEN"
+# render_env writes DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false} and load_preserved_state
+# doesn't carry it, so upgrade must re-assert it — else the flag flips to false and the NEXT
+# require_deployed command (up/apply/upgrade) errors "run setup" on an already-deployed box.
+assert_eq "upgrade preserves DEPLOYMENT_COMPLETED (require_deployed survives)" "$(run_sourced "$U" env_get_file "$U/.env" DEPLOYMENT_COMPLETED)" "true"
 assert_contains "upgrade still rebuilds images"             "$(cat "$UL")" "compose up -d --build"
 
 echo "== black-box: apply recovers from a failed 'compose up' (#125) =="


### PR DESCRIPTION
## What & why

Two bug fixes. The first surfaced while reproducing a `git pull → pithead setup → pithead upgrade` loop on the **gouda** testbench; the second is the inconsistent gap below the dashboard **Workers Alive** panel.

### 1. `pithead upgrade` no longer un-deploys an already-deployed stack
`stack_upgrade` re-renders `.env` on every run, and `render_env` writes `DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false}`. But `load_preserved_state` only carries the Tor onions, RPC creds, and proxy token — **not** `DEPLOYMENT_COMPLETED` — so the shell variable was unset and each `upgrade` silently rewrote the flag to `false`.

Blast radius (since `is_deployed` is just `grep -q "^DEPLOYMENT_COMPLETED=true"`):
- the **next** `require_deployed` command (`up` / `apply` / another `upgrade`) aborts with *"The stack isn't fully set up yet — run setup first"*
- a bare `pithead` drops into `setup` instead of showing help
- `doctor` nags *"DEPLOYMENT_COMPLETED is not true… Run 'pithead setup'"*

…which forces a needless, heavyweight `setup` (Tor re-provision, GRUB edit) before every upgrade.

**Reproduced on gouda** with the exact commands: flag went `true` → run `upgrade` → flag came back `false`.

**Fix:** `upgrade` now re-asserts `DEPLOYMENT_COMPLETED=true` before the render, mirroring what `apply` already does. It's only ever reached past `require_deployed`, so the stack is deployed by definition. Covered by a new black-box regression test in the existing `#128` upgrade block (verified to fail on the old code, pass on the fix).

### 2. Dashboard "Workers Alive" panel had no bottom gap
Every dashboard section is a `.card` wrapped in a `.grid`, and `.grid` supplies the consistent `20px` bottom margin between sections. `WorkersTable` was the **one** top-level section rendered as a bare `.card` with no `.grid` wrapper, so the space below it collapsed to `0` — out of step with the rest of the layout. Now wrapped in `.grid` exactly like the `ChartCard` above it.

## Related issue

No pre-existing issues — both are newly found. (Searched open issues; nearest are #59/#104, unrelated.)

## Checklist

- [x] `make test` passes locally (lint + dashboard pytest ≥ coverage gate + `pithead` shell suite + compose validation + selftest + fakes)
- [x] `pithead` and test scripts are shellcheck-clean (no new warnings)
- [x] Docs unchanged — both are bug fixes that restore *intended* behavior; no documented behavior changes
- [ ] ~This PR is focused on a single logical change~ — two small fixes bundled into one PR by request
- [ ] No linked issue — newly-found bugs, filed directly as fixes

## Test evidence
- `pithead` shell suite: **252 passed, 0 failed** (incl. new `upgrade preserves DEPLOYMENT_COMPLETED` assertion)
- Dashboard frontend logic: **32 passed, 0 failed**
- Full `make test`: green through all stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)