### PR TITLE
fix(#278): keep p2pool's monerod RPC/ZMQ direct under Tor — restores mining on the Tor default

### DIFF
--- a/build/p2pool/Dockerfile
+++ b/build/p2pool/Dockerfile
@@ -4,9 +4,11 @@ FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae
 ARG P2POOL_VERSION=v4.16
 ARG P2POOL_HASH=1b03b2e4d4adfe488b2867eb85b57366fbaf8594a7f84cdbf13a3c8519159280
 
-# Install runtime dependencies
+# Install runtime dependencies. socat (#278): the entrypoint bridges 127.0.0.1 -> the real monerod so
+# p2pool's node RPC/ZMQ stay DIRECT while --socks5 routes only the sidechain over Tor (p2pool proxies
+# everything but loopback when --socks5 is set).
 RUN apt-get update && apt-get install -y \
-    wget ca-certificates libgomp1 \
+    wget ca-certificates libgomp1 socat \
     && rm -rf /var/lib/apt/lists/*
 
 RUN wget -O p2pool.tar.gz https://github.com/SChernykh/p2pool/releases/download/${P2POOL_VERSION}/p2pool-${P2POOL_VERSION}-linux-x64.tar.gz \

--- a/build/p2pool/entrypoint.sh
+++ b/build/p2pool/entrypoint.sh
@@ -8,9 +8,41 @@ set -euo pipefail
 # routing — e.g. "--mini --socks5 172.28.0.25:9050 --socks5-proxy-type tor"). We word-split it HERE
 # because Docker Compose passes a `- ${VAR}` command item as ONE argument (no word-splitting), which
 # would hand p2pool a single mangled flag. An empty value expands to nothing (no stray empty arg).
+# #278: p2pool's --socks5 (#165 Tor sidechain routing) ALSO proxies the monerod RPC/ZMQ connection —
+# unless the node address is LOOPBACK. p2pool exempts only 127.0.0.1/::1/localhost from the SOCKS5
+# proxy (verified vs p2pool v4.16: json_rpc_request.cpp / util.cpp is_localhost), so a private Docker
+# node IP (e.g. 172.28.0.26) gets dialled THROUGH Tor — which can't reach a private IP → "get_info ...
+# empty response", no block template, no mining. There is no per-host proxy-bypass flag. So when the
+# Tor proxy is on, bridge 127.0.0.1 -> the real node with socat and repoint --host at loopback: the
+# node RPC/ZMQ then stay DIRECT (socat is a plain TCP forward, not p2pool's proxy) while the sidechain
+# P2P still rides --socks5 over Tor. The socat hops (loopback -> node) are intra-stack, allowed by the
+# #270 firewall (subnet -> 172.16/12).
+if printf '%s' "${P2POOL_FLAGS:-}" | grep -q -- '--socks5'; then
+    _node="" _rpc="18081" _zmq="18083" _prev=""
+    for _a in "$@"; do
+        case "$_prev" in --host) _node="$_a" ;; --rpc-port) _rpc="$_a" ;; --zmq-port) _zmq="$_a" ;; esac
+        _prev="$_a"
+    done
+    case "$_node" in
+        ""|127.0.0.1|::1|localhost) : ;;   # already loopback (or p2pool's 127.0.0.1 default) — nothing to bridge
+        *)
+            echo "[p2pool-entrypoint] Tor on (#278): bridging 127.0.0.1 -> $_node for monerod RPC($_rpc)/ZMQ($_zmq) so the node stays DIRECT (p2pool only exempts loopback from --socks5)."
+            socat "TCP-LISTEN:$_rpc,bind=127.0.0.1,fork,reuseaddr" "TCP:$_node:$_rpc" &
+            socat "TCP-LISTEN:$_zmq,bind=127.0.0.1,fork,reuseaddr" "TCP:$_node:$_zmq" &
+            _args=(); _skip=0
+            for _a in "$@"; do
+                if [ "$_skip" = 1 ]; then _args+=("127.0.0.1"); _skip=0; continue; fi
+                _args+=("$_a"); [ "$_a" = "--host" ] && _skip=1
+            done
+            set -- "${_args[@]}"
+            ;;
+    esac
+fi
+
 # Log the FINAL launch command (#273): makes the applied flags — notably the #165 `--socks5` Tor
 # routing — auditable in `docker logs p2pool`, so a stale image silently dropping P2POOL_FLAGS shows
-# up here (and `pithead doctor` fails on it) rather than leaking quietly.
+# up here (and `pithead doctor` fails on it) rather than leaking quietly. After the #278 block above so
+# it reflects the rewritten --host.
 echo "[p2pool-entrypoint] launching: p2pool $* ${P2POOL_FLAGS:-}"
 # shellcheck disable=SC2086  # intentional word-splitting of the space-separated flag string
 exec p2pool "$@" ${P2POOL_FLAGS:-}


### PR DESCRIPTION
Closes #278. **Restores mining for the v1.1 Tor default** (a #165 regression that produced zero shares), and unblocks the #256 benchmark.

## Root cause (source-grounded vs p2pool v4.16)
p2pool's `--socks5` (added by #165 for Tor sidechain routing) **also proxies p2pool's monerod RPC *and* ZMQ connection** (`json_rpc_request.cpp:249-256`, `zmq_reader.cpp:33-38`). p2pool exempts **only loopback** (`127.0.0.1`/`::1`/`localhost`; `util.cpp` `is_localhost`) from the proxy — a private Docker IP does **not** qualify. So with the default `p2pool.clearnet=false`, p2pool dialled the local monerod's private IP **through Tor**, which can't reach it → `get_info … empty response` → no template → **no mining**. There is **no per-host proxy-bypass flag**; the official p2pool Tor setup assumes `--host 127.0.0.1`.

Masked until now by #272 (e2e ran the pre-#165 p2pool with no `--socks5`).

## Fix
When `--socks5` is set, the p2pool entrypoint bridges `127.0.0.1` → the real node with **socat** (RPC + ZMQ) and repoints `--host` at loopback. The node RPC/ZMQ then stay **DIRECT** (socat is a plain TCP forward, not p2pool's proxy) while the **sidechain P2P still rides `--socks5` over Tor**. The node/ports are read from the args (no compose coupling); it's a no-op when clearnet (no `--socks5`) or the node is already loopback. `socat` added to the image.

## Validation (gouda, live, `p2pool.clearnet=false` — the default)
- Entrypoint logs `Tor on (#278): bridging 127.0.0.1 -> 172.28.0.26 …`; 4 socat procs running.
- p2pool gets a **full block template (44 transactions)** + `StratumServer event loop started` — reaching monerod, mining-ready (was looping on "empty response").
- p2pool syncs both the **mainchain** (via the bridged node) and the **sidechain** (`SideChain add_block`, over Tor).
- **#274 egress gate: clean PASS** — monerod/p2pool/tari/xmrig all "no persistent public connections" (`[verify-egress] OK`). monerod-via-socat is a private hop; the sidechain rides Tor.
- shellcheck clean.

Refs #165, #270, #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)