### PR TITLE
fix(privacy): install Tor-egress firewall before containers start — close startup window (#276)

### DIFF
--- a/pithead
+++ b/pithead
@@ -144,12 +144,17 @@ stack_up() {
     log "Starting stack..."
     warn_missing_data_dirs
     migrate_compose_project
+    # Install the Tor-only egress firewall BEFORE the containers start (#270). DOCKER-USER is a static
+    # chain whose rules reference the fixed subnet/Tor IP, so they can go in before the network exists;
+    # Docker preserves DOCKER-USER and (re)adds the FORWARD jump when it creates the network. Doing this
+    # first closes the startup window in which a clearnet app (e.g. Tari) could open a connection that
+    # the ESTABLISHED rule would then grandfather past the DROP.
+    apply_tor_egress_firewall
     # Docker Compose automatically picks up COMPOSE_PROFILES from .env
     if ! compose_up_checked -d; then
         error "Stack failed to start — see the error above."
     fi
     log "Stack started successfully!"
-    apply_tor_egress_firewall
     # Remind the operator at start-time if a node is coming up on clearnet (#183).
     print_clearnet_banner
     announce_dashboard_url
@@ -172,8 +177,9 @@ stack_restart() {
 # Fail-closed host firewall so a misconfigured/buggy bridge daemon (monerod/p2pool/tari/xmrig-proxy)
 # CAN'T leak the home IP: each may reach the LAN, the other containers and the Tor SOCKS, but any
 # DIRECT clearnet dial is DROPPED — only the `tor` container reaches the internet. Rules live in
-# Docker's DOCKER-USER chain (preserved across Docker restarts), installed at up/apply and removed at
-# down. Needs root (sudo), like the GRUB/HugePages steps; IPv4-only (mining_net is IPv4). Opt out with
+# Docker's DOCKER-USER chain (preserved across Docker restarts), installed BEFORE containers start at
+# `up` (so there is no startup window to grandfather), re-asserted at `apply`, removed at `down`. Needs
+# root (sudo), like the GRUB/HugePages steps; IPv4-only (mining_net is IPv4). Opt out with
 # network.tor_egress_firewall=false. Proven by tests/integration/benchmarks/bench-verify-egress.sh.
 # See docs/privacy.md.
 TOR_EGRESS_TAG="pithead-tor-egress"
@@ -225,6 +231,10 @@ apply_tor_egress_firewall() {
     fi
     subnet=$(env_get NETWORK_SUBNET 2>/dev/null); [ -n "$subnet" ] || subnet="172.28.0.0/24"
     tor_ip=$(env_get NETWORK_PREFIX 2>/dev/null); [ -n "$tor_ip" ] || tor_ip="172.28.0"; tor_ip="${tor_ip}.25"
+    # DOCKER-USER may not exist yet on a first-ever `up` (Docker creates it with its first network).
+    # Pre-create it so installing here — before compose runs — succeeds; Docker adopts the existing
+    # chain and adds the FORWARD jump. Harmless (-N fails with rc 1) once the chain is already there.
+    sudo iptables -N DOCKER-USER 2>/dev/null || true
     while IFS= read -r rule; do
         # shellcheck disable=SC2086  # intentional word-splitting of the rule body
         if ! sudo iptables -I DOCKER-USER "$pos" -m comment --comment "$TOR_EGRESS_TAG" $rule 2>/dev/null; then

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -207,6 +207,9 @@ printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWA
 iptlog="$(cat "$FW/ipt.log" 2>/dev/null)"
 assert_contains "installs the fail-closed clearnet DROP, tagged" "$iptlog" "-I DOCKER-USER 7 -m comment --comment pithead-tor-egress -s 172.28.0.0/24 -j DROP"
 assert_contains "exempts the Tor container"                      "$iptlog" "-m comment --comment pithead-tor-egress -s 172.28.0.25 -j ACCEPT"
+# Pre-creates DOCKER-USER so the BEFORE-compose install at `up` can't miss on a first-ever start where
+# Docker hasn't created the chain yet — closes the startup window that grandfathered leaks (#276).
+assert_contains "pre-creates the DOCKER-USER chain (idempotently)"  "$iptlog" "-N DOCKER-USER"
 # opt-out: TOR_EGRESS_FIREWALL=false installs nothing
 printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWALL=false\n' > "$FW/.env"
 : > "$FW/ipt.log"; PATH="$FW/bin:$PATH" run_sourced "$FW" apply_tor_egress_firewall >/dev/null 2>&1


### PR DESCRIPTION
Closes #276. Follow-up hardening to #270 (#275), found during live validation on the gouda e2e bench.

## Problem
#270 installed the Tor-egress firewall **after** `docker compose up`. Containers dial immediately, so a connection a clearnet-only app opens in the window before the rules land is matched by the leading `ESTABLISHED,RELATED -j ACCEPT` rule and **grandfathered past the DROP**.

**Reproduced live:** a fresh `pithead up` with the firewall enabled left **Tari** (#271, the only clearnet app) holding **2–3 DIRECT PUBLIC peers**, and `bench-verify-egress.sh tor` → FAIL. Restarting just Tari (re-dial under the present rules) → 0 public, proving the rules work for *new* connections and the residue is purely install ordering.

## Fix (`pithead` only — no image rebuild)
- Move `apply_tor_egress_firewall` **before** `compose_up_checked` in `stack_up`, so no container dials before the rules exist.
- Pre-create `DOCKER-USER` (`iptables -N … || true`) so the pre-compose install also succeeds on a first-ever `up` (where Docker hasn't created the chain yet). `DOCKER-USER` is a static chain Docker preserves across network (re)creation and re-jumps from `FORWARD` when it builds the network, so rules referencing the fixed subnet/Tor IP are safe to install early.

## Validation (gouda, live)
- Log now prints `Tor-only egress enforced` **before** `Stack started successfully!`.
- Fresh `pithead up` → **Tari 0 public peers at t+0 and t+25s** (was 2–3); DROP counter climbs from the start.
- `bench-verify-egress.sh tor` → **first fully clean all-Tor PASS**: monerod ✓ p2pool ✓ tari ✓ xmrig ✓.
- `down`/`up` firewall lifecycle clean (rules 7→0→7); #275 `set -e` fix holds.
- `tests/stack/run.sh`: **378 passed, 0 failed** (adds a `pre-creates the DOCKER-USER chain` assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)