### PR TITLE
build(#282): supply-chain & secrets hardening (gitleaks, Trivy, Dependabot, SHA-pinned actions, zizmor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot (Wave 7 tooling, #282): automated dependency + CVE update PRs across every
+# supply-chain surface. Grouped + weekly to keep PR volume sane.
+version: 2
+updates:
+  # GitHub Actions — keep the SHA-pinned actions (#282) fresh. Dependabot rewrites the SHA and the
+  # `# vX.Y.Z` comment together.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Dashboard Python deps — bumps the hashed uv.lock + pyproject floors (#283).
+  - package-ecosystem: "uv"
+    directory: "/build/dashboard"
+    schedule:
+      interval: "weekly"
+    groups:
+      python:
+        patterns: ["*"]
+
+  # Base-image digests across every build/* Dockerfile (incl. the uv build image). This is the
+  # mechanism that clears base-distro CVEs — e.g. the openssl point-release accepted in .trivyignore.
+  - package-ecosystem: "docker"
+    directories:
+      - "/build/dashboard"
+      - "/build/monero"
+      - "/build/p2pool"
+      - "/build/tor"
+      - "/build/xmrig-proxy"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, develop]
   pull_request:
 
+# Least privilege (#282): every job here only reads the repo — none push commits, comment, or
+# publish packages. Narrowing the default GITHUB_TOKEN limits the blast radius of a compromised step.
+permissions:
+  contents: read
+
 jobs:
   dashboard:
     name: Dashboard tests (pytest + coverage)
@@ -12,8 +17,10 @@ jobs:
     env:
       UV_PYTHON_DOWNLOADS: never  # use the setup-python 3.11; don't fetch another interpreter
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install uv (pinned — reproducible, hash-locked installs, #283)
@@ -34,8 +41,10 @@ jobs:
     name: Frontend logic tests (node --test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
       # Pure client logic (worker sort, tooltip formatting) lives in static/logic.mjs and is
@@ -48,7 +57,9 @@ jobs:
     name: Dashboard image (Docker test stage)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Build the dashboard test stage (installs package + runs the suite in-container)
         run: docker build --target test ./build/dashboard
 
@@ -65,15 +76,30 @@ jobs:
       matrix:
         service: [monero, p2pool, tor, xmrig-proxy, dashboard]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: docker build ./build/${{ matrix.service }}
         run: docker build -t "pithead-${{ matrix.service }}:ci" "./build/${{ matrix.service }}"
+      - name: Scan image for CVEs (Trivy)
+        # Gate on actionable (fixable) HIGH/CRITICAL only; accepted findings live in .trivyignore.
+        # Must stay green before v1.1 images publish (#282).
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: pithead-${{ matrix.service }}:ci
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore
 
   hadolint:
     name: Dockerfile lint (hadolint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Install hadolint
         run: |
           sudo curl -fsSL -o /usr/local/bin/hadolint \
@@ -88,8 +114,10 @@ jobs:
     env:
       UV_PYTHON_DOWNLOADS: never
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install uv (pinned)
@@ -102,11 +130,49 @@ jobs:
         # locked `dev` extra — one pinned ruff for CI, pre-commit, and local devs.
         run: make lint-py
 
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0  # full history so the scan covers every commit, not just the tip
+      - name: Scan git history for secrets (gitleaks, pinned by digest)
+        # Run the binary via its pinned image (the gitleaks-action requires a license for org repos).
+        # Accepted false positives live in .gitleaks.toml.
+        run: |
+          docker run --rm -v "$PWD":/repo \
+            ghcr.io/gitleaks/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f \
+            git /repo --no-banner --redact --config /repo/.gitleaks.toml
+
+  zizmor:
+    name: Workflow audit (zizmor)
+    runs-on: ubuntu-latest
+    env:
+      UV_PYTHON_DOWNLOADS: never
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+      - name: Install uv (pinned)
+        run: |
+          export UV_INSTALL_DIR="$HOME/.local/bin"
+          curl -LsSf https://astral.sh/uv/0.10.10/install.sh | sh
+          echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
+      - name: Audit workflows (injection, token scope, self-hosted-runner risks)
+        run: uvx zizmor@1.25.2 --offline .github/workflows/
+
   shell:
     name: Shell tests (shellcheck + pithead suite)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       # shellcheck is preinstalled on ubuntu-* runners, so we invoke it directly.
       # Avoid `apt-get update`, which refreshes every configured source (incl.
       # unrelated third-party mirrors like dl.google.com) and intermittently fails
@@ -134,6 +200,8 @@ jobs:
     name: Compose config + security hardening
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Validate docker-compose.yml interpolation + hardening invariants (#90)
         run: bash tests/stack/test_compose.sh

--- a/.github/workflows/integration-mini-stack.yml
+++ b/.github/workflows/integration-mini-stack.yml
@@ -13,12 +13,17 @@ on:
       - "build/dashboard/**"
       - ".github/workflows/integration-mini-stack.yml"
 
+permissions:
+  contents: read
+
 jobs:
   mini-stack:
     name: Fake-daemon mini-stack (docker)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       # ubuntu-latest ships Docker with the Compose v2 plugin — no setup needed.
       - name: Run the fake-daemon mini-stack
         run: bash tests/integration/mini-stack/run-mini-stack.sh

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -32,6 +32,10 @@ concurrency:
   group: release-gate
   cancel-in-progress: false
 
+# Least privilege (#282): this runs on a self-hosted box holding real keys — keep the token read-only.
+permissions:
+  contents: read
+
 jobs:
   release-gate:
     name: Tier-4 live matrix (real nodes)
@@ -45,7 +49,9 @@ jobs:
     # box; prefer an ephemeral / just-in-time runner in its own runner group.
     runs-on: [self-hosted, pithead-release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Validate against the real synced nodes
         # Inputs go through env (not interpolated into the script) to avoid shell injection.
@@ -70,7 +76,7 @@ jobs:
 
       - name: Upload artifacts (redacted)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-gate-results
           path: tests/integration/results/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+# gitleaks secret-scan config (Wave 7 tooling, #282). Extends the upstream default ruleset.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Accepted false positives"
+regexTarget = "line"
+# curl auth assembled from shell ENV VARS (e.g. `-u "${USER:-}:${PASS:-}"`) is not a hardcoded
+# secret — the upstream `curl-auth-user` rule can't distinguish `${VAR}` from a literal credential.
+# This pattern only matches env-var expansions, so a real `-u "admin:hunter2"` is still caught.
+regexes = [
+  '''-u "\$\{[A-Z_]+:-\}:\$\{[A-Z_]+:-\}"''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,8 @@
 # Pre-commit hooks (Wave 7 tooling, #280). Local == CI: these mirror `make lint` + the CI lint
 # jobs, so issues are caught before they reach a PR. Set up once with:
 #   uv sync --project build/dashboard --extra dev && uv run --project build/dashboard pre-commit install
-# Later Wave 7 children add more hooks here (#281 shfmt/Biome/yamllint/markdownlint;
-# #282 gitleaks). Keep the ruff `rev` in lockstep with the `dev` extra's ruff pin in
-# build/dashboard/pyproject.toml.
+# Later Wave 7 children add more hooks here (#281 shfmt/Biome/yamllint/markdownlint). Keep the
+# ruff `rev` in lockstep with the `dev` extra's ruff pin in build/dashboard/pyproject.toml.
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.17
@@ -13,6 +12,12 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+
+  # Secret scanning (#282) — stop a key reaching history in the first place. Uses .gitleaks.toml.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,14 @@
+# Trivy ignore file (Wave 7 tooling, #282). One finding ID per line.
+#
+# The image scan gates on ACTIONABLE (fixable) HIGH/CRITICAL only (`--ignore-unfixed`) — unfixed
+# distro CVEs are reported but don't block. The entries below are the currently-accepted *fixable*
+# findings, each with a rationale and how it clears. Revisit whenever Dependabot bumps a base image.
+
+# openssl: the fix is a base-distro point release (Debian deb13u2 / Ubuntu 3.0.13-0ubuntu3.11) not
+# yet in our digest-pinned bases. Cleared when Dependabot (docker) bumps the base image digests.
+CVE-2026-45447
+
+# Base-image build tooling living in the python:3.11-slim *system* site-packages — NOT in the app's
+# /app/.venv and never invoked at runtime (the entrypoint runs the venv's python). Cleared by a base bump.
+CVE-2026-23949
+CVE-2026-24049

--- a/build/dashboard/Dockerfile
+++ b/build/dashboard/Dockerfile
@@ -1,14 +1,12 @@
 # ==========================================================================
-# Shared base: system deps + package metadata + source.
+# Shared base: system deps + package metadata + source. Deliberately has NO uv —
+# the production image must not ship the build tool (a runtime image with uv pulls
+# uv's own CVEs into image scans, #282). uv lives only in the build/test stages.
 # ==========================================================================
 # Pinned by digest (#135) so the python:3.11-slim tag can't be silently re-pointed.
 FROM python:3.11-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0 AS base
 
-# uv for reproducible, hash-locked installs from uv.lock (#283). The uv binary is copied from the
-# official image, pinned by digest (same posture as the base image, #135).
-COPY --from=ghcr.io/astral-sh/uv:0.10.10@sha256:cbe0a44ba994e327b8fe7ed72beef1aaa7d2c4c795fd406d1dbf328bacb2f1c5 /uv /uvx /bin/
-
-# Install into a project venv on PATH (so entrypoint.sh's `python3` resolves to it); use the
+# Run from a project venv on PATH (so entrypoint.sh's `python3` resolves to it); use the
 # digest-pinned base interpreter (never let uv download a different Python); compile bytecode and
 # copy (not hardlink) from the BuildKit cache mount used on the sync steps below.
 ENV UV_PYTHON_DOWNLOADS=never \
@@ -30,21 +28,28 @@ COPY pyproject.toml uv.lock ./
 COPY mining_dashboard/ ./mining_dashboard/
 
 # ==========================================================================
-# Test stage: install with test extras and run the suite with coverage.
+# Build stage: uv resolves the locked runtime deps into /app/.venv. uv is COPYed in
+# here (and in test) but never into production.
+# ==========================================================================
+FROM base AS build
+COPY --from=ghcr.io/astral-sh/uv:0.10.10@sha256:cbe0a44ba994e327b8fe7ed72beef1aaa7d2c4c795fd406d1dbf328bacb2f1c5 /uv /bin/
+RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked
+
+# ==========================================================================
+# Test stage: add the test extras to the venv and run the suite with coverage.
 # Build explicitly with `docker build --target test .` (CI does this);
 # a normal `docker compose build` targets the production stage and skips it.
 # ==========================================================================
-FROM base AS test
+FROM build AS test
 RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked --extra test
 COPY tests/ ./tests/
 RUN python -m pytest --cov=mining_dashboard --cov-report=term-missing --cov-fail-under=80
 
 # ==========================================================================
-# Production stage: install the package (runtime deps only) and run it.
+# Production stage: copy ONLY the resolved venv from `build` (no uv binary) and run it.
 # ==========================================================================
 FROM base AS production
-# Runtime deps + the package only (no test/dev extras).
-RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked
+COPY --from=build /app/.venv /app/.venv
 COPY entrypoint.sh .
 RUN chmod +x entrypoint.sh
 


### PR DESCRIPTION
Closes #282 — the highest-security-ROI child of Wave 7 (#279), the one with a deadline: it lands **before v1.1 images publish**. Extends our existing posture (SHA256-verified binaries, digest-pinned bases #135) to the previously-unguarded surfaces.

## What's in here

**1. SHA-pinned GitHub Actions** — every `uses:` across `ci.yml`, `integration-mini-stack.yml`, `release-gate.yml` pinned to a commit SHA + `# vX.Y.Z` comment (the thing we already refuse to skip for Docker bases). Dependabot keeps them fresh.

**2. zizmor workflow audit** (CI job, clean). Fixed its findings rather than suppressing:
- `permissions: contents: read` on every workflow (was using the broad default `GITHUB_TOKEN`).
- `persist-credentials: false` on every checkout. Both matter most for `release-gate.yml`, which runs on a **self-hosted box holding real wallet/onion keys**.

**3. gitleaks secret scanning** — CI job (full git history, image pinned by digest) + pre-commit hook. Repo is clean across all 491 commits; the one false positive (curl digest-auth built from **env vars** in `build/monero/healthcheck.sh`, not a literal) is allowlisted in `.gitleaks.toml` with a pattern that still catches real hardcoded creds.

**4. Trivy image scanning** of all 5 images in the `build-images` matrix — fail on **actionable** (`--ignore-unfixed`) HIGH/CRITICAL, with accepted findings in `.trivyignore`. The bases carry a long tail of *unfixed* distro CVEs (reported, not gated); only 3 *fixable* CVE IDs remain, all base-distro (openssl point-release + base-python build tooling) that clear via Dependabot base bumps.

**5. Dependabot** (`.github/dependabot.yml`) across **github-actions**, **uv** (`build/dashboard/uv.lock`, #283), and **docker** (base digests of all 5 Dockerfiles) — the mechanism that actually clears base-image CVEs.

**Bonus — Dockerfile hardening:** the dashboard production image no longer ships `uv`. uv is a build-time tool whose binary was dragging a HIGH (`rustls-webpki`) into the runtime image scan; a builder stage now copies only the resolved `/app/.venv`. (This also lands the best-practice item deferred in #283.)

## Verified locally (Docker available)

- **zizmor**: clean. **gitleaks**: no leaks (working tree + 491-commit history).
- **Trivy** `--ignore-unfixed` enumerated across the python-slim / ubuntu:24.04 / alpine bases (alpine: 0 actionable).
- **Dockerfile refactor**: production image has **no uv/uvx**, test stage still runs **532 tests**, entrypoint resolves to `/app/.venv/bin/python3`.
- All YAML/TOML parse.

## Heads-up (separate from this PR)
The `Fake-daemon mini-stack (docker)` check I made **required** on `develop` is **path-filtered** (only runs on `tests/integration/**` / `build/dashboard/**` / its own workflow). A PR touching none of those paths would never report it and stay blocked. This PR edits that workflow so it runs here — but we should **drop it from the required set** (or make it always-report). Happy to do that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)