### PR TITLE
Pull-based install: wire ${STACK_VERSION} through compose + pithead pull/build mode (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   manifest** (promoted digests + upstream pins) and a pinned install bundle. Safe by construction:
   `--dry-run` previews the whole plan, it never starts the live stack on the build host, and it never
   prints the registry token. Images publish to `ghcr.io/p2pool-starter-stack/pithead-*`
-  (override via `PITHEAD_REGISTRY` / `PITHEAD_IMAGE_PREFIX`). The remaining hop for one-command
-  pull-based installs — wiring `${STACK_VERSION}` into `docker-compose.yml` — is tracked in
-  `docs/releasing.md`.
+  (override via `PITHEAD_REGISTRY` / `PITHEAD_IMAGE_PREFIX`). **Release installs pull the published
+  images — no local build:** each compose service carries an `image: …/pithead-<svc>:${STACK_VERSION}`
+  ref alongside `build:`, and pithead auto-selects the mode — a source checkout (Dockerfiles present)
+  builds locally and tags `:dev` (`--pull never`); a release bundle (no Dockerfiles, just
+  `pithead`+`VERSION`+compose+`build/tari/`) resolves `STACK_VERSION` from `VERSION` and pulls
+  `:vX.Y.Z` (`--pull missing`). So a release is `./pithead setup` with no compile wait.
 
 - **Chart hashrate-averaging-window toggle (#168).** A new **Avg** control on the dashboard chart
   plots any of xmrig-proxy's five native averaging windows — **1m / 10m / 1h / 12h / 24h**. It's

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ x-logging: &default-logging
 services:
   # --- Tor Anonymity Service ---
   tor:
+    # A source checkout builds the 5 first-party images locally from build/; a release install pulls
+    # these published images instead. pithead chooses build-vs-pull via its `--pull` policy and sets
+    # PITHEAD_REGISTRY / STACK_VERSION (export_build_provenance, #44); the defaults below keep a bare
+    # `docker compose` working (tag `:dev`).
+    image: ${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-tor:${STACK_VERSION:-dev}
     build: ./build/tor
     container_name: tor
     # Memory ceiling (#132 — see monerod). Generous so an OOM-restart, which would blip every onion
@@ -43,6 +48,7 @@ services:
   # Only starts if "local_node" profile is active
   monerod:
     profiles: ["local_node"]
+    image: ${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-monero:${STACK_VERSION:-dev}
     build: ./build/monero
     container_name: monerod
     # Memory CEILINGS (#132): cap each service so a leak/spike OOM-restarts the offender in its own
@@ -146,6 +152,7 @@ services:
 
   # --- P2Pool Node ---
   p2pool:
+    image: ${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-p2pool:${STACK_VERSION:-dev}
     build: ./build/p2pool
     container_name: p2pool
     # Memory ceiling (#132 — see monerod). RandomX HugePages are separate; this caps p2pool's own
@@ -212,6 +219,7 @@ services:
 
   # --- XMRig Proxy ---
   xmrig-proxy:
+    image: ${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-xmrig-proxy:${STACK_VERSION:-dev}
     build: ./build/xmrig-proxy
     container_name: xmrig-proxy
     # Memory ceiling (#132 — see monerod). Tiny in practice (~2 MiB observed).
@@ -280,6 +288,7 @@ services:
 
   # --- Monitoring Dashboard ---
   dashboard:
+      image: ${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-dashboard:${STACK_VERSION:-dev}
       build:
         context: ./build/dashboard
         # Stack version baked into the image so the dashboard header can show it (Issue #58).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -155,11 +155,17 @@ What exists today:
   assets, never starts the live stack on the build host, and never prints the registry token.
   Preview any run with `make release ARGS="--dry-run"`.
 
+- ✅ **Pull-based install — `${STACK_VERSION}` wired through `docker-compose.yml`.** Each first-party
+  service now carries an `image: ${PITHEAD_REGISTRY:-…}/pithead-<svc>:${STACK_VERSION:-dev}` ref
+  alongside its `build:`. pithead picks build-vs-pull automatically: a **source checkout** (the image
+  Dockerfiles are present) builds locally and tags `:dev` with `--pull never`; a **release install**
+  (the bundle ships no Dockerfiles, just `pithead` + `VERSION` + compose + `build/tari/`'s template)
+  resolves `STACK_VERSION` to `vX.Y.Z` and **pulls** the published images (`--pull missing`; `upgrade`
+  forces a re-pull). Override with `PITHEAD_REGISTRY` / `PITHEAD_PULL`. So a release is now
+  `cp config.advanced.example.json config.json && ./pithead setup` — no local build.
+
 **Remaining:**
 
-- ⬜ Wiring `${STACK_VERSION}` through `docker-compose.yml` so a release install *pulls* the
-  published images instead of building them (the script publishes the images and a bundle today; the
-  compose `image:` refs are the last hop for the one-command pull UX).
 - ⬜ The dashboard "new version available" update warning
   ([#59](https://github.com/p2pool-starter-stack/pithead/issues/59)), which builds on the
   version badge — tracked separately.

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 467 dashboard unit tests · 12 contract tests · 30 frontend
-tests · 36 `pithead` shell sections · 15 harness self-test sections ·
+tests · 37 `pithead` shell sections · 15 harness self-test sections ·
 8 live config scenarios (15 axis values) · 6 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 36 `pithead` shell sections · 15 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 467 |
 | 1 — Unit | frontend (node --test) | 30 |
-| 1 — Unit | `pithead` shell suite | 36 sections |
+| 1 — Unit | `pithead` shell suite | 37 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 6 |
@@ -572,7 +572,7 @@ tests · 36 `pithead` shell sections · 15 harness self-test sections ·
 - bandBorderWidth: zero-height segments get no border, real ones keep full width
 - uptimeCell: online shows uptime, offline shows DOWN
 
-### `pithead` shell suite (tests/stack/run.sh) — 36 sections
+### `pithead` shell suite (tests/stack/run.sh) — 37 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -585,6 +585,7 @@ tests · 36 `pithead` shell sections · 15 harness self-test sections ·
 - unit: generate_caddyfile scheme (#140)
 - unit: host detection (#140)
 - unit: release.sh pure logic (#44)
+- unit: pull-vs-build mode (#44)
 - unit: explain_subnet_collision (#180)
 - unit: env helpers
 - unit: export_build_provenance (Issue #58)
@@ -743,5 +744,5 @@ tests · 36 `pithead` shell sections · 15 harness self-test sections ·
 
 ---
 
-_Grand total: **574** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **575** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/pithead
+++ b/pithead
@@ -112,12 +112,28 @@ explain_subnet_collision() {
     esac
 }
 
+# A source checkout has the image build CONTEXTS (Dockerfiles) and builds the first-party images
+# locally; a release install ships only the runtime bits (compose, pithead, and build/tari/'s config
+# template that inject_service_configs renders at setup) and pulls the published images. Key off a
+# Dockerfile, NOT `build/` — a release bundle still contains build/tari/, so `[ -d build ]` is true (#44).
+is_source_checkout() { [ -f build/dashboard/Dockerfile ]; }
+
+# `docker compose up` pull policy (#44): a source checkout builds the first-party images locally —
+# `never`, so up doesn't attempt (and warn about) a registry pull for an unpublished `:dev` tag —
+# while a release install pulls them: `missing`. Override with PITHEAD_PULL (e.g. `always` to force a
+# re-pull on upgrade).
+resolve_pull_policy() {
+    if [ -n "${PITHEAD_PULL:-}" ]; then printf '%s' "$PITHEAD_PULL"
+    elif is_source_checkout; then printf 'never'
+    else printf 'missing'; fi
+}
+
 # Run `docker compose up` with live output; on failure, explain a bridge-subnet collision (#180) if
 # that's what Docker rejected. Returns compose's own exit code.
 compose_up_checked() {
     local tmp out rc
     tmp="$(mktemp)"
-    docker compose up "$@" 2>&1 | tee "$tmp"
+    docker compose up --pull "$(resolve_pull_policy)" "$@" 2>&1 | tee "$tmp"
     rc=${PIPESTATUS[0]}
     out="$(cat "$tmp")"; rm -f "$tmp"
     [ "$rc" -ne 0 ] && explain_subnet_collision "$out"
@@ -171,8 +187,12 @@ stack_upgrade() {
     generate_caddyfile
     log "Re-rendered generated config for the current release."
     migrate_compose_project
-    if ! compose_up_checked -d --build; then
-        error "Upgrade failed during 'docker compose up' — see the error above."
+    # Source checkout: rebuild the images from build/. Release install: pull the new published images
+    # instead — force a re-pull so a moved tag is refreshed (#44).
+    if is_source_checkout; then
+        compose_up_checked -d --build || error "Upgrade failed during 'docker compose up' — see the error above."
+    else
+        PITHEAD_PULL=always compose_up_checked -d || error "Upgrade failed during 'docker compose up' — see the error above."
     fi
     log "Stack upgraded."
 }
@@ -576,7 +596,7 @@ reset_dashboard() {
     sudo chmod -R 755 "$p2pool_dir/stats"
 
     log "Bringing services back up..."
-    docker compose up -d dashboard p2pool
+    docker compose up --pull "$(resolve_pull_policy)" -d dashboard p2pool
 }
 
 # --- Backup / Restore ---
@@ -843,6 +863,19 @@ export_build_provenance() {
             commit="${commit}-dirty"
         fi
         PITHEAD_GIT_COMMIT="$commit"
+    fi
+
+    # Image coordinates for docker-compose's `image:` refs (#44). A source checkout (build/ present)
+    # builds the first-party images locally and tags them `:dev`; a release install (no build/, just
+    # the published bundle) pulls `:vX.Y.Z` from the registry. PITHEAD_REGISTRY honours an env override.
+    export PITHEAD_REGISTRY STACK_VERSION
+    PITHEAD_REGISTRY="${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}"
+    if is_source_checkout; then
+        STACK_VERSION="dev"
+    elif [ -n "$PITHEAD_VERSION" ]; then
+        STACK_VERSION="v$PITHEAD_VERSION"
+    else
+        STACK_VERSION="dev"
     fi
 }
 
@@ -1509,7 +1542,7 @@ resolve_dashboard_host() {
 
 provision_tor() {
     log "Initializing Tor service to generate Onion addresses..."
-    docker compose up -d tor
+    docker compose up --pull "$(resolve_pull_policy)" -d tor
     # Poll for the three hidden-service hostname files instead of a fixed sleep — Tor can take
     # more or less than 15s to publish them, especially on first run.
     log "Waiting for Tor hidden services to be generated..."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -364,14 +364,17 @@ write_manifest() {
     log "Wrote ingredients manifest: $out"
 }
 
-# A pinned install bundle: compose + example config + the manifest, with the resolved STACK_VERSION.
+# A pinned, pull-based install bundle: the runtime files needed to `./pithead setup` WITHOUT building.
+# Deliberately ships NO image Dockerfiles — so pithead detects release mode (is_source_checkout=false),
+# resolves STACK_VERSION from the bundled VERSION, and pulls the published `:vX.Y.Z` images. build/tari/'s
+# config template IS included because inject_service_configs renders it at setup.
 make_bundle() {
     local out="$1" d="$WORKDIR/pithead-$TAG"
-    mkdir -p "$d"
-    cp docker-compose.yml config.advanced.example.json "$d/" 2>/dev/null || true
-    printf 'STACK_VERSION=%s\n' "$TAG" > "$d/.env.release"
-    printf 'Pithead %s — pinned install bundle.\n\nQuick start:\n  1. cp config.advanced.example.json config.json  (set your wallet addresses)\n  2. export STACK_VERSION=%s\n  3. docker compose pull && ./pithead setup\n\nImages are pulled from %s (no local build).\n' \
-        "$TAG" "$TAG" "$REGISTRY" > "$d/README.txt"
+    mkdir -p "$d/build/tari"
+    cp pithead VERSION docker-compose.yml config.advanced.example.json "$d/" 2>/dev/null || true
+    cp build/tari/config.toml.template "$d/build/tari/" 2>/dev/null || true
+    printf 'Pithead %s — pinned install bundle (images pulled from %s, no local build).\n\nQuick start:\n  1. cp config.advanced.example.json config.json   # then set your wallet addresses\n  2. ./pithead setup\n\nThere are no build contexts here, so pithead pulls the published %s images instead of building.\n' \
+        "$TAG" "$REGISTRY" "$TAG" > "$d/README.txt"
     if [ "$DRY_RUN" -eq 1 ]; then printf '   %s[dry-run]%s would tar -> %s\n' "$C_YELLOW" "$C_RESET" "$out"; return 0; fi
     tar -czf "$out" -C "$WORKDIR" "pithead-$TAG"
     log "Wrote install bundle: $out"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -266,6 +266,27 @@ ver_file="$(tr -d ' \t\r\n' < "$ROOT/VERSION")"
 ver_pyproject="$(grep -oE '^version = "[^"]+"' "$ROOT/build/dashboard/pyproject.toml" | head -1 | cut -d'"' -f2)"
 assert_eq "pyproject.toml version matches VERSION (#44)" "$ver_pyproject" "$ver_file"
 
+echo "== unit: pull-vs-build mode (#44) =="
+# is_source_checkout / resolve_pull_policy / STACK_VERSION key off whether the image build CONTEXTS
+# (Dockerfiles) are present: a source checkout builds locally (:dev, --pull never); a release bundle
+# (only build/tari/ + VERSION) pulls (:vX.Y.Z, --pull missing). Two scratch dirs stand in for each.
+SRCM="$SANDBOX/srcmode"; mkdir -p "$SRCM/build/dashboard"; : > "$SRCM/build/dashboard/Dockerfile"; printf '0.1.0\n' > "$SRCM/VERSION"
+RELM="$SANDBOX/relmode"; mkdir -p "$RELM/build/tari"; printf '0.1.0\n' > "$RELM/VERSION"
+# shellcheck disable=SC1090
+( cd "$SRCM" || exit; set --; source "$STACK" 2>/dev/null; set +eu; is_source_checkout ); assert_rc "is_source_checkout true with a Dockerfile" "$?" "0"
+# shellcheck disable=SC1090
+( cd "$RELM" || exit; set --; source "$STACK" 2>/dev/null; set +eu; is_source_checkout ); assert_rc "is_source_checkout false without a Dockerfile" "$?" "1"
+# shellcheck disable=SC1090
+assert_eq "pull policy: source -> never"      "$( cd "$SRCM" || exit; set --; source "$STACK" 2>/dev/null; set +eu; resolve_pull_policy )" "never"
+# shellcheck disable=SC1090
+assert_eq "pull policy: release -> missing"   "$( cd "$RELM" || exit; set --; source "$STACK" 2>/dev/null; set +eu; resolve_pull_policy )" "missing"
+# shellcheck disable=SC1090
+assert_eq "pull policy: PITHEAD_PULL override" "$( cd "$SRCM" || exit; set --; source "$STACK" 2>/dev/null; set +eu; PITHEAD_PULL=always resolve_pull_policy )" "always"
+# shellcheck disable=SC1090
+assert_eq "STACK_VERSION dev in a source checkout"   "$( cd "$SRCM" || exit; set --; source "$STACK" 2>/dev/null; set +eu; export_build_provenance; printf '%s' "$STACK_VERSION" )" "dev"
+# shellcheck disable=SC1090
+assert_eq "STACK_VERSION v0.1.0 in a release bundle" "$( cd "$RELM" || exit; set --; source "$STACK" 2>/dev/null; set +eu; export_build_provenance; printf '%s' "$STACK_VERSION" )" "v0.1.0"
+
 echo "== unit: explain_subnet_collision (#180) =="
 ov="$(run_sourced "$SANDBOX" explain_subnet_collision "invalid pool request: Pool overlaps with other one on this address space" 2>&1)"
 assert_contains "subnet overlap -> network.subnet hint"  "$ov" "network"
@@ -472,7 +493,7 @@ assert_rc "apply without .env fails" "$rc" "1"
 assert_contains "apply needs setup" "$out" "setup"
 
 echo "== black-box: config validation =="
-V="$SANDBOX/val"; mkdir -p "$V/build/tari"; cp "$STACK" "$V/pithead"; make_stubs "$V/bin"
+V="$SANDBOX/val"; mkdir -p "$V/build/tari" "$V/build/dashboard"; : > "$V/build/dashboard/Dockerfile"; cp "$STACK" "$V/pithead"; make_stubs "$V/bin"
 cp "$ROOT/build/tari/config.toml.template" "$V/build/tari/"
 mkdir -p "$V/data/monero" "$V/data/tari" "$V/data/p2pool" "$V/data/tor" "$V/data/dashboard" "$V/data/p2pool/stats"
 seed_env() { cat > "$V/.env" <<EOF
@@ -606,7 +627,7 @@ assert_eq "donate-level 0 by default (no fee)"  "$(run_sourced "$V" env_get_file
 # Build provenance is exported for the build args, not persisted to .env (Issue #58) — so a git pull
 # never shows up as a config change. Assert it stays out of the rendered .env.
 assert_eq "provenance not written to .env" "$(run_sourced "$V" env_get_file "$V/.env" PITHEAD_VERSION)" ""
-assert_contains "compose up called" "$(cat "$DOCKER_LOG")" "compose up -d --remove-orphans"
+assert_contains "compose up called (build mode)" "$(cat "$DOCKER_LOG")" "compose up --pull never -d --remove-orphans"
 
 # Regression (Issue #58): a second apply with nothing changed must report no changes and exit 0
 # cleanly — never tripping the ERR trap. (Provenance keys briefly leaked into this diff; when they
@@ -682,7 +703,7 @@ assert_eq "remote creds not persisted" "$(jq -r '.monero.node_username' "$V/conf
 echo "== black-box: upgrade re-renders generated config (#128) =="
 # `upgrade` used to be just `up --build`, leaving the generated .env/Caddyfile/Tari config stale
 # after a git pull. It must now re-render them while preserving secrets.
-U="$SANDBOX/upgrade"; mkdir -p "$U/build/tari" "$U/data/monero" "$U/data/tari" "$U/data/p2pool/stats" "$U/data/tor" "$U/data/dashboard"
+U="$SANDBOX/upgrade"; mkdir -p "$U/build/tari" "$U/build/dashboard" "$U/data/monero" "$U/data/tari" "$U/data/p2pool/stats" "$U/data/tor" "$U/data/dashboard"; : > "$U/build/dashboard/Dockerfile"
 cp "$STACK" "$U/pithead"; make_stubs "$U/bin"; cp "$ROOT/build/tari/config.toml.template" "$U/build/tari/"
 # Stale .env: secrets present, but STRATUM_BIND (a rendered var) is missing — the upgrade must fill it.
 cat > "$U/.env" <<EOF
@@ -704,11 +725,12 @@ assert_eq "upgrade preserves the proxy token"               "$(run_sourced "$U" 
 # doesn't carry it, so upgrade must re-assert it — else the flag flips to false and the NEXT
 # require_deployed command (up/apply/upgrade) errors "run setup" on an already-deployed box.
 assert_eq "upgrade preserves DEPLOYMENT_COMPLETED (require_deployed survives)" "$(run_sourced "$U" env_get_file "$U/.env" DEPLOYMENT_COMPLETED)" "true"
-assert_contains "upgrade still rebuilds images"             "$(cat "$UL")" "compose up -d --build"
+assert_contains "upgrade still rebuilds images (source mode)" "$(cat "$UL")" "compose up --pull never -d --build"
 
 echo "== black-box: apply recovers from a failed 'compose up' (#125) =="
 # A docker stub that fails `compose up -d --remove-orphans` only when FAIL_UP=1 (else succeeds).
-A="$SANDBOX/applyfail"; mkdir -p "$A/build/tari" "$A/bin" "$A/data/monero" "$A/data/tari" "$A/data/p2pool/stats" "$A/data/tor" "$A/data/dashboard"
+A="$SANDBOX/applyfail"; mkdir -p "$A/build/tari" "$A/build/dashboard" "$A/bin" "$A/data/monero" "$A/data/tari" "$A/data/p2pool/stats" "$A/data/tor" "$A/data/dashboard"
+: > "$A/build/dashboard/Dockerfile"   # source-checkout marker → pithead builds (--pull never), #44
 cp "$STACK" "$A/pithead"; cp "$ROOT/build/tari/config.toml.template" "$A/build/tari/"
 cat > "$A/bin/docker" <<'EOF'
 #!/usr/bin/env bash
@@ -718,7 +740,7 @@ case "$*" in
   "exec tor cat /var/lib/tor/monero/hostname") echo "mona.onion"; exit 0 ;;
   "exec tor cat /var/lib/tor/tari/hostname")   echo "taria.onion"; exit 0 ;;
   "exec tor cat /var/lib/tor/p2pool/hostname") echo "p2pa.onion"; exit 0 ;;
-  "compose up -d --remove-orphans") [ "${FAIL_UP:-0}" = "1" ] && exit 1 || exit 0 ;;
+  "compose up --pull never -d --remove-orphans") [ "${FAIL_UP:-0}" = "1" ] && exit 1 || exit 0 ;;
 esac
 exit 0
 EOF


### PR DESCRIPTION
**Closes #44.** Completes the release-engineering goal — *"no more git pull + rebuild"* — by making a release install **pull** the published images instead of building them. This is the remaining hop after #221 shipped the publishing pipeline.

## How it works

Each first-party service now carries an `image:` ref alongside its `build:`:

```yaml
image: ${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-<svc>:${STACK_VERSION:-dev}
build: ./build/<svc>
```

pithead picks **build vs pull automatically**, keyed on whether the image Dockerfiles are present:

| | source checkout (Dockerfiles present) | release bundle (no Dockerfiles) |
|---|---|---|
| `STACK_VERSION` | `dev` | `vX.Y.Z` (from `VERSION`) |
| `compose up` | `--pull never` → **builds** locally | `--pull missing` → **pulls** |
| `upgrade` | `--build` | `--pull always` (re-pull) |

Override with `PITHEAD_REGISTRY` / `PITHEAD_PULL`. The release bundle (`make_bundle`) ships the runtime set — `pithead` + `VERSION` + compose + `build/tari/`'s config template — and **no Dockerfiles**, so it auto-detects release mode. A release is now `cp config.advanced.example.json config.json && ./pithead setup` — no compile wait.

## Why `--pull never` for dev

Empirically (validated locally **and on gouda, Compose v5.1.4**): a service with both `build:` and `image:` on `docker compose up` tries to **pull first, then falls back to build**. For a dev checkout that means a noisy failed-pull of the unpublished `:dev` tag before building — so source mode uses `--pull never` (builds directly, no noise), and release mode uses `--pull missing` (pulls). Both behaviours confirmed on gouda.

## Safety / no dev regression

- `pithead up`/`apply` in a **source checkout** still build (`--pull never`) — verified on gouda + by the suite.
- The gouda check ran in a throwaway dir; the real deployment was untouched.

## Tests

- **7 new unit tests**: `is_source_checkout`, `resolve_pull_policy` (source/release/`PITHEAD_PULL` override), `STACK_VERSION` (dev vs `v0.1.0`).
- The existing apply/upgrade sandboxes now carry a stub Dockerfile to stay source-mode; their compose-up assertions include `--pull never`, and the failure-injection stub matches the new form.
- Shell suite **260 → 268**; `make test-compose` green (image refs render); full local suite green; lint clean.

## Docs
`docs/releasing.md` (pull-install now ✅) + `CHANGELOG.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)