### PR TITLE
test(itest): poll monero sync panel to "done" before asserting (release-gate flake)

### DIFF
--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 500 dashboard unit tests · 12 contract tests · 31 frontend
-tests · 40 `pithead` shell sections · 16 harness self-test sections ·
+tests · 40 `pithead` shell sections · 17 harness self-test sections ·
 9 live config scenarios (17 axis values) · 6 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -21,7 +21,7 @@ tests · 40 `pithead` shell sections · 16 harness self-test sections ·
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 6 |
 | 4 — Live matrix | config scenarios | 9 (17 axis values) |
-| 4 — Live matrix | harness self-test | 16 sections |
+| 4 — Live matrix | harness self-test | 17 sections |
 
 ---
 
@@ -775,7 +775,7 @@ tests · 40 `pithead` shell sections · 16 harness self-test sections ·
 - xmrig-proxy dev-fee donate-level is explicit + live (#173)
 - xmrig-proxy stopped for failover
 
-### Harness self-test (tests/integration/selftest.sh) — 16 sections
+### Harness self-test (tests/integration/selftest.sh) — 17 sections
 - overrides_to_jq: value typing
 - resolve_overrides: prerequisite gate (never mutates the canonical chain)
 - render_scenario_config: applies overrides, stays valid JSON
@@ -787,6 +787,7 @@ tests · 40 `pithead` shell sections · 16 harness self-test sections ·
 - rx: local exec runs in the stack dir
 - api_state + jq_get: parse a fixture
 - _pred_tari_synced: gates on .sync.tari.state
+- _pred_monero_panel_done: gates on .sync.monero.state
 - _pred_pool_ready: gates on .pool.type matching expected
 - _pred_hashes_flowing: gates on stratum.total_hashes > 0
 - dispatch loop: a stdin-draining child must not skip iterations
@@ -795,5 +796,5 @@ tests · 40 `pithead` shell sections · 16 harness self-test sections ·
 
 ---
 
-_Grand total: **614** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **615** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -239,6 +239,17 @@ _pred_status_ok() { pithead status >/dev/null 2>&1; }
 # Predicate: monerod itself reports caught up (authoritative; see monero_caught_up).
 _pred_monero_synced() { monero_caught_up; }
 
+# Predicate: the dashboard's monero sync PANEL has settled to "done" — distinct from
+# _pred_monero_synced, which reads monerod's RPC directly. After a scenario's apply recreates the
+# dashboard, the panel starts at "loading" and only flips to "done" once the first monerod poll lands,
+# so we poll it rather than reading cold. A single-shot read raced that first poll and spuriously
+# failed one scenario during the v1.0.0 release gate; a genuinely stuck panel (the #180 regression)
+# never settles, so a bounded wait still catches it.
+_pred_monero_panel_done() {
+    local st; st="$(api_state)"; [ -n "$st" ] || return 1
+    [ "$(jq_get "$st" '.sync.monero.state')" = "done" ]
+}
+
 # Predicate: the sync gate has released the miner — at least one worker is online on the proxy.
 # (proxy_workers is the reliable signal; stratum.conns can read 0 on a healthy, mining box.)
 _pred_miner_running() {

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -304,8 +304,9 @@ run_scenario() {
 # The read-only assertion battery (infrastructure-level). Asserts the live running state of
 # the stack for a given config WITHOUT changing anything — so it backs both a post-apply
 # scenario check and the non-destructive `--check` mode. Calibrated against real hardware:
-# it trusts monerod's own sync flag (the dashboard's UI state reads "loading" for a synced
-# local node) and proxy_workers for mining liveness (stratum.conns can read 0 while mining).
+# monerod's own RPC sync flag is authoritative for "caught up", and (for a local node) the
+# dashboard's sync panel is polled to "done" before snapshotting — it reads "loading" until its
+# first poll lands after a restart. proxy_workers signals mining liveness (stratum.conns can read 0).
 assert_running_state() {
     local name="$1" config="$2"
     local st mode pool secure tari_req xvb rpc_lan monero_clearnet tari_clearnet
@@ -364,7 +365,11 @@ assert_running_state() {
     # 2. pithead status is green for a healthy config.
     pithead status >/dev/null 2>&1; assert_rc "status exit code is 0 (healthy)" "$?" "0"
 
-    # 3. Dashboard reachable and reading live state.
+    # 3. Dashboard reachable and reading live state. In local mode, let the monero sync panel finish
+    #    its first poll after the scenario's apply/restart before snapshotting, so step 4 sees settled
+    #    state instead of a cold "loading" (a stuck panel never settles, so the assert still catches the
+    #    #180 regression). Poll, don't sleep (issue #54).
+    [ "$mode" = "local" ] && wait_for 60 3 "monero sync panel to settle (dashboard)" _pred_monero_panel_done || true
     st="$(api_state)"
     if [ -z "$st" ]; then
         it_fail "dashboard /api/state reachable" "empty response"

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -153,6 +153,15 @@ FIXTURE='{"sync":{"monero":{"state":"done"},"tari":{"state":"loading"}}}'
 if _pred_tari_synced; then it_fail "_pred_tari_synced false when tari loading" "passed on loading"; else it_pass "_pred_tari_synced false when tari loading"; fi
 FIXTURE='{"sync":{"monero":{"state":"done"},"tari":{"state":"done"}},"monero":{"mode":"Pruned"},"pool":{"type":"Main"},"proxy_workers":2,"stratum":{"conns":2,"total_hashes":12345}}'
 
+echo "== _pred_monero_panel_done: gates on .sync.monero.state =="
+# rx is stubbed to FIXTURE above (sync.monero.state == "done").
+if _pred_monero_panel_done; then it_pass "_pred_monero_panel_done true when monero done"; else it_fail "_pred_monero_panel_done true when monero done" "returned non-zero on done"; fi
+# A still-"loading" panel must hold the settle wait — the v1.0.0 release-gate flake: a cold single-shot
+# read raced the dashboard's first poll after a restart and spuriously failed a synced node.
+FIXTURE='{"sync":{"monero":{"state":"loading"},"tari":{"state":"done"}}}'
+if _pred_monero_panel_done; then it_fail "_pred_monero_panel_done false when monero loading" "passed on loading"; else it_pass "_pred_monero_panel_done false when monero loading"; fi
+FIXTURE='{"sync":{"monero":{"state":"done"},"tari":{"state":"done"}},"monero":{"mode":"Pruned"},"pool":{"type":"Main"},"proxy_workers":2,"stratum":{"conns":2,"total_hashes":12345}}'
+
 echo "== _pred_pool_ready: gates on .pool.type matching expected =="
 if _pred_pool_ready "Main"; then it_pass "_pred_pool_ready true when pool matches"; else it_fail "_pred_pool_ready true when pool matches" "returned non-zero on Main==Main"; fi
 if _pred_pool_ready "Mini"; then it_fail "_pred_pool_ready false when pool differs" "passed on Main!=Mini"; else it_pass "_pred_pool_ready false when pool differs"; fi


### PR DESCRIPTION
## What

The #54 live integration matrix raced the dashboard's monero sync panel during the **v1.0.0 release gate** and spuriously failed 1 of 5 local scenarios — aborting the release. This hardens the assertion. **No product code is touched.**

## The flake

`assert_running_state` took a single cold `api_state` snapshot and read `.sync.monero.state` **once** (`run.sh`). After each scenario's `apply` recreates the dashboard container, that panel starts at `loading` and only flips to `done` once the dashboard completes its **first monerod poll**. `pithead status` can already be green (container up, `/api/state` answering) before that poll lands — so a fully-synced node reads `loading` if the assertion gets there first.

It did, on `local-pruned-main-xvb-off`:

```
✓ monerod reports synced (RPC)
✗ monero sync panel reads done (dashboard)   expected [done], got [loading]
```

The **other 4 local scenarios passed the identical read**, and gouda's steady-state panel reads `done` — a genuinely stuck panel (the #180 regression this assertion guards) would have failed *all* of them.

## The fix

Mirror the existing `_pred_tari_synced` treatment — poll a real readiness signal instead of reading cold (#54):

- **`lib.sh`** — new `_pred_monero_panel_done` predicate (dashboard panel; distinct from the RPC-level `_pred_monero_synced`)
- **`run.sh`** — `wait_for` the panel to settle (60s, local mode only) before snapshotting; fixed the now-stale comment that claimed the panel "reads loading for a synced local node"
- **`selftest.sh`** — cover the predicate (`done`→true, `loading`→false)
- **`docs/test-inventory.md`** — regenerated (16→17 harness self-test sections)

A genuinely stuck panel never settles, so the bounded wait still fails it — **the #180 guard is preserved, the race is gone.**

## Verification

- `shellcheck` clean · `make test` green · integration `selftest: 97 passed, 0 failed` · `make test-inventory-check` up to date
- The full live matrix re-run (part of the re-triggered release) is the end-to-end proof across apply/restart scenarios.

Found while running the v1.0.0 release; relates to #54, #180.