### PR TITLE
ci: guard the release gate against a missing runner + add develop to triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
 
 jobs:

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -35,6 +35,12 @@ concurrency:
 jobs:
   release-gate:
     name: Tier-4 live matrix (real nodes)
+    # Only run automatically once a self-hosted runner is actually wired up — set the repo variable
+    # ENABLE_RELEASE_GATE=true when one is registered. Without this guard, every push to main queues
+    # a job no runner can claim, and GitHub auto-cancels it after a 24h timeout — a permanent red ✗
+    # on main. A skipped job is green/neutral instead. A manual workflow_dispatch ALWAYS runs, so a
+    # maintainer can still validate a reviewed ref on a registered runner on demand.
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.ENABLE_RELEASE_GATE == 'true' }}
     # Register the server with these labels: `pithead-release` scopes the gate to the dedicated
     # box; prefer an ephemeral / just-in-time runner in its own runner group.
     runs-on: [self-hosted, pithead-release]


### PR DESCRIPTION
## What & why

Two small CI changes, prep for the new `develop` integration branch (v1.1+ work lands on `develop`; `main` stays at the released state).

- **`release-gate.yml`** — gate the self-hosted Tier-4 job behind `if: ${{ github.event_name == 'workflow_dispatch' || vars.ENABLE_RELEASE_GATE == 'true' }}`. There's **no self-hosted runner registered**, so every push to `main` was queuing a job no runner could claim, which GitHub auto-cancels after a **24h timeout** — a permanent red ✗ on `main`. Now the automatic run is **skipped (green/neutral)** until a runner is wired up and the repo variable `ENABLE_RELEASE_GATE=true` is set. A manual `workflow_dispatch` still runs (for a maintainer validating a reviewed ref).
- **`ci.yml`** — run CI on pushes to `develop` too (PRs already run on any base branch).

## Related issue
N/A — CI/infra hygiene (supports the `develop` workflow + clears the red gate on `main`).

## Checklist
- [x] No product/code change; workflow YAML only (both parse)
- [x] `release-gate` still runnable on demand via `workflow_dispatch`
- [x] Focused, single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)