### PR TITLE
build(#282): scope Dependabot to safe updates (docker digest-only, pin protobuf/grpcio)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,13 @@ updates:
     groups:
       python:
         patterns: ["*"]
+    ignore:
+      # protobuf/grpcio are pinned to what the vendored Tari gRPC stubs assert at import time
+      # (see build/dashboard/pyproject.toml); a major bump needs the stubs regenerated first.
+      - dependency-name: "protobuf"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "grpcio"
+        update-types: ["version-update:semver-major"]
 
   # Base-image digests across every build/* Dockerfile (incl. the uv build image). This is the
   # mechanism that clears base-distro CVEs — e.g. the openssl point-release accepted in .trivyignore.
@@ -35,3 +42,8 @@ updates:
     groups:
       docker:
         patterns: ["*"]
+    ignore:
+      # Major/minor base bumps (e.g. python 3.11->3.14, ubuntu 24.04->26.04) are deliberate
+      # migrations, not security updates — keep Dependabot to digest + patch within the pinned tag.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
Follow-up to #282 — the first Dependabot run proposed **breaking major bumps**, so this scopes the config:

- **docker**: ignore `semver-major`/`semver-minor`. Base-image upgrades (python:3.11-slim→3.14-slim, ubuntu:24.04→26.04) are deliberate migrations, not security updates — and would break the build (Python is pinned to 3.11 via `.python-version`/`uv.lock` + `UV_PYTHON_DOWNLOADS=never`). Dependabot now stays on the pinned tags and only bumps the digest/patch (the security use case).
- **uv (python)**: ignore `protobuf`/`grpcio` majors — both are pinned to what the vendored Tari gRPC stubs assert at import time (see the comment in `build/dashboard/pyproject.toml`); a major bump needs the stubs regenerated first.

Closed the two offending PRs ([#300](https://github.com/p2pool-starter-stack/pithead/pull/300) docker majors, [#301](https://github.com/p2pool-starter-stack/pithead/pull/301) protobuf 7). [#299](https://github.com/p2pool-starter-stack/pithead/pull/299) (action bumps to v6 — aligns with RigForge) is safe and being merged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)