### PR TITLE
fix(#273): fail-loud when a stale p2pool image drops the Tor flags

### DIFF
--- a/build/p2pool/entrypoint.sh
+++ b/build/p2pool/entrypoint.sh
@@ -8,5 +8,9 @@ set -euo pipefail
 # routing — e.g. "--mini --socks5 172.28.0.25:9050 --socks5-proxy-type tor"). We word-split it HERE
 # because Docker Compose passes a `- ${VAR}` command item as ONE argument (no word-splitting), which
 # would hand p2pool a single mangled flag. An empty value expands to nothing (no stray empty arg).
+# Log the FINAL launch command (#273): makes the applied flags — notably the #165 `--socks5` Tor
+# routing — auditable in `docker logs p2pool`, so a stale image silently dropping P2POOL_FLAGS shows
+# up here (and `pithead doctor` fails on it) rather than leaking quietly.
+echo "[p2pool-entrypoint] launching: p2pool $* ${P2POOL_FLAGS:-}"
 # shellcheck disable=SC2086  # intentional word-splitting of the space-separated flag string
 exec p2pool "$@" ${P2POOL_FLAGS:-}

--- a/pithead
+++ b/pithead
@@ -593,6 +593,23 @@ doctor() {
         dr_ok "No clearnet initial sync active — all node P2P is Tor-only (#183)."
     fi
 
+    # p2pool Tor-routing fail-safe (#273): with clearnet off, P2POOL_FLAGS carries the #165 --socks5;
+    # the RUNNING p2pool must actually carry it. A STALE p2pool image (pre-#165 entrypoint) ignores the
+    # env var and dials sidechain peers directly — over CLEARNET, exposing the home IP. The #270 firewall
+    # now DROPs that dial (so a stale p2pool just can't peer rather than leaking), but surface the cause
+    # loudly so the fix — rebuild with 'pithead upgrade' — is obvious instead of a silent leak/stall.
+    # Read the EXEC'd args from /proc/1/cmdline (the env flags are word-split in the entrypoint, so they
+    # never appear in the container's Args). Empty = p2pool not running (often an intentional sync hold
+    # #31/#35) — don't flag.
+    if printf '%s' "$(env_get P2POOL_FLAGS 2>/dev/null)" | grep -q -- '--socks5'; then
+        local _p2args; _p2args=$(docker exec p2pool cat /proc/1/cmdline 2>/dev/null | tr '\0' ' ')
+        case "$_p2args" in
+            "")         : ;;
+            *--socks5*) dr_ok "p2pool routes outbound sidechain P2P via Tor (#165)." ;;
+            *)          dr_fail "p2pool is NOT routing over Tor despite p2pool.clearnet=false — its sidechain P2P would hit CLEARNET (exposing your IP). Almost certainly a STALE p2pool image not applying P2POOL_FLAGS (#165/#273): run 'pithead upgrade' to rebuild it. (#270's egress firewall blocks the dial meanwhile, so p2pool can't peer until you do.)" ;;
+        esac
+    fi
+
     # --- Disk: free space per underlying filesystem ---
     echo ""
     echo "Disk:"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -43,6 +43,7 @@ case "$*" in
   "exec tor cat /var/lib/tor/monero/hostname") echo "mona.onion" ;;
   "exec tor cat /var/lib/tor/tari/hostname")   echo "taria.onion" ;;
   "exec tor cat /var/lib/tor/p2pool/hostname") echo "p2pa.onion" ;;
+  "exec p2pool cat /proc/1/cmdline") printf '%s' "${P2POOL_PROC1:-}" ;;  # #273: tests set the running p2pool argv
   *hash-password*)
     # Fake `caddy hash-password` (#8): a per-password digest so enable/change paths differ, and it
     # never echoes the plaintext back (real bcrypt doesn't either) — keeps the leak checks honest.
@@ -955,6 +956,16 @@ seed_env
 printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" > "$V/config.json"
 out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 assert_contains "doctor: OK when Tor-only (#183)" "$(cd "$V" && PATH="$V/bin:$PATH" ./pithead doctor 2>&1)" "Tor-only"
+
+# p2pool compose↔image coupling fail-safe (#273): clearnet is off, so apply renders P2POOL_FLAGS with
+# the #165 --socks5. doctor reads the RUNNING p2pool argv (/proc/1/cmdline, stubbed via P2POOL_PROC1)
+# and must FAIL loudly if --socks5 is absent (a stale pre-#165 image silently dropping the env flags),
+# and pass when it IS present. The config above (p2pool.pool=mini, clearnet default off) is reused.
+dr273() { cd "$V" && P2POOL_PROC1="$1" PATH="$V/bin:$PATH" ./pithead doctor 2>&1; }
+assert_contains "doctor FAILs when p2pool isn't on Tor — stale image (#273)" \
+    "$(dr273 'p2pool --host 172.28.0.26 --rpc-port 18081 --mini')" "STALE p2pool image"
+assert_contains "doctor OK when p2pool IS routed over Tor (#273)" \
+    "$(dr273 'p2pool --host 172.28.0.26 --mini --socks5 172.28.0.25:9050 --socks5-proxy-type tor')" "routes outbound sidechain P2P via Tor"
 
 echo "== black-box: local node creds auto-generated + persisted (#50) =="
 # A local node with BLANK creds: apply must generate them, write them into .env AND back into


### PR DESCRIPTION
Closes #273.

## Problem
#165 moved `P2POOL_FLAGS` into the p2pool container **env**, word-split by a **new entrypoint**. A *new compose + old image* partial update leaves the **old** entrypoint (`exec p2pool "$@"`) ignoring the env → p2pool starts with no `--mini`/`--socks5` → wrong sidechain + **clearnet dial, silently**. For a privacy stack, failing *open* is the wrong direction.

## Fix (detect + diagnose; the leak itself is already fail-closed)
The actual leak is now blocked by **#270** (the egress firewall DROPs the clearnet dial, so a stale p2pool just can't peer) and prevented by **#272** (deploy rebuilds). #273 makes the *cause* loud instead of a mysterious stall:
- **`pithead doctor`** — when clearnet is off (`P2POOL_FLAGS` carries `--socks5`), reads the **running** p2pool argv from `/proc/1/cmdline` and **FAILs** with a "STALE p2pool image → run `pithead upgrade`" hint if `--socks5` is absent. Image-independent (pithead is always current, unlike an image-resident healthcheck which a stale image wouldn't have).
- **p2pool entrypoint** — logs the final launch command, so the applied flags are auditable in `docker logs p2pool`.

## Validation
- Unit (`tests/stack/run.sh`, **381/0**): doctor **FAILs** on a stale (no-`--socks5`) p2pool argv; **OK** when `--socks5` is present.
- Live (gouda): `docker exec p2pool cat /proc/1/cmdline` shows `--socks5` → the check correctly reads OK. shellcheck clean.

Refs #165, #166, #270, #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)