### PR TITLE
fix(release): bundle every ./build runtime mount, not just tari (broken monerod install)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -370,15 +370,33 @@ write_manifest() {
     log "Wrote ingredients manifest: $out"
 }
 
+# The host paths under ./build/ that docker-compose.yml MOUNTS at runtime (volumes:), as opposed to
+# build: contexts. A pull-based bundle builds nothing and the images do NOT bake these in — monerod, for
+# instance, reads /root/bitmonero.conf.template purely from this host mount — so every one MUST ship in
+# the bundle, or the container mounts an empty dir and fails to start (the v1.0.0 bundle missed monerod's
+# template this way). Matches the volume short-syntax source (between "- " and the first ":"); ignores
+# build:/context: lines so no Dockerfile lands in the bundle (which would flip is_source_checkout to true
+# and make pithead build instead of pull). Sourced + unit-tested.
+compose_build_mounts() {
+    grep -oE '^[[:space:]]*-[[:space:]]+\./build/[^:[:space:]]+:' "${1:-docker-compose.yml}" \
+        | sed -E 's/^[[:space:]]*-[[:space:]]+//; s/:$//' | sort -u
+}
+
 # A pinned, pull-based install bundle: the runtime files needed to `./pithead setup` WITHOUT building.
 # Deliberately ships NO image Dockerfiles — so pithead detects release mode (is_source_checkout=false),
-# resolves STACK_VERSION from the bundled VERSION, and pulls the published `:vX.Y.Z` images. build/tari/'s
-# config template IS included because inject_service_configs renders it at setup.
+# resolves STACK_VERSION from the bundled VERSION, and pulls the published `:vX.Y.Z` images. Every
+# ./build/* path the compose mounts at runtime (compose_build_mounts) IS shipped, so the pulled
+# containers find the config templates they render at setup.
 make_bundle() {
     local out="$1" d="$WORKDIR/pithead-$TAG"
-    mkdir -p "$d/build/tari"
+    mkdir -p "$d"
     cp pithead VERSION docker-compose.yml config.advanced.example.json "$d/" 2>/dev/null || true
-    cp build/tari/config.toml.template "$d/build/tari/" 2>/dev/null || true
+    local m
+    while IFS= read -r m; do
+        [ -e "$m" ] || { warn "bundle: compose mounts '$m' but it is missing from the tree — skipping"; continue; }
+        mkdir -p "$d/$(dirname "$m")"
+        cp -R "$m" "$d/$(dirname "$m")/"
+    done < <(compose_build_mounts docker-compose.yml)
     printf 'Pithead %s — pinned install bundle (images pulled from %s, no local build).\n\nQuick start:\n  1. cp config.advanced.example.json config.json   # then set your wallet addresses\n  2. ./pithead setup\n\nThere are no build contexts here, so pithead pulls the published %s images instead of building.\n' \
         "$TAG" "$REGISTRY" "$TAG" > "$d/README.txt"
     if [ "$DRY_RUN" -eq 1 ]; then printf '   %s[dry-run]%s would tar -> %s\n' "$C_YELLOW" "$C_RESET" "$out"; return 0; fi

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -338,6 +338,21 @@ case "$(bash "$REL" --help 2>&1)" in
     *"set -euo pipefail"*) bad "release --help stops at the comment header" "leaked the script body into --help" ;;
     *)                     ok  "release --help stops at the comment header" ;;
 esac
+# Bundle completeness: the pull-based bundle must ship every ./build/* path the compose MOUNTS at
+# runtime. A pull install builds nothing and the images don't bake these in, so a missing one mounts an
+# empty dir and breaks the container — the v1.0.0 bundle shipped without monerod's bitmonero.conf.template
+# exactly this way. compose_build_mounts derives the list make_bundle copies.
+# shellcheck disable=SC1090
+BUILD_MOUNTS="$( cd "$ROOT" || exit; set --; source "$REL" 2>/dev/null; set +eu; compose_build_mounts docker-compose.yml )"
+assert_contains "bundle ships monerod's config template" "$BUILD_MOUNTS" "./build/monero/bitmonero.conf.template"
+assert_contains "bundle ships the tari config dir"        "$BUILD_MOUNTS" "./build/tari"
+_bm_missing=""
+for _m in $BUILD_MOUNTS; do [ -e "$ROOT/$_m" ] || _bm_missing="$_bm_missing $_m"; done
+assert_eq "every compose ./build runtime mount exists in the tree" "${_bm_missing:-none}" "none"
+case "$BUILD_MOUNTS" in
+    *Dockerfile*) bad "bundle build-mounts exclude Dockerfiles" "a Dockerfile would flip the bundle pull->build mode" ;;
+    *)            ok  "bundle build-mounts exclude Dockerfiles" ;;
+esac
 # write_manifest's "- **Version:**" line starts with a dash; without `printf --` it died with
 # "printf: - : invalid option" and broke the whole publish stage. Render it and assert it survives.
 man_out="$SANDBOX/manifest.md"


### PR DESCRIPTION
## The bug (found deploying released v1.0.0)

The pull-based install bundle is broken: a `./pithead setup` from `pithead-v1.0.0.tar.gz` **can't start monerod**.

`make_bundle` hard-coded `cp build/tari/config.toml.template` and nothing else. But docker-compose.yml also bind-mounts **`./build/monero/bitmonero.conf.template`** into monerod (line 80), and the monero image does **not** bake that template in — the Dockerfile only `COPY`s `entrypoint.sh`, and the entrypoint reads the template purely from the host mount (`TEMPLATE_PATH=/root/bitmonero.conf.template`). With the file absent from the bundle, Docker mounts an **empty dir** there and `envsubst < $TEMPLATE_PATH` fails → no config → monerod won't start.

Confirmed against the published image:
```
$ docker run --rm --entrypoint sh ghcr.io/p2pool-starter-stack/pithead-monero:v1.0.0 \
    -c 'test -e /root/bitmonero.conf.template && echo PRESENT || echo ABSENT'
ABSENT
```

The bundle copied `build/tari/` explicitly but never generalized, so when the monero template mount was added later, the bundle silently went stale.

## The fix

Derive the list from the compose file instead of hard-coding:

- **`compose_build_mounts`** — lists every `./build/*` path mounted under `volumes:` (the short-syntax source before the first `:`), and deliberately **excludes** `build:`/`context:` lines so no Dockerfile lands in the bundle (which would flip `is_source_checkout` → true and make pithead build instead of pull).
- `make_bundle` copies each one. Now monerod's template **and** the full `build/tari/` dir (config template + the #234 wrapper entrypoint — also previously omitted) ship.

```
$ compose_build_mounts docker-compose.yml
./build/monero/bitmonero.conf.template
./build/tari
# bundle now contains: build/monero/bitmonero.conf.template, build/tari/config.toml.template, build/tari/entrypoint.sh
```

## Test guard (so it can't regress)

`tests/stack/run.sh` asserts the derived list includes the monerod template + tari dir, that **every** listed mount exists in the tree, and that **no Dockerfile** is ever bundled. This catches any future `./build` runtime mount that someone forgets to ship.

- `shellcheck` clean · `make test` green · inventory current

## Follow-ups (not in this PR — they touch the live release)
- The 5 GHCR `:v1.0.0` images are **private** → nobody can pull them. Need to be made public.
- Re-cut + re-attach a corrected `pithead-v1.0.0.tar.gz` to the v1.0.0 release.