### PR TITLE
fix(#291): apply Tor-egress firewall BEFORE compose in stack_upgrade

### DIFF
--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 553 dashboard unit tests · 12 contract tests · 59 frontend
-tests · 48 `pithead` shell sections · 17 harness self-test sections ·
+tests · 49 `pithead` shell sections · 17 harness self-test sections ·
 9 live config scenarios (17 axis values) · 7 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 48 `pithead` shell sections · 17 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 553 |
 | 1 — Unit | frontend (node --test) | 59 |
-| 1 — Unit | `pithead` shell suite | 48 sections |
+| 1 — Unit | `pithead` shell suite | 49 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 7 |
@@ -697,7 +697,7 @@ tests · 48 `pithead` shell sections · 17 harness self-test sections ·
 - edgePath: column-crossing edges route orthogonally through a clear lane
 - route palette + names cover every route the server can emit
 
-### `pithead` shell suite (tests/stack/run.sh) — 48 sections
+### `pithead` shell suite (tests/stack/run.sh) — 49 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -711,6 +711,7 @@ tests · 48 `pithead` shell sections · 17 harness self-test sections ·
 - p2pool entrypoint moves the Tari merge-mine gRPC onto loopback under Tor (#278 follow-up)
 - unit: tor_egress_rules — fail-closed Tor-only egress ruleset (#270)
 - black-box: apply/remove_tor_egress_firewall via stubbed iptables (#270)
+- regression: every command installs the Tor-egress firewall BEFORE compose (#291)
 - unit: config_bool honours an explicit false (jq // false-coercion guard, #294)
 - unit: clearnet initial sync helpers (#183)
 - unit: clock_sync_status (mining is time-sensitive)
@@ -901,5 +902,5 @@ tests · 48 `pithead` shell sections · 17 harness self-test sections ·
 
 ---
 
-_Grand total: **705** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **706** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/pithead
+++ b/pithead
@@ -290,6 +290,13 @@ stack_upgrade() {
     generate_caddyfile
     log "Re-rendered generated config for the current release."
     migrate_compose_project
+    # (Re)assert the Tor-only egress firewall BEFORE compose — same ordering as stack_up (#276), for
+    # the same reason: if the firewall isn't already installed (e.g. `down` then `upgrade`), starting
+    # containers first opens a startup window where a clearnet app (Tari, #271) can open a connection
+    # that the leading ESTABLISHED rule then grandfathers past the DROP (#291). In normal operation
+    # it's already installed from `up` and this is a cheap idempotent re-apply. Runs after the .env
+    # render above so the toggle/subnet are current.
+    apply_tor_egress_firewall # Tor-only egress (#270), consistent with up/apply
     # Source checkout: rebuild the images from build/. Release install: pull the new published images
     # instead — force a re-pull so a moved tag is refreshed (#44).
     if is_source_checkout; then
@@ -303,7 +310,6 @@ stack_upgrade() {
     else
         PITHEAD_PULL=always compose_up_checked -d || error "Upgrade failed during 'docker compose up' — see the error above."
     fi
-    apply_tor_egress_firewall # reassert the Tor-only egress firewall (#270), consistent with up/apply
     log "Stack upgraded."
 }
 

--- a/pithead
+++ b/pithead
@@ -193,8 +193,9 @@ stack_restart() {
 # Fail-closed host firewall so a misconfigured/buggy bridge daemon (monerod/p2pool/tari/xmrig-proxy)
 # CAN'T leak the home IP: each may reach the LAN, the other containers and the Tor SOCKS, but any
 # DIRECT clearnet dial is DROPPED — only the `tor` container reaches the internet. Rules live in
-# Docker's DOCKER-USER chain (preserved across Docker restarts), installed BEFORE containers start at
-# `up` (so there is no startup window to grandfather), re-asserted at `apply`, removed at `down`. Needs
+# Docker's DOCKER-USER chain (preserved across Docker restarts), installed BEFORE containers start on
+# every path that brings a clearnet-capable app up — `up`, `upgrade`, `apply`, `reset-dashboard` (so
+# there is no startup window to grandfather a leak past) — and removed at `down`. Needs
 # root (sudo), like the GRUB/HugePages steps; IPv4-only (mining_net is IPv4). Opt out with
 # network.tor_egress_firewall=false. Proven by tests/integration/benchmarks/bench-verify-egress.sh.
 # See docs/privacy.md.
@@ -847,6 +848,10 @@ reset_dashboard() {
     sudo chmod -R 755 "$p2pool_dir/stats"
 
     log "Bringing services back up..."
+    # p2pool can dial clearnet, so assert the Tor-only egress firewall BEFORE it starts (#270/#291).
+    # Idempotent if it's already present from `up`; closes the gap where running reset-dashboard on a
+    # `down` stack would otherwise bring p2pool up with no firewall installed at all.
+    apply_tor_egress_firewall
     docker compose up --pull "$(resolve_pull_policy)" -d dashboard p2pool
 }
 
@@ -2710,6 +2715,12 @@ apply() {
 
     log "Updating containers..."
     migrate_compose_project
+    # (Re)assert the Tor-only egress firewall BEFORE compose recreates anything — same ordering as
+    # up/upgrade (#276/#291), for the same reason: if it isn't already installed (e.g. `down` then
+    # `apply`), recreating containers first opens a startup window where a clearnet app dials out and
+    # the leading ESTABLISHED rule grandfathers it past the DROP. Idempotent, so the common case
+    # (already installed from `up`) is a cheap re-assert; the .env it reads was committed just above.
+    apply_tor_egress_firewall
     # Mark the recreate in-flight: cleared only after a SUCCESSFUL `up`, so a failure here (image
     # build error, a port already bound, a failed health/dependency gate, daemon hiccup) leaves the
     # marker for the next apply to retry instead of no-opping on the already-committed config (#125).
@@ -2726,7 +2737,6 @@ apply() {
         docker compose restart caddy
     fi
     rm -f "$apply_marker"
-    apply_tor_egress_firewall # (re)install the fail-closed Tor-only egress rules (#270)
     log "Configuration applied."
     announce_dashboard_url
 }

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -296,6 +296,28 @@ printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWA
 PATH="$FW/bin:$PATH" run_sourced "$FW" apply_tor_egress_firewall >/dev/null 2>&1
 assert_eq "opt-out (network.tor_egress_firewall=false) installs no DROP" "$(grep -c 'DROP' "$FW/ipt.log" 2>/dev/null)" "0"
 
+echo "== regression: stack_upgrade installs the Tor-egress firewall BEFORE compose (#291) =="
+# #272 added the firewall re-assert AFTER compose in stack_upgrade, reopening the startup window #276
+# closed for stack_up: if the firewall isn't already installed (down -> upgrade), a clearnet app can
+# dial out before the DROP lands and get grandfathered by the leading ESTABLISHED rule. The order of
+# apply_tor_egress_firewall vs compose_up_checked is load-bearing, so pin it. Neutralise the upgrade
+# preamble (config render, dirs, migrations) and record only the two ops we care about.
+upg_order=$(
+    cd "$SANDBOX" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    require_env() { :; }; parse_and_validate_config() { :; }; load_preserved_state() { :; }
+    ensure_directories() { :; }; resolve_dashboard_host() { :; }; render_env() { :; }; mv() { :; }
+    inject_service_configs() { :; }; generate_caddyfile() { :; }; migrate_compose_project() { :; }
+    is_source_checkout() { return 1; }; log() { :; }; docker() { :; }
+    apply_tor_egress_firewall() { echo firewall; }
+    compose_up_checked() { echo compose; }
+    stack_upgrade
+)
+assert_eq "stack_upgrade applies the firewall before 'compose up' (#291)" \
+    "$(printf '%s' "$upg_order" | tr '\n' ',')" "firewall,compose"
+
 echo "== unit: config_bool honours an explicit false (jq // false-coercion guard, #294) =="
 # Regression for #294: `.x // true` returns true even when x is explicitly false (jq treats false as
 # empty), which silently broke the #270 firewall opt-out (config false → .env stayed true) and

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -295,6 +295,28 @@ printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWA
 : >"$FW/ipt.log"
 PATH="$FW/bin:$PATH" run_sourced "$FW" apply_tor_egress_firewall >/dev/null 2>&1
 assert_eq "opt-out (network.tor_egress_firewall=false) installs no DROP" "$(grep -c 'DROP' "$FW/ipt.log" 2>/dev/null)" "0"
+# remove: `down` (and every re-apply) strips ONLY our tagged rules — this removal is the precondition
+# for the #291 down->upgrade/apply window, so prove it deletes the tags and spares foreign DOCKER-USER
+# rules. iptables-save replays two tagged rules + one foreign rule; remove must -D the tagged pair only.
+RM="$SANDBOX/rm"
+mkdir -p "$RM/bin"
+printf '#!/usr/bin/env bash\nexec "$@"\n' >"$RM/bin/sudo"
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s/ipt.log"\n' "$RM" >"$RM/bin/iptables"
+cat >"$RM/bin/iptables-save" <<'SAVE'
+#!/usr/bin/env bash
+cat <<'RULES'
+-A DOCKER-USER -m comment --comment pithead-tor-egress -s 172.28.0.0/24 -j DROP
+-A DOCKER-USER -m comment --comment pithead-tor-egress -s 172.28.0.25 -j ACCEPT
+-A DOCKER-USER -j RETURN
+RULES
+SAVE
+chmod +x "$RM/bin/sudo" "$RM/bin/iptables" "$RM/bin/iptables-save"
+: >"$RM/ipt.log"
+PATH="$RM/bin:$PATH" run_sourced "$RM" remove_tor_egress_firewall >/dev/null 2>&1
+rmlog="$(cat "$RM/ipt.log" 2>/dev/null)"
+assert_contains "down removes the tagged clearnet DROP" "$rmlog" "-D DOCKER-USER -m comment --comment pithead-tor-egress -s 172.28.0.0/24 -j DROP"
+assert_contains "down removes the tagged Tor-exempt ACCEPT" "$rmlog" "-D DOCKER-USER -m comment --comment pithead-tor-egress -s 172.28.0.25 -j ACCEPT"
+assert_not_contains "down leaves foreign DOCKER-USER rules untouched" "$rmlog" "RETURN"
 
 echo "== regression: every command installs the Tor-egress firewall BEFORE compose (#291) =="
 # The firewall must go in BEFORE any clearnet-capable container starts, on EVERY path that brings one
@@ -304,6 +326,23 @@ echo "== regression: every command installs the Tor-egress firewall BEFORE compo
 # firewall sentinel MUST precede the compose sentinel. fw_then_compose() extracts just those two from
 # whatever else the function prints (warnings, banners) so the assert is exact.
 fw_then_compose() { printf '%s\n' "$1" | grep -xE 'firewall|compose' | tr '\n' ','; }
+
+# up: the reference path #276 fixed — pin it too so a future reorder of stack_up is caught here.
+up_order=$(
+    cd "$SANDBOX" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    log() { :; }
+    warn_missing_data_dirs() { :; }
+    migrate_compose_project() { :; }
+    print_clearnet_banner() { :; }
+    announce_dashboard_url() { :; }
+    apply_tor_egress_firewall() { echo firewall; }
+    compose_up_checked() { echo compose; }
+    stack_up
+)
+assert_eq "up applies the firewall before 'compose up' (#276)" "$(fw_then_compose "$up_order")" "firewall,compose,"
 
 upg_order=$(
     cd "$SANDBOX" || exit

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -296,27 +296,93 @@ printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWA
 PATH="$FW/bin:$PATH" run_sourced "$FW" apply_tor_egress_firewall >/dev/null 2>&1
 assert_eq "opt-out (network.tor_egress_firewall=false) installs no DROP" "$(grep -c 'DROP' "$FW/ipt.log" 2>/dev/null)" "0"
 
-echo "== regression: stack_upgrade installs the Tor-egress firewall BEFORE compose (#291) =="
-# #272 added the firewall re-assert AFTER compose in stack_upgrade, reopening the startup window #276
-# closed for stack_up: if the firewall isn't already installed (down -> upgrade), a clearnet app can
-# dial out before the DROP lands and get grandfathered by the leading ESTABLISHED rule. The order of
-# apply_tor_egress_firewall vs compose_up_checked is load-bearing, so pin it. Neutralise the upgrade
-# preamble (config render, dirs, migrations) and record only the two ops we care about.
+echo "== regression: every command installs the Tor-egress firewall BEFORE compose (#291) =="
+# The firewall must go in BEFORE any clearnet-capable container starts, on EVERY path that brings one
+# up (#276 closed the window for stack_up; #291 + this change close it for upgrade/apply/reset). If a
+# container starts first, the leading ESTABLISHED rule grandfathers its clearnet dial past the DROP.
+# Each case neutralises the command's preamble and records the order of the two load-bearing ops; the
+# firewall sentinel MUST precede the compose sentinel. fw_then_compose() extracts just those two from
+# whatever else the function prints (warnings, banners) so the assert is exact.
+fw_then_compose() { printf '%s\n' "$1" | grep -xE 'firewall|compose' | tr '\n' ','; }
+
 upg_order=$(
     cd "$SANDBOX" || exit
     # shellcheck disable=SC1090
     source "$STACK"
     set +e
-    require_env() { :; }; parse_and_validate_config() { :; }; load_preserved_state() { :; }
-    ensure_directories() { :; }; resolve_dashboard_host() { :; }; render_env() { :; }; mv() { :; }
-    inject_service_configs() { :; }; generate_caddyfile() { :; }; migrate_compose_project() { :; }
-    is_source_checkout() { return 1; }; log() { :; }; docker() { :; }
+    require_env() { :; }
+    parse_and_validate_config() { :; }
+    load_preserved_state() { :; }
+    ensure_directories() { :; }
+    resolve_dashboard_host() { :; }
+    render_env() { :; }
+    mv() { :; }
+    inject_service_configs() { :; }
+    generate_caddyfile() { :; }
+    migrate_compose_project() { :; }
+    is_source_checkout() { return 1; }
+    log() { :; }
+    docker() { :; }
     apply_tor_egress_firewall() { echo firewall; }
     compose_up_checked() { echo compose; }
     stack_upgrade
 )
-assert_eq "stack_upgrade applies the firewall before 'compose up' (#291)" \
-    "$(printf '%s' "$upg_order" | tr '\n' ',')" "firewall,compose"
+assert_eq "upgrade applies the firewall before 'compose up' (#291)" "$(fw_then_compose "$upg_order")" "firewall,compose,"
+
+# apply had the same after-compose ordering bug as #272's stack_upgrade — fixed alongside #291. Take
+# the no-change-but-incomplete-marker retry path so apply recreates containers without the interactive
+# diff (env_changed_keys returns nothing; a pre-seeded .apply-incomplete marker forces the retry).
+apply_order=$(
+    cd "$SANDBOX" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    # shellcheck disable=SC2034  # read by the sourced apply()'s "not provisioned" guard, unseen here
+    MONERO_ONION=onion
+    require_env() { :; }
+    parse_and_validate_config() { :; }
+    load_preserved_state() { :; }
+    is_deployed() { return 0; }
+    ensure_directories() { :; }
+    resolve_dashboard_host() { :; }
+    render_env() { :; }
+    env_changed_keys() { :; }
+    mv() { :; }
+    inject_service_configs() { :; }
+    generate_caddyfile() { :; }
+    migrate_compose_project() { :; }
+    announce_dashboard_url() { :; }
+    log() { :; }
+    warn() { :; }
+    docker() { :; }
+    apply_tor_egress_firewall() { echo firewall; }
+    compose_up_checked() { echo compose; }
+    : >".env.apply-incomplete" # force the retry path
+    apply
+)
+assert_eq "apply applies the firewall before 'compose up' (#291)" "$(fw_then_compose "$apply_order")" "firewall,compose,"
+
+# reset-dashboard recreates p2pool (clearnet-capable); on a `down` stack it must install the firewall
+# first or p2pool comes up with no firewall at all. -y skips the destructive confirm; the docker stub
+# emits the compose sentinel only for the `compose up` it ends on.
+rd_order=$(
+    cd "$SANDBOX" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    env_get() { echo "/nonexistent/reset-$1"; } # non-existent dirs -> rm skipped
+    assert_safe_dir() { :; }
+    mkdir() { :; }
+    sudo() { :; }
+    log() { :; }
+    docker() {
+        [ "$1 $2" = "compose up" ] && echo compose
+        return 0
+    }
+    apply_tor_egress_firewall() { echo firewall; }
+    reset_dashboard -y
+)
+assert_eq "reset-dashboard applies the firewall before 'compose up' (#291)" "$(fw_then_compose "$rd_order")" "firewall,compose,"
 
 echo "== unit: config_bool honours an explicit false (jq // false-coercion guard, #294) =="
 # Regression for #294: `.x // true` returns true even when x is explicitly false (jq treats false as


### PR DESCRIPTION
## What

Restore the **firewall-before-compose** ordering on every command that brings a clearnet-capable container up. `apply_tor_egress_firewall` (#270) must run *before* `compose up`, or the leading `ESTABLISHED,RELATED -j ACCEPT` rule grandfathers a clearnet dial opened during the startup window past the `DROP` (the original reason #276 moved it before compose in `stack_up`).

Auditing every container-start path (the second half of this request) surfaced three commands that violated the invariant:

| Command | Before | After |
|---|---|---|
| `up` (`stack_up`) | firewall before compose ✓ | unchanged |
| `upgrade` (`stack_upgrade`) | firewall **after** compose ✗ (#291) | firewall before compose |
| `apply` | firewall **after** compose ✗ | firewall before compose |
| `reset-dashboard` | **never asserted** the firewall ✗ | firewall before bringing p2pool up |
| `provision_tor` | tor only (the egress proxy) | n/a — no change |
| `restart` | restart-in-place, rules persist | n/a — no change |

The command guards (`require_env` / `require_deployed`) were already consistent and appropriate across the dispatch — no changes needed there.

## When it bites

In normal operation the firewall is installed at `up` and persists across `upgrade`/`apply` (Docker never flushes `DOCKER-USER`), so there's no window. The gap opens on a `down` → `upgrade`/`apply`/`reset-dashboard` sequence, where the firewall was removed at `down` and the command starts containers before reinstalling it.

- **upgrade** (#291, observed): deploying `develop` to gouda via `down` → `git checkout develop` → `pithead upgrade`, Tari came up holding **2 grandfathered public peers** (`57.129.110.6`, `78.80.36.112`); a `docker compose restart tari` cleared them.
- **apply**: identical window on `down` → `apply`.
- **reset-dashboard**: worse — it never called `apply_tor_egress_firewall` at all, so on a `down` stack p2pool (clearnet-capable) came up with **no firewall installed**, and stayed that way until the next `up`/`apply`/`upgrade`.

## Fix

- `stack_upgrade`, `apply`: move `apply_tor_egress_firewall` to **before** `compose_up_checked`, after the `.env` render/commit (so the toggle/subnet are current). The re-apply is idempotent, so the common case (firewall already present) is a cheap re-assert.
- `reset_dashboard`: assert the firewall before the `compose up dashboard p2pool`.
- Update the firewall header comment to list every path it's installed on.
- Regression test (`tests/stack/run.sh`): a shared `fw_then_compose` helper pins firewall-before-compose ordering for **upgrade, apply, and reset-dashboard** — each verified to **fail** against its pre-fix ordering and pass after.

## Testing

- `tests/stack/run.sh`: **395 passed, 0 failed** (incl. the three new ordering regressions).
- `make lint-sh` (shellcheck + shfmt): clean.

Closes #291. Refs #270 #272 #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)