### PR TITLE
docs: add "source checkout → release images" upgrade path

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -89,7 +89,8 @@ A small **version badge** sits beside the hostname so you always know which buil
 released build shows the version (e.g. **`v1.3.0`**); a development or working-tree build shows a
 dashed **`dev · branch @ commit`** marker instead, so it's never mistaken for a release. It appears
 on every screen — including Sync Mode — which makes it easy to confirm what you're on when sharing a
-screenshot in a bug report.
+screenshot in a bug report. On a `dev` build but would rather run a published release? See
+[Switching a source checkout to release images](operations.md#switching-a-source-checkout-to-release-images).
 
 When a **newer Pithead release** is out, a clickable **`New release vX.Y.Z available ↗`** badge
 appears next to the version badge, linking to the GitHub release. It's a heads-up only — it never

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,6 +73,9 @@ cd pithead && chmod +x pithead
 cp config.json.template config.json   # then set your payout addresses
 ```
 
+> Changed your mind later? You can convert a clone to the published images in place — see
+> [Switching a source checkout to release images](operations.md#switching-a-source-checkout-to-release-images).
+
 ---
 
 ## 3. Run setup

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,6 +86,28 @@ the new release *before* pulling/rebuilding — so a release that changes a conf
 `.env` var takes effect, not just the new image. Your data directories and `config.json` are untouched,
 so your blockchain sync and settings are preserved across upgrades.
 
+### Switching a source checkout to release images
+
+If you cloned the repo (so the dashboard badge reads `dev · branch @ commit`) and would rather run the
+**published, tested images** — a clean version badge, a working update-checker, and no local build —
+convert the install in place. Your `config.json`, `.env`, Tor onion keys, and data directories are all
+preserved:
+
+```bash
+./pithead backup -y          # safety snapshot: config.json, .env, onion keys, dashboard db (chains excluded)
+# overlay the published release files — leaves config.json, .env, .git, and your data dirs untouched:
+curl -fsSL https://github.com/p2pool-starter-stack/pithead/releases/latest/download/pithead.tar.gz | tar xz --strip-components=1
+rm -f build/*/Dockerfile     # remove the image Dockerfiles → pithead switches from build to pull
+./pithead upgrade            # re-render config, pull :vX.Y.Z, recreate
+```
+
+`pithead` chooses build-vs-pull by whether the image Dockerfiles are present (`build/<svc>/Dockerfile`) —
+deleting them is what flips it from building `:dev` locally to pulling the published `:vX.Y.Z`. To go
+back to building from source, `git checkout vX.Y.Z` (or `git pull`) restores the Dockerfiles, then
+`./pithead upgrade` rebuilds locally again. The new validation in `upgrade` will refuse to start on a
+non-primary Monero payout address, so confirm yours is a `4…`/95-char address first (see
+[Configuration](configuration.md)).
+
 > **Moving the install?** Data directories are stored as absolute paths in `.env`, so relocating or
 > copying the stack to a different path (or running a second checkout) points it at a *different,
 > empty* `data/` — a full re-sync, and the dashboard history is orphaned. If you move the install,


### PR DESCRIPTION
Spun out of moving **pithead-prod** onto a release: there was no documented way to convert a `git clone` (which builds `:dev` locally — the `dev · branch @ commit` badge) to the **published release images**. This adds it.

- **`operations.md`** — new **Switching a source checkout to release images** subsection under *Updating the stack*: `backup -y` → overlay the release bundle → `rm -f build/*/Dockerfile` (the switch that flips pithead from build to pull) → `upgrade`. Explains the build-vs-pull mechanism, how to reverse it (`git checkout vX.Y.Z` restores the Dockerfiles), and notes that `upgrade` now refuses a non-primary Monero address (1.0.3).
- **`dashboard.md`** — the dev-badge explanation now links to the recipe (where someone confused by `dev · …` actually lands).
- **`getting-started.md`** — the *build from source* alternative links to it ("changed your mind later?").

Docs-only; anchor verified against the new heading; README already cross-links to `operations#updating-the-stack`.