### PR TITLE
docs(#259): third-party attribution + GPLv3 compliance for published images

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+The MIT license above applies to this project's own code. Bundled third-party
+components — including the GPLv3 `p2pool` and `xmrig-proxy` binaries in the
+published images — retain their own licenses. See THIRD_PARTY_LICENSES.md.

--- a/README.md
+++ b/README.md
@@ -208,4 +208,7 @@ appreciated:
 
 ## 📄 License
 
-Provided "as-is" under the [MIT License](./LICENSE).
+Pithead's own code is provided "as-is" under the [MIT License](./LICENSE). Bundled
+third-party components keep their own licenses (two — `p2pool`, `xmrig-proxy` — are GPLv3,
+shipped unmodified as separate containers) — see
+[`THIRD_PARTY_LICENSES.md`](./THIRD_PARTY_LICENSES.md).

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,32 @@
+# Third-Party Licenses
+
+Pithead's own code is [MIT](./LICENSE). The images it builds and the files it
+vendors also **redistribute** third-party components, which keep their own licenses:
+
+## Bundled binaries (in the published `pithead-*` images)
+
+Version-pinned, sha256-verified, **unmodified** upstream binaries (pin + hash in each
+`build/<name>/Dockerfile`):
+
+| Binary | Version | License | Source |
+|--------|---------|---------|--------|
+| monerod | v0.18.5.0 | BSD-3-Clause | <https://github.com/monero-project/monero> |
+| p2pool | v4.16 | **GPL-3.0-or-later** | <https://github.com/SChernykh/p2pool/releases/tag/v4.16> |
+| xmrig-proxy | 6.26.0 | **GPL-3.0-or-later** | <https://github.com/xmrig/xmrig-proxy/releases/tag/v6.26.0> |
+| tor | distro | BSD-3-Clause | <https://gitlab.torproject.org/tpo/core/tor> |
+
+`p2pool` and `xmrig-proxy` are GPL-3.0, shipped **unmodified** as **separate
+containers** (mere aggregation — no linking into Pithead's code). The GPLv3 text is at
+<https://www.gnu.org/licenses/gpl-3.0.txt>; the **corresponding source** is the exact
+upstream release linked above (matching the pinned version + sha256 in the Dockerfile).
+
+## Vendored / generated (in `pithead-dashboard`)
+
+- Frontend JS under `build/dashboard/mining_dashboard/web/static/`: **preact** 10.24.3 (MIT),
+  **htm** 3.1.1 (Apache-2.0), **chart.js** 4.4.6 (MIT), **chartjs-plugin-zoom** 2.2.0 (MIT),
+  **hammerjs** 2.0.8 (MIT) — see that dir's `vendor/README.md`.
+- Tari gRPC `.proto` files + generated stubs under
+  `build/dashboard/mining_dashboard/client/tari/`: **BSD-3-Clause**, © The Tari Project.
+
+Base images (`ubuntu`/`alpine`/`python-slim`) and the dashboard's Python dependencies
+(`build/dashboard/pyproject.toml`) carry their own, permissive licenses.

--- a/build/dashboard/mining_dashboard/web/static/vendor/README.md
+++ b/build/dashboard/mining_dashboard/web/static/vendor/README.md
@@ -5,13 +5,16 @@ step and serves entirely from `/static` under a strict Content-Security-Policy
 (`script-src 'self'`, no `'unsafe-inline'`/`'unsafe-eval'`). Both are standalone ES modules
 with no bare imports and no `eval`/`new Function`, so they load and run under that CSP.
 
-| File                | Package  | Version | Source                                               |
-|---------------------|----------|---------|------------------------------------------------------|
-| `preact.module.js`  | preact   | 10.24.3 | <https://unpkg.com/preact@10.24.3/dist/preact.module.js> |
-| `htm.module.js`     | htm      | 3.1.1   | <https://unpkg.com/htm@3.1.1/dist/htm.module.js>         |
-| `chart.umd.min.js`  | chart.js | (vendored previously) | <https://www.chartjs.org/>                 |
-| `chartjs-plugin-zoom.min.js` | chartjs-plugin-zoom | 2.2.0 | <https://unpkg.com/chartjs-plugin-zoom@2.2.0/dist/chartjs-plugin-zoom.min.js> |
-| `hammer.min.js`     | hammerjs | 2.0.8 | <https://unpkg.com/hammerjs@2.0.8/hammer.min.js> |
+| File                | Package  | Version | License | Source                                     |
+|---------------------|----------|---------|---------|--------------------------------------------|
+| `preact.module.js`  | preact   | 10.24.3 | MIT | <https://unpkg.com/preact@10.24.3/dist/preact.module.js> |
+| `htm.module.js`     | htm      | 3.1.1   | Apache-2.0 | <https://unpkg.com/htm@3.1.1/dist/htm.module.js>     |
+| `chart.umd.min.js`  | chart.js | 4.4.6 | MIT | <https://www.chartjs.org/>                             |
+| `chartjs-plugin-zoom.min.js` | chartjs-plugin-zoom | 2.2.0 | MIT | <https://unpkg.com/chartjs-plugin-zoom@2.2.0/dist/chartjs-plugin-zoom.min.js> |
+| `hammer.min.js`     | hammerjs | 2.0.8 | MIT | <https://unpkg.com/hammerjs@2.0.8/hammer.min.js> |
+
+These licenses are also recorded in the repo-root `THIRD_PARTY_LICENSES.md`. `chart.umd.min.js`
+lives one directory up (in `static/`, not `vendor/`); listed here so the attribution is complete.
 
 `chartjs-plugin-zoom` is a UMD bundle (like `chart.umd.min.js`), loaded as a classic `<script>`
 after Chart.js; it exposes the global `ChartZoom` and is registered explicitly via


### PR DESCRIPTION
Closes #259.

Bare-minimum licensing hygiene so the MIT claim is accurate. MIT stays right for the orchestrator — `p2pool` and `xmrig-proxy` are GPLv3 but shipped **unmodified** as **separate containers** (mere aggregation, no linking).

**One new file:** [`THIRD_PARTY_LICENSES.md`](../blob/claude/flamboyant-greider-54f336/THIRD_PARTY_LICENSES.md) — lists the redistributed components (bundled binaries, vendored JS, Tari gRPC stubs) with licenses, and the **corresponding-source pointers** to the exact upstream releases for the two GPLv3 binaries.

**Small edits:**
- `LICENSE` + README "License" — scope MIT to our own code; bundled files keep their own licenses.
- Vendored-JS README — license column (`htm` = Apache-2.0, rest MIT) + fixed stale chart.js version.

No code or image changes.

> Trimmed from an earlier, heavier draft per review: dropped the explainer doc and the in-image GPL-text/NOTICE bundling (Dockerfile changes). Corresponding source is pointed at upstream + this public repo. If you'd rather bake the GPL text + source NOTICE into the two GPLv3 images for §6 belt-and-suspenders, say the word and I'll add it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)