### PR TITLE
fix(privacy): route Tari clearnet peer dials through Tor SOCKS — genuinely behind Tor (#271)

### DIFF
--- a/build/tari/config.toml.template
+++ b/build/tari/config.toml.template
@@ -112,5 +112,13 @@ control_address = "/ip4/172.28.0.25/tcp/9051"
 socks_address_override = "/ip4/172.28.0.25/tcp/9050"
 control_auth = "auto"
 
+# Route EVERY outbound dial through the Tor SOCKS proxy — including peers learned via gossip that
+# advertise a bare /ip4 (clearnet) address. With this true (an upstream default that favours speed),
+# minotari direct-dials those clearnet peers and leaks the home IP (#271, observed as sustained
+# connections to public IPs). false = clearnet peers are reached via Tor exit nodes, so Tari stays
+# fully functional AND never touches clearnet directly. No per-address exemptions (no local wallet).
+proxy_bypass_for_outbound_tcp = false
+proxy_bypass_addresses = []
+
 # Port mapping for the hidden service
 onion_port = 18189

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -672,6 +672,10 @@ assert_contains "monerod: DNS checkpoints disabled (#161)" "$(cat "$MONC")" "dis
 assert_contains "monerod: update check disabled (#161)"    "$(cat "$MONC")" "check-updates=disabled"
 # tari (#162): no DNS seeds; peer_seeds onion-only; the inert check_for_updates gRPC method dropped.
 assert_contains "tari: DNS seeds disabled (#162)" "$(cat "$TARC")" "dns_seeds = []"
+# #271: minotari defaults proxy_bypass_for_outbound_tcp=true → it direct-dials peers advertising a bare
+# /ip4 (clearnet) address, bypassing Tor. false routes every dial through the SOCKS proxy (reach those
+# peers via Tor exits) — so Tari is functional AND never touches clearnet directly.
+assert_contains "tari: outbound TCP dials routed via Tor SOCKS, not direct (#271)" "$(cat "$TARC")" "proxy_bypass_for_outbound_tcp = false"
 case "$(grep -E '::/ip4/|::/ip6/' "$TARC" || true)" in
     "") ok "tari: peer_seeds are onion-only (#162)" ;;
     *)  bad "tari: peer_seeds are onion-only (#162)" "clearnet /ip4//ip6/ peer seeds present" ;;


### PR DESCRIPTION
Closes #271. The substantive Wave 2 item — makes Tari **functional *and* private** over Tor, the only app that was previously blocked-but-dead under the #270 firewall.

## Root cause (confirmed against tari v5.3.0 source + tari-launchpad)
minotari's tor transport defaults **`proxy_bypass_for_outbound_tcp = true`**. With it true, `SocksTransport::dial()` (`comms/core/src/transports/socks.rs:119-128`) **direct-dials any peer that advertises a bare `/ip4|/ip6 .../tcp` address, bypassing Tor** — and the seed list ships clearnet variants. That's the leak #271 observed (sustained direct connections to public IPs despite `type = "tor"`). tari-launchpad's own `docker_rig/config.toml` carries this exact knob.

## Fix (`build/tari/config.toml.template`, one setting)
```toml
[base_node.p2p.transport.tor]
proxy_bypass_for_outbound_tcp = false   # route EVERY dial through SOCKS, incl. clearnet peers
proxy_bypass_addresses = []             # no per-address exemptions (no local Tari wallet)
```
Now clearnet peers are reached **via Tor exit nodes**, so Tari keeps full connectivity while never touching clearnet directly. Merge-mining is unaffected (base node ↔ MM proxy is local gRPC).

## Live validation (gouda, firewall on)
| | before fix | after fix |
|---|---|---|
| direct-public connections | 2–3 (leak) | **0** |
| peer dials via Tor SOCKS | ~1 (onion only) | **up to 36** |
| peer connectivity | blocked-dead (3 vs 44 fail) | discovering + dialing peers over Tor |

Tari now routes 100% of outbound through Tor and is back to actively connecting to peers (handshakes are slow/flaky over Tor — the latency cost #256 will quantify). Combined with the existing dead-resolver DNS sinkhole (#162), Tari has **no clearnet TCP and no clearnet DNS** — genuinely, completely behind Tor.

Tests: `tests/stack/run.sh` asserts the config (full suite green). Note: applies on `pithead upgrade` (re-renders service configs); `pithead apply` only re-renders on `.env` changes.

## Follow-ups (not blocking)
- Two **upstream** items worth filing on `tari-project/tari`: the privacy-hostile `proxy_bypass_for_outbound_tcp=true` default under `type="tor"`, and Tari Pulse having no disable flag (we already sinkhole its DNS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)