### PR TITLE
docs: correct disk requirements to real usage — Tari ~135 GB, chains grow ~100+ GB/yr (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ chmod +x pithead
 ./pithead setup
 ```
 
-> **Prereqs:** Ubuntu Server **24.04 LTS**, **16 GB+ RAM**, an **SSD** (~150 GB pruned / ~300 GB
-> full), and your **Monero + Tari payout addresses** handy — full sizing in
-> [Hardware Requirements](docs/hardware.md).
+> **Prereqs:** Ubuntu Server **24.04 LTS**, **16 GB+ RAM**, an **SSD** (~300 GB pruned / ~500 GB
+> full minimum — the chains grow ~100+ GB/year, so 2–4 TB is the set-and-forget choice), and your
+> **Monero + Tari payout addresses** handy — full sizing in [Hardware Requirements](docs/hardware.md).
 
 `setup` checks dependencies (and offers to install them on Ubuntu), asks for your wallet
 addresses, provisions Tor, tunes the kernel for RandomX, and offers to start the stack. Then:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -120,8 +120,9 @@ connect to a node you run elsewhere (it must have ZMQ publishing enabled for P2P
 
 ### What hardware do I need?
 
-Plan for **16 GB+ RAM**, a CPU with **AVX2** for RandomX, and an **SSD** (~150 GB pruned /
-~300 GB full). Full minimum-vs-recommended sizing for the stack host is in
+Plan for **16 GB+ RAM**, a CPU with **AVX2** for RandomX, and an **SSD** (~300 GB pruned /
+~500 GB full minimum — Tari's chain alone is ~135 GB, and both chains grow ~100+ GB/year, so a
+**2–4 TB** drive is the set-and-forget choice). Full minimum-vs-recommended sizing for the stack host is in
 [Hardware Requirements](hardware.md). (Miner hardware is sized separately in
 [RigForge](https://github.com/p2pool-starter-stack/rigforge).)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ driven by a single script — `pithead` — and most of it is automated.
 | **Operating system** | Ubuntu Server **24.04 LTS** is the officially supported platform. Other Linux distributions and macOS may work but aren't officially supported. |
 | **CPU** | A processor with **AVX2** support is highly recommended for RandomX performance. |
 | **RAM** | **16 GB** minimum with HugePages enabled (~6 GB is reserved for RandomX); **32 GB** recommended for a full node or long uptimes. |
-| **Disk** | A **pruned** Monero node needs ~**80–100 GB** and a **full** one **200 GB+**, plus ~**50 GB** for the Tari node — so plan for ~**150 GB** (pruned) or ~**300 GB** (full) of **SSD**, with room to grow. |
+| **Disk** | A **pruned** Monero node needs ~**100 GB** and a **full** one ~**265 GB**, plus ~**135 GB** for the Tari node (its chain is the biggest single consumer) — so plan for **~300 GB** (pruned) or **~500 GB** (full) of **SSD** minimum. Both chains grow ~**100+ GB/year**, so a **2–4 TB** drive is the set-and-forget choice. |
 | **Software** | Docker Engine, Docker Compose V2, `jq`, and `openssl`. |
 
 > 📐 **Full sizing guidance** for the stack host — minimum vs. recommended specs, plus ways to run
@@ -29,8 +29,8 @@ driven by a single script — `pithead` — and most of it is automated.
 > [RigForge](https://github.com/p2pool-starter-stack/rigforge).
 
 > 🔎 **`setup` checks this for you.** Before it starts anything, `pithead setup` runs a best-effort
-> pre-flight on free disk and total RAM. If either is below the recommended minimums (~150 GB
-> pruned / ~300 GB full disk, 16 GB RAM), it prints a **warning** — but it never blocks setup, so
+> pre-flight on free disk and total RAM. If either is below the recommended minimums (~300 GB
+> pruned / ~500 GB full disk, 16 GB RAM), it prints a **warning** — but it never blocks setup, so
 > you can proceed on a smaller host at your own risk. See **[Hardware Requirements](hardware.md)**.
 
 You don't have to install the software dependencies yourself. `setup` checks for them and, **on

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -25,8 +25,8 @@ Size the **host** for nodes, storage, and uptime; size the **workers** for CPU m
 |---|---|---|
 | **CPU** | 4 cores, 64-bit x86 (AVX2 advised) | 6–8+ cores with **AVX2** |
 | **RAM** | **16 GB** | **32 GB** |
-| **Disk — pruned node** | ~150 GB SSD | 300 GB+ SSD |
-| **Disk — full node** | ~300 GB SSD | 600 GB+ SSD |
+| **Disk — pruned node** | ~300 GB SSD | 1 TB+ SSD |
+| **Disk — full node** | ~500 GB SSD | 2 TB+ SSD |
 | **Network** | Always-on broadband | Unmetered broadband |
 | **OS** | Ubuntu Server **24.04 LTS** | Ubuntu Server 24.04 LTS |
 
@@ -42,15 +42,25 @@ from each project's own guidance:
 
 | Service | RAM it wants | Disk | Notes |
 |---|---|---|---|
-| **[Monero node](https://docs.getmonero.org/running-node/)** (`monerod`) | **4 GB** minimum; more RAM = bigger DB cache and faster sync | **~95 GB** pruned · **~230 GB** full — and growing | SSD strongly recommended. Not run at all in remote-node mode. |
+| **[Monero node](https://docs.getmonero.org/running-node/)** (`monerod`) | **4 GB** minimum; more RAM = bigger DB cache and faster sync | **~100 GB** pruned · **~265 GB** full — and growing | SSD strongly recommended. Not run at all in remote-node mode. |
 | **[P2Pool](https://github.com/SChernykh/p2pool)** | **~2.3 GB** for the RandomX dataset it uses to verify blocks fast (`--light-mode` skips it, saving ~2 GB, but verifies slower) | tiny (sidechain state) | Needs a 64-bit CPU with **AVX2** and a synced `monerod`. |
-| **[Tari base node](https://www.tari.com/integration-guide)** (`minotari_node`) | **4 GB** minimum, **8 GB+** recommended; grows over time | **50 GB+** SSD | Light enough to run on a Raspberry Pi; the stack caps its memory so growth can't take the host down. |
+| **[Tari base node](https://www.tari.com/integration-guide)** (`minotari_node`) | **4 GB** minimum, **8 GB+** recommended; grows over time | **~135 GB** SSD — and growing | **The single largest disk consumer** — Tari's chain rivals a *full* Monero node, so budget for it whether or not you prune Monero. The stack caps its memory so growth can't take the host down. |
 | **XMRig proxy · Tor · Caddy · dashboard · Docker** | a few hundred MB combined | a few GB (Docker images) | These coordinate and serve the UI — they don't mine, so no special CPU. |
 
-Add the three heavy services together — Monero (4 GB), P2Pool (~2.3 GB), Tari (4 GB) — plus a
-couple of GB for the OS, page cache, and supporting containers, and you land on the **16 GB / ~150 GB
-minimum** above. Double the RAM and disk so Monero gets a roomier cache and both chains have space
-to grow, and you reach the **32 GB / 300 GB recommendation**.
+Add the three heavy services' RAM — Monero (4 GB), P2Pool (~2.3 GB), Tari (4 GB) — plus a couple of
+GB for the OS, page cache, and supporting containers, and you land on the **16 GB minimum** above.
+
+**Disk is dominated by the two chains.** A pruned Monero node (~100 GB) **plus the Tari node
+(~135 GB)** and a few GB for P2Pool and the OS put a pruned host near **~250 GB today**; a
+*full* Monero node (~265 GB) instead of pruned pushes that toward **~400 GB**. The surprise for most
+people is **Tari** — its chain rivals a full Monero node, so pruning Monero doesn't shrink it. (A
+*freshly synced* pruned node is ~100 GB, but **pruning an existing full chain doesn't reclaim the
+space until you compact it** — `mdb_copy -c` — so until then it sits at full size.)
+
+**Both chains keep growing — roughly ~100+ GB/year combined** (Tari, a young chain, grows fastest;
+Monero adds tens of GB/year). That's why the table above lists a **~300 GB (pruned) / ~500 GB (full)
+minimum** but recommends much more: for a **set-and-forget host, put it on a 2–4 TB SSD** and you
+won't think about disk for years. (Current sizes are measured on live deployments, not estimates.)
 
 > **Heads-up on RandomX RAM:** Monero and P2Pool both want large memory pages for RandomX, so they
 > share **one ~6 GB HugePages reservation** rather than each adding their own — see
@@ -97,17 +107,21 @@ and the node databases do a lot of random I/O that punishes spinning disks. What
 
 | | Pruned (default) | Full (`monero.prune: false`) |
 |---|---|---|
-| Monero chain | ~80–100 GB | 200 GB+ |
-| Tari chain | 50 GB+ | 50 GB+ |
+| Monero chain | ~100 GB | ~265 GB |
+| Tari chain | ~135 GB | ~135 GB |
 | P2Pool + dashboard + Docker images | a few GB | a few GB |
-| **Plan for** | **~150 GB+ SSD** | **~300 GB+ SSD** |
+| **Plan for** | **~300 GB+ SSD** | **~500 GB+ SSD** |
 
-Both chains **keep growing**, so leave headroom — the *recommended* sizes above (300 GB pruned /
-600 GB full) exist for exactly that. Pruning (the default) keeps a fully validating Monero node at a
-fraction of the size and is the right choice for almost everyone.
+Both chains **keep growing — ~100+ GB/year combined** (Tari, a young chain, grows fastest), so leave
+plenty of headroom: the *recommended* **1 TB+ (pruned) / 2 TB+ (full)** sizes exist for exactly that,
+and a **2–4 TB SSD** is the true set-and-forget choice — you won't revisit disk for years. Note that
+**Tari's chain (~135 GB) is the largest single item** and is the same whether or not you prune
+Monero, so pruning only saves disk on the Monero side.
+Pruning (the default) keeps a fully validating Monero node at a fraction of the size and is the
+right choice for almost everyone.
 
 > **`setup` pre-flights these.** Before committing to a sync, `./pithead setup` checks free disk and
-> total RAM against the minimums on this page (~150 GB pruned / ~300 GB full disk, 16 GB RAM) and
+> total RAM against the minimums on this page (~300 GB pruned / ~500 GB full disk, 16 GB RAM) and
 > **warns** if the host falls short — it never blocks. `./pithead doctor` re-runs the same disk and
 > RAM checks on demand, so you can re-verify a host at any time.
 
@@ -120,8 +134,8 @@ You can put any service's data on a dedicated disk by pointing its `*.data_dir` 
 - **Always-on broadband.** All upstream traffic (Monero, Tari, P2Pool) goes over **Tor**, with **no
   public port forwarding** required — the stack uses hidden services for inbound peers.
 - **Initial sync is the heavy part.** The first run downloads and verifies both chains over Tor
-  (slower than clearnet): tens of GB pruned, ~200 GB+ for a full Monero node. This can take anywhere
-  from a few hours to a day or more. You can avoid it by
+  (slower than clearnet): ~100 GB pruned / ~265 GB full for Monero, plus ~135 GB for Tari. This can
+  take anywhere from a few hours to a day or more. You can avoid it by
   [reusing an existing synced node](configuration.md#reusing-an-existing-node).
 - **Steady state is light.** Once synced, bandwidth is modest.
 - **LAN reachability for workers.** Each worker rig connects to the host on **port 3333** over your
@@ -150,7 +164,7 @@ away:
 
 | Want to… | Do this | Saves |
 |---|---|---|
-| Skip the Monero node entirely | **Remote-node mode** (`monero.mode: remote`) — the bundled `monerod` isn't started | ~80–200 GB disk + Monero's 4 GB RAM/CPU |
+| Skip the Monero node entirely | **Remote-node mode** (`monero.mode: remote`) — the bundled `monerod` isn't started | ~100–265 GB disk + Monero's 4 GB RAM/CPU |
 | Skip the initial sync wait | [Reuse an existing synced chain](configuration.md#reusing-an-existing-node) | Hours–days + sync bandwidth |
 | Free the 6 GB HugePages reservation | `./pithead setup --skip-optimize` | ~6 GB RAM (at the cost of RandomX performance) |
 | Free RAM for other apps | Lower `tari.mem_limit` (e.g. `"4g"`) | Caps Tari's ceiling lower |

--- a/pithead
+++ b/pithead
@@ -1900,13 +1900,16 @@ prompt_start_stack() {
 
 # Per-component free-disk requirement in GiB — the single source of truth for the stack's disk
 # budget, shared by setup's preflight_resources and doctor's Disk check. Monero (the blockchain) is
-# pruning-aware: ~95 GiB pruned, ~230 GiB full. The rest are fixed. Summed, this is ~150 GiB pruned
-# / ~288 GiB full, matching the documented ~150 GB pruned / ~300 GB full headline (docs/hardware.md).
+# pruning-aware: ~120 GiB pruned, ~320 GiB full. Tari's chain is the other heavyweight — ~170 GiB and
+# growing fast. Summed, this is ~300 GiB pruned / ~500 GiB full, the documented minimum
+# (docs/hardware.md). These carry generous growth headroom over usage measured on live nodes
+# (Monero pruned ~100 GiB / full ~265 GiB, Tari ~135 GiB) because both chains grow ~100+ GiB/year
+# combined — for a set-and-forget host the docs recommend a 2–4 TB drive.
 # Args: <component> [<prune>] where prune (1 = on, 0 = off) only matters for "monero". Prints GiB.
 disk_component_gib() {
     case "$1" in
-        monero)    if [ "${2:-1}" -eq 1 ] 2>/dev/null; then echo 95; else echo 230; fi ;;
-        tari)      echo 50 ;;
+        monero)    if [ "${2:-1}" -eq 1 ] 2>/dev/null; then echo 120; else echo 320; fi ;;
+        tari)      echo 170 ;;
         p2pool)    echo 5 ;;
         dashboard) echo 2 ;;
         tor)       echo 1 ;;

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -392,9 +392,9 @@ run_grub append_grub_boot_params "$g"; assert_rc "insert: no active line -> rc 1
 assert_eq "insert: leaves file unchanged when no active line" "$(cat "$g")" "$before"
 
 echo "== unit: disk_component_gib =="
-assert_eq "monero pruned -> 95"  "$(run_sourced "$SANDBOX" disk_component_gib monero 1)" "95"
-assert_eq "monero full -> 230"   "$(run_sourced "$SANDBOX" disk_component_gib monero 0)" "230"
-assert_eq "tari -> 50"           "$(run_sourced "$SANDBOX" disk_component_gib tari)"     "50"
+assert_eq "monero pruned -> 120" "$(run_sourced "$SANDBOX" disk_component_gib monero 1)" "120"
+assert_eq "monero full -> 320"   "$(run_sourced "$SANDBOX" disk_component_gib monero 0)" "320"
+assert_eq "tari -> 170"          "$(run_sourced "$SANDBOX" disk_component_gib tari)"     "170"
 assert_eq "tor -> 1"             "$(run_sourced "$SANDBOX" disk_component_gib tor)"      "1"
 
 echo "== unit: check_disk_grouped (mocked df) =="
@@ -419,27 +419,27 @@ DM="$DISK/data"; mkdir -p "$DM/monero" "$DM/tari" "$DM/p2pool" "$DM/dashboard" "
 md="$DM/monero" td="$DM/tari" pd="$DM/p2pool" dd="$DM/dashboard" rd="$DM/tor"
 
 # All five dirs on ONE filesystem with plenty of space -> a SINGLE grouped OK line naming every
-# component, with the combined pruned requirement (95+50+5+2+1 = 153 GB).
+# component, with the combined pruned requirement (120+170+5+2+1 = 298 GB).
 one_map="$md=/data $td=/data $pd=/data $dd=/data $rd=/data /data=/data"
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
        run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "one fs -> single line" "$(printf '%s\n' "$out" | grep -c 'Data on')" "1"
 assert_contains "single line names all components" "$out" "(monero, tari, p2pool, dashboard, tor)"
-assert_contains "single line shows combined ~153 GB" "$out" "needs ~153 GB"
+assert_contains "single line shows combined ~298 GB" "$out" "needs ~298 GB"
 assert_contains "ample space -> OK" "$out" "OK"
 
-# Same single filesystem but too small (100 GiB < 153 GiB) -> ONE WARN line.
+# Same single filesystem but too small (100 GiB < 298 GiB) -> ONE WARN line.
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=104857600 DF_AVAIL_H=100G \
        run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "one small fs -> single line" "$(printf '%s\n' "$out" | grep -c 'Data on')" "1"
-assert_contains "small fs warns below need" "$out" "below the ~153 GB"
+assert_contains "small fs warns below need" "$out" "below the ~298 GB"
 
 # Two filesystems: monero+tari on /big, the rest on /small -> ONE line per filesystem.
 two_map="$md=/big $td=/big $pd=/small $dd=/small $rd=/small /big=/big /small=/small"
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$two_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
        run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "two fs -> two lines" "$(printf '%s\n' "$out" | grep -c 'Data on')" "2"
-assert_contains "/big groups monero+tari (~145 GB)" "$out" "/big (monero, tari): 600G free — needs ~145 GB"
+assert_contains "/big groups monero+tari (~290 GB)" "$out" "/big (monero, tari): 600G free — needs ~290 GB"
 assert_contains "/small groups the small three (~8 GB)" "$out" "/small (p2pool, dashboard, tor): 600G free — needs ~8 GB"
 
 # Preflight mode is WARN-only and silent when there's enough room.


### PR DESCRIPTION
**Re-raised on its own branch.** This disk-requirements work was committed to `docs-launch-polish` *after* its PR (#230) had already merged, so it never reached main — main still shows the old `~150/300 GB` sizing and the old preflight budget. This PR puts it on a clean branch off main.

## Why
Measured on both live deployments: a **pruned** host uses ~240 GB, a **full** one ~400 GB — dominated by **Tari's chain (~135 GB)**, which the old "~50 GB" estimate badly missed. And both chains keep growing (**~100+ GB/year combined**; Tari, being young, grows fastest). Under-provisioning is a real safety gap: a full disk corrupts monerod's DB.

## Changes
- **Minimums:** ~300 GB pruned / ~500 GB full (was ~150/300). **Recommended** 1 TB+ / 2 TB+, with a **2–4 TB SSD** called out as the set-and-forget choice.
- **hardware.md:** per-component breakdown (Monero ~100 pruned / ~265 full, **Tari ~135**), the ~100+ GB/year growth, and the **prune-doesn't-compact gotcha** (pruning an existing *full* chain stays full-size on disk until `mdb_copy -c`).
- **Preflight budget** (`pithead disk_component_gib`, the source of truth for `setup`/`doctor` disk warnings): monero pruned 95→120 / full 230→320, tari 50→170 (summed ~298 GiB pruned / ~498 GiB full). **Unit + grouped disk tests updated.**
- **README / getting-started / faq:** disk prereqs updated to match.

Shell suite: **277 passed, 0 failed.** Inventory drift-guard clean.

Part of #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)