### PR TITLE
fix(#272): e2e deploys via `pithead upgrade` so it tests the branch's rebuilt images

### DIFF
--- a/pithead
+++ b/pithead
@@ -283,6 +283,7 @@ stack_upgrade() {
     else
         PITHEAD_PULL=always compose_up_checked -d || error "Upgrade failed during 'docker compose up' — see the error above."
     fi
+    apply_tor_egress_firewall   # reassert the Tor-only egress firewall (#270), consistent with up/apply
     log "Stack upgraded."
 }
 

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -13,8 +13,9 @@
 #   3. Takes a `pithead backup` of the live stack (the rollback anchor).
 #   4. Borrows a miner (default miner-0): backs up its xmrig config and repoints it at gouda so
 #      the live matrix has a real worker mining through this stack.
-#   5. Deploys the branch (`pithead apply` — builds the branch's images) and runs the live harness
-#      (tests/integration/run.sh) DETACHED on the box so an SSH drop can't kill a long matrix.
+#   5. Deploys the branch (`pithead upgrade` — re-renders configs AND rebuilds the branch's first-party
+#      images from build/, so a Dockerfile/entrypoint change is actually tested #272) and runs the live
+#      harness (tests/integration/run.sh) DETACHED on the box so an SSH drop can't kill a long matrix.
 #   6. ALWAYS restores: the miner's original pool config, and the canonical baseline stack — even
 #      on failure or Ctrl-C (an EXIT trap). The synced chains are never touched.
 #
@@ -270,8 +271,14 @@ borrow_miner() {
 
 # --- Phase 4: deploy the branch ---------------------------------------------
 deploy_branch() {
-    log "Deploying the branch on $GOUDA_HOST (pithead apply — builds the branch's images)"
-    on_gouda "cd '$E2E_DIR' && ./pithead apply -y" || die "pithead apply failed in $E2E_DIR — branch did not deploy."
+    # #272: `pithead apply` runs `compose up --pull` (never --build), so it would test whatever images
+    # were last built on the box, not this branch. `pithead upgrade` re-renders the generated configs
+    # (inject_service_configs) AND rebuilds the first-party images from build/ (--build) before
+    # recreating — so a Dockerfile/entrypoint change in the branch is actually under test.
+    log "Deploying the branch on $GOUDA_HOST (pithead upgrade — re-render configs + rebuild first-party images)"
+    on_gouda "cd '$E2E_DIR' && ./pithead upgrade" || die "pithead upgrade failed in $E2E_DIR — branch did not deploy."
+    # Record what was actually built, so "what did we test" is unambiguous in the run log (#272).
+    on_gouda "cd '$E2E_DIR' && docker compose images --format '{{.Service}} {{.Repository}}:{{.Tag}} {{.ID}}' 2>/dev/null | grep -E 'p2pool|dashboard|monero|tor|xmrig' || true" | while IFS= read -r l; do step "image: $l"; done
     wait_gouda_healthy 300 || warn "stack applied but not yet healthy; the harness will wait on real readiness signals"
     wait_synced 300 || true   # let the recreated monerod/tari re-confirm their tip before the harness pre-check
     ok "branch deployed; stack reconciled"


### PR DESCRIPTION
Closes #272.

## Problem
`e2e.sh deploy_branch` ran `pithead apply -y` → `docker compose up --pull` (**never `--build`**), so the live harness tested whatever first-party images were last built on the box, not the branch under test. This masked #165's p2pool clearnet leak (the entrypoint word-split only exists in a *rebuilt* image) — every prior "all passed" run had been on stale images. `apply` also *skips* entirely when `.env` is unchanged, so a config-template change wasn't picked up either.

## Fix
- **`e2e.sh deploy_branch` now uses `pithead upgrade`**, which re-renders the generated configs (`inject_service_configs`) **and** rebuilds the first-party images from `build/` (`--build`) before recreating. No git pull (e2e already checks out the branch). Logs the built image IDs so "what we tested" is unambiguous.
- **`stack_upgrade` now reasserts the Tor-egress firewall** (#270), consistent with `up`/`apply` — previously the upgrade path relied on the rules persisting from a prior `up`.

## Validation (gouda, live)
Ran `pithead upgrade` on the e2e checkout:
- **All 5 first-party images rebuilt** (`Building` + `naming to …:dev` for p2pool/dashboard/monero/tor/xmrig-proxy).
- **Config re-render proven:** a unique marker injected into the generated `config.toml` was **wiped** by the re-render, and the `#271` template's `proxy_bypass_for_outbound_tcp` now appears in the rendered config (so a template change propagates via upgrade).
- **Rebuild-on-change proven conclusively:** appended `LABEL pithead_e2e272_proof` to `build/p2pool/Dockerfile`, rebuilt → the label is present in the `:dev` image (`"pithead_e2e272_proof":"rebuilt"`). Reverted.
- **Firewall reasserted:** removed the rules (0), ran upgrade → back to 7. 9/9 containers healthy.

Local: shellcheck clean, `tests/stack/run.sh` 379/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)