### PR TITLE
docs(quickstart): release-bundle install (pull) as the quick start + config.json.template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,18 +32,15 @@ that the **system clock is NTP-synchronized** (clock skew gets shares/blocks rej
 
 ### Install / Upgrade
 
-**New install** — clone the repo (or download the `pithead-v1.0.1.tar.gz` install bundle from the GitHub Release's assets) and follow the [quickstart](docs/getting-started.md) (`./pithead setup`).
-
-**Upgrade an existing (source) checkout:**
+**Install** — download the latest release bundle (pulls the published, tested images) and run setup; see the [quickstart](docs/getting-started.md):
 
 ```sh
-git pull
-./pithead upgrade
+curl -fsSL https://github.com/p2pool-starter-stack/pithead/releases/latest/download/pithead.tar.gz | tar xz
+cd pithead && cp config.json.template config.json   # set your Monero + Tari payout addresses
+./pithead setup
 ```
 
-`./pithead upgrade` **re-renders the generated config itself** — the P2Pool v4.16 monerod settings (`out-peers`, the clearnet-window priority nodes) and the new `doctor` clock check are picked up automatically — then rebuilds and recreates only the containers that changed. **No separate `./pithead apply` is needed for this release**, and your `config.json` plus preserved secrets (Tor onions, RPC credentials, proxy token) are kept untouched. Run `./pithead apply` only when *you* edit `config.json` — e.g. to opt into the new, default-off [clearnet initial sync](docs/privacy.md). Verify afterwards with `./pithead status` and `./pithead doctor`.
-
-See [`docs/operations.md`](docs/operations.md) for the full lifecycle reference.
+**Upgrade** — re-download the bundle over your install (or `git pull` for a source checkout), then `./pithead upgrade`. It **re-renders the generated config itself** — the P2Pool v4.16 monerod settings (`out-peers`, the clearnet-window priority nodes) and the new `doctor` clock check are picked up automatically — so **no separate `./pithead apply` is needed for this release**, and your `config.json` plus preserved secrets (Tor onions, RPC credentials, proxy token) are kept untouched. Run `./pithead apply` only when *you* edit `config.json` — e.g. to opt into the new, default-off [clearnet initial sync](docs/privacy.md). See [`docs/operations.md`](docs/operations.md) for the full lifecycle reference.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,15 @@ coffee gets cold**.
 ## 🚀 Quick Start
 
 ```bash
-git clone https://github.com/p2pool-starter-stack/pithead.git
+# Grab the latest release — pulls the published, tested images (no local build)
+curl -fsSL https://github.com/p2pool-starter-stack/pithead/releases/latest/download/pithead.tar.gz | tar xz
 cd pithead
-chmod +x pithead
+cp config.json.template config.json   # then set your Monero + Tari payout addresses
 ./pithead setup
 ```
+
+> Want every tunable? Copy `config.advanced.example.json` instead. Prefer to build from source (a
+> `dev` build) — e.g. to contribute? See [Install from source](docs/getting-started.md#alternative-build-from-source).
 
 > **Prereqs:** Ubuntu Server **24.04 LTS**, **16 GB+ RAM**, an **SSD** (~300 GB pruned / ~500 GB
 > full minimum — the chains grow ~100+ GB/year, so 2–4 TB is the set-and-forget choice), and your

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Everything runs through `pithead` (`./pithead help` lists it all):
 | `./pithead setup` | First-time interactive setup. |
 | `./pithead apply` | Preview and apply `config.json` changes. |
 | `./pithead up` / `down` / `restart` | Start / stop / restart the stack. |
-| `./pithead upgrade` | Rebuild and restart after a `git pull`. |
+| `./pithead upgrade` | Re-render config, then pull (bundle) or rebuild (source) the images and restart — see [Updating](docs/operations.md#updating-the-stack). |
 | `./pithead logs [service]` | Follow logs (all, or one service). |
 | `./pithead status` | Container status + health-check of every expected service (warns on anything down). |
 | `./pithead doctor` | Read-only health report (deps, Docker, AVX2, HugePages, RAM/disk, onion state). |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,12 +5,12 @@ driven by a single script — `pithead` — and most of it is automated.
 
 > **TL;DR**
 > ```bash
-> git clone https://github.com/p2pool-starter-stack/pithead.git
+> curl -fsSL https://github.com/p2pool-starter-stack/pithead/releases/latest/download/pithead.tar.gz | tar xz
 > cd pithead
-> chmod +x pithead
+> cp config.json.template config.json   # set your Monero + Tari payout addresses
 > ./pithead setup
 > ```
-> Answer a few prompts, let it run, and open the dashboard at `https://<your-hostname>`.
+> Let it run, then open the dashboard at `https://<your-hostname>`.
 
 ---
 
@@ -47,14 +47,31 @@ On an unsupported OS — or if dependency detection misfires on an unusual setup
 
 ## 2. Get the code
 
+Download the latest release — this pulls the **published, tested images** (no local build), so the
+dashboard shows the real version and the update-checker works:
+
 ```bash
-git clone https://github.com/p2pool-starter-stack/pithead.git
+curl -fsSL https://github.com/p2pool-starter-stack/pithead/releases/latest/download/pithead.tar.gz | tar xz
 cd pithead
-chmod +x pithead
+cp config.json.template config.json   # then set your Monero + Tari payout addresses
 ```
 
-You'll need your **Monero** payout address and your **Tari** payout address ready before you start
-setup. (Tari wallets are sometimes labeled **Minotari** — same thing.)
+`config.json.template` is minimal — just your two payout addresses; `setup` fills in sensible defaults
+for everything else. Want the full set of knobs? Copy `config.advanced.example.json` instead. Have your
+**Monero** and **Tari** payout addresses ready (Tari wallets are sometimes labeled **Minotari** — same
+thing).
+
+### Alternative: build from source
+
+To build the images locally instead of pulling the published ones — e.g. to develop or modify the
+stack — clone the repo. pithead sees the `build/` context and builds locally, tagging the images `:dev`
+(the dashboard badge then reads `dev · <branch> @ <commit>` instead of the release version):
+
+```bash
+git clone https://github.com/p2pool-starter-stack/pithead.git
+cd pithead && chmod +x pithead
+cp config.json.template config.json   # then set your payout addresses
+```
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -12,7 +12,7 @@ the full list.
 | `./pithead up` | Start the stack. |
 | `./pithead down` | Stop the stack. |
 | `./pithead restart` | Restart the stack. |
-| `./pithead upgrade` | Re-render the generated config, then rebuild and restart the containers (run after a `git pull`). |
+| `./pithead upgrade` | Re-render the generated config, then **pull** (release bundle) or **rebuild** (source checkout) the images and restart. Run after downloading a newer bundle or a `git pull`. |
 | `./pithead logs [service]` | Follow logs for all containers, or a single service (e.g. `logs p2pool`). |
 | `./pithead status` | Show container status **and health-check every expected service** — warns about anything down/unhealthy and exits non-zero if so (handy for cron/monitoring). Profile-aware, and treats a stopped `p2pool`/`xmrig-proxy` as intentional during a node-down failover or while the miner is held until the chains sync. |
 | `./pithead doctor` | Read-only diagnostics: deps, Docker, AVX2, HugePages, RAM/disk, `.env`/onion state, and container status — a paste-able health report. |
@@ -64,18 +64,27 @@ isn't boot-enabled; the fix is `sudo systemctl enable --now docker`.
 
 ## Updating the stack
 
-Pull the latest changes, then rebuild and restart:
+How you update depends on how you installed (see [Getting Started](getting-started.md#2-get-the-code)).
+
+**Release bundle (the default):** from your install directory, re-download the latest bundle over it,
+then upgrade — `upgrade` **pulls** the new published images:
+
+```bash
+curl -fsSL https://github.com/p2pool-starter-stack/pithead/releases/latest/download/pithead.tar.gz | tar xz --strip-components=1
+./pithead upgrade
+```
+
+**Source checkout:** pull the latest code, then upgrade — `upgrade` **rebuilds** the images locally:
 
 ```bash
 git pull
 ./pithead upgrade
 ```
 
-`upgrade` re-renders the generated config (`.env`, the Caddyfile, and the Tari config) for the
-current release, then rebuilds the container images and restarts the stack — so a release that
-changes a config template or adds an `.env` var takes effect, not just the new image. Your data
-directories and `config.json` are untouched, so your blockchain sync and settings are preserved
-across upgrades.
+Either way, `upgrade` re-renders the generated config (`.env`, the Caddyfile, and the Tari config) for
+the new release *before* pulling/rebuilding — so a release that changes a config template or adds an
+`.env` var takes effect, not just the new image. Your data directories and `config.json` are untouched,
+so your blockchain sync and settings are preserved across upgrades.
 
 > **Moving the install?** Data directories are stored as absolute paths in `.env`, so relocating or
 > copying the stack to a different path (or running a second checkout) points it at a *different,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -159,10 +159,10 @@ What exists today:
   service now carries an `image: ${PITHEAD_REGISTRY:-…}/pithead-<svc>:${STACK_VERSION:-dev}` ref
   alongside its `build:`. pithead picks build-vs-pull automatically: a **source checkout** (the image
   Dockerfiles are present) builds locally and tags `:dev` with `--pull never`; a **release install**
-  (the bundle ships no Dockerfiles, just `pithead` + `VERSION` + compose + `build/tari/`'s template)
-  resolves `STACK_VERSION` to `vX.Y.Z` and **pulls** the published images (`--pull missing`; `upgrade`
-  forces a re-pull). Override with `PITHEAD_REGISTRY` / `PITHEAD_PULL`. So a release is now
-  `cp config.advanced.example.json config.json && ./pithead setup` — no local build.
+  (the bundle ships no Dockerfiles, just `pithead` + `VERSION` + compose + the config templates + the
+  `./build` runtime mounts) resolves `STACK_VERSION` to `vX.Y.Z` and **pulls** the published images
+  (`--pull missing`; `upgrade` forces a re-pull). Override with `PITHEAD_REGISTRY` / `PITHEAD_PULL`. So
+  a release is now `cp config.json.template config.json && ./pithead setup` — no local build.
 
 **Remaining:**
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -368,7 +368,7 @@ publish() {
     stage "7/7  Publish GitHub Release $TAG"
     local manifest="$WORKDIR/ingredients-$TAG.md"
     write_manifest "$manifest"
-    local bundle="$WORKDIR/pithead-$TAG.tar.gz"
+    local bundle="$WORKDIR/pithead.tar.gz"   # versionless name → stable /releases/latest/download/ URL
     make_bundle "$bundle"
 
     confirm "Create git tag $TAG, push it, and publish the GitHub Release?" \
@@ -435,19 +435,24 @@ compose_build_mounts() {
 # ./build/* path the compose mounts at runtime (compose_build_mounts) IS shipped, so the pulled
 # containers find the config templates they render at setup.
 make_bundle() {
-    local out="$1" d="$WORKDIR/pithead-$TAG"
+    # Unpacks to a versionless "pithead/" dir so the documented quick start can `cd pithead` and so a
+    # later bundle re-download upgrades it in place. Ships BOTH config templates: config.json.template
+    # (basic — just the two wallet addresses, the documented quick-start config) and the advanced
+    # example. The bundle README + the repo quick start both point at the basic one (matching setup's
+    # own "copy config.json.template" guidance); the advanced example is "for more options".
+    local out="$1" d="$WORKDIR/pithead"
     mkdir -p "$d"
-    cp pithead VERSION docker-compose.yml config.advanced.example.json "$d/" 2>/dev/null || true
+    cp pithead VERSION docker-compose.yml config.json.template config.advanced.example.json "$d/" 2>/dev/null || true
     local m
     while IFS= read -r m; do
         [ -e "$m" ] || { warn "bundle: compose mounts '$m' but it is missing from the tree — skipping"; continue; }
         mkdir -p "$d/$(dirname "$m")"
         cp -R "$m" "$d/$(dirname "$m")/"
     done < <(compose_build_mounts docker-compose.yml)
-    printf 'Pithead %s — pinned install bundle (images pulled from %s, no local build).\n\nQuick start:\n  1. cp config.advanced.example.json config.json   # then set your wallet addresses\n  2. ./pithead setup\n\nThere are no build contexts here, so pithead pulls the published %s images instead of building.\n' \
+    printf 'Pithead %s — pinned install bundle (images pulled from %s, no local build).\n\nQuick start:\n  1. cp config.json.template config.json   # then set your Monero + Tari payout addresses\n     (more options: config.advanced.example.json)\n  2. ./pithead setup\n\nThere are no build contexts here, so pithead pulls the published %s images instead of building.\n' \
         "$TAG" "$REGISTRY" "$TAG" > "$d/README.txt"
     if [ "$DRY_RUN" -eq 1 ]; then printf '   %s[dry-run]%s would tar -> %s\n' "$C_YELLOW" "$C_RESET" "$out"; return 0; fi
-    tar -czf "$out" -C "$WORKDIR" "pithead-$TAG"
+    tar -czf "$out" -C "$WORKDIR" "pithead"
     log "Wrote install bundle: $out"
 }
 

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -346,6 +346,15 @@ esac
 BUILD_MOUNTS="$( cd "$ROOT" || exit; set --; source "$REL" 2>/dev/null; set +eu; compose_build_mounts docker-compose.yml )"
 assert_contains "bundle ships monerod's config template" "$BUILD_MOUNTS" "./build/monero/bitmonero.conf.template"
 assert_contains "bundle ships the tari config dir"        "$BUILD_MOUNTS" "./build/tari"
+# The bundle must ship the BASIC config template (the documented quick-start config — `cp
+# config.json.template config.json`) and unpack to a versionless `pithead/` dir for the stable
+# /releases/latest/download/pithead.tar.gz URL. Build a real bundle and inspect it.
+# shellcheck disable=SC1090,SC2034  # dynamic source; TAG/REGISTRY/DRY_RUN are consumed inside make_bundle
+( cd "$ROOT" || exit; set --; source "$REL" 2>/dev/null; set +eu
+  WORKDIR="$SANDBOX/bundle"; mkdir -p "$WORKDIR"; TAG=v9.9.9; REGISTRY=ghcr.io/test; DRY_RUN=0
+  make_bundle "$WORKDIR/pithead.tar.gz" >/dev/null 2>&1; tar tzf "$WORKDIR/pithead.tar.gz" 2>/dev/null ) > "$SANDBOX/bundle.list" 2>/dev/null
+grep -q '^pithead/config.json.template$' "$SANDBOX/bundle.list" && ok "bundle ships config.json.template (basic quick-start config)" || bad "bundle ships config.json.template" "absent from the bundle"
+grep -q '^pithead/$'                     "$SANDBOX/bundle.list" && ok "bundle unpacks to versionless pithead/"               || bad "bundle unpacks to pithead/" "top-level dir is not pithead/"
 _bm_missing=""
 for _m in $BUILD_MOUNTS; do [ -e "$ROOT/$_m" ] || _bm_missing="$_bm_missing $_m"; done
 assert_eq "every compose ./build runtime mount exists in the tree" "${_bm_missing:-none}" "none"


### PR DESCRIPTION
Makes the documented quick start match how releases are meant to be installed — fixing the `dev · main @ <sha>` badge you hit on pithead-prod.

## Why
The README + getting-started quick starts were `git clone && ./pithead setup` — the **source/build** path. So every new user got a `:dev` build of the latest commit instead of the **published, tested `:vX.Y.Z` images**, plus a `dev` dashboard badge and a non-working update-checker. `docs/releasing.md` already says installs should *pull the bundle* — the docs just never followed.

## Changes
- **Quick start** (README + getting-started) → download the latest release bundle (pull mode, no local build):
  ```sh
  curl -fsSL https://github.com/p2pool-starter-stack/pithead/releases/latest/download/pithead.tar.gz | tar xz
  cd pithead
  cp config.json.template config.json   # set Monero + Tari payout addresses
  ./pithead setup
  ```
- **`config.json.template`** (basic — two wallet addresses) is the quick-start config, matching `setup`'s own guidance (pithead:1261). `config.advanced.example.json` is now "for more options."
- **`make_bundle`**: ships `config.json.template` (it only shipped the *advanced* example — the actual inconsistency), names the asset **`pithead.tar.gz`** (versionless → stable `/releases/latest/download/` URL) and unpacks to a versionless **`pithead/`** dir.
- **`git clone`** moved to an **"Alternative: build from source"** section (the `:dev` path — for contributors).
- **Tests**: assert the bundle ships `config.json.template` + unpacks to `pithead/`.

## Not a new release
No image/code change — purely docs + bundle packaging. After merge I'll **re-cut the v1.0.1 bundle with this and re-attach `pithead.tar.gz`** to the v1.0.1 release, so the quick-start URL resolves for the current release. The `:v1.0.1` images are untouched.

`shellcheck` clean · `make test` green.