### PR TITLE
feat(#255,#91): run all containers as non-root + security follow-ups

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,10 +33,10 @@ We aim to acknowledge reports promptly and will keep you posted as we work on a 
 
 ## Security posture
 
-The stack is hardened by default: least-privilege containers (leaf services run with
-`no-new-privileges` and — except the dashboard, which writes its history DB as root into a
-user-owned volume — drop all Linux capabilities; the internet-facing and Docker-socket-facing
-ones also use a read-only root filesystem), SHA256-verified and version-pinned binaries,
+The stack is hardened by default: least-privilege containers (every service runs as a **non-root
+user**, not uid 0; leaf services run with `no-new-privileges` and drop all Linux capabilities; the
+internet-facing and Docker-socket-facing ones also use a read-only root filesystem),
+SHA256-verified and version-pinned binaries,
 localhost-only RPC, a LAN-scoped (and narrowable) stratum port, scoped Docker socket proxies,
 and Tor for all node networking. If you find a gap in any of these, that's exactly the kind of
 report we want.

--- a/build/dashboard/Dockerfile
+++ b/build/dashboard/Dockerfile
@@ -72,11 +72,14 @@ LABEL org.opencontainers.image.title="Pithead Dashboard" \
 
 # Run non-root (#255). debian-slim has no stock uid-1000 user, so create 'pithead' (uid:gid
 # 1000:1000) to match the uid pithead chowns ${DASHBOARD_DATA_DIR} (/data) to. /app + the venv stay
-# root-owned and are only read/executed at runtime; the SQLite history is written to /data, and the
-# clearnet-state marker dir is world-writable (#234), so no app-dir writes are needed. This lets
-# compose finally cap_drop:[ALL] the dashboard — it no longer needs root's CAP_DAC_OVERRIDE to write
-# into the host-user-owned data dir.
-RUN groupadd -g 1000 pithead && useradd -u 1000 -g 1000 -m -s /usr/sbin/nologin pithead
+# root-owned and are only read/executed at runtime; the SQLite history is written to /data and the
+# clearnet-state marker to /clearnet-state. Create both in-image owned by pithead: with a host
+# bind-mount (the real stack) the mount masks them and pithead's chown governs ownership; with a
+# NAMED volume (the integration mini-stack) Docker seeds the empty volume from the image dir's
+# ownership, so this is what makes /data writable there. This lets compose finally cap_drop:[ALL]
+# the dashboard — it no longer needs root's CAP_DAC_OVERRIDE to write the host-user-owned data dir.
+RUN groupadd -g 1000 pithead && useradd -u 1000 -g 1000 -m -s /usr/sbin/nologin pithead \
+    && install -d -o pithead -g pithead /data /clearnet-state
 USER pithead
 
 ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]

--- a/build/dashboard/Dockerfile
+++ b/build/dashboard/Dockerfile
@@ -70,4 +70,13 @@ LABEL org.opencontainers.image.title="Pithead Dashboard" \
       org.opencontainers.image.version=$PITHEAD_VERSION \
       org.opencontainers.image.revision=$PITHEAD_GIT_COMMIT
 
+# Run non-root (#255). debian-slim has no stock uid-1000 user, so create 'pithead' (uid:gid
+# 1000:1000) to match the uid pithead chowns ${DASHBOARD_DATA_DIR} (/data) to. /app + the venv stay
+# root-owned and are only read/executed at runtime; the SQLite history is written to /data, and the
+# clearnet-state marker dir is world-writable (#234), so no app-dir writes are needed. This lets
+# compose finally cap_drop:[ALL] the dashboard — it no longer needs root's CAP_DAC_OVERRIDE to write
+# into the host-user-owned data dir.
+RUN groupadd -g 1000 pithead && useradd -u 1000 -g 1000 -m -s /usr/sbin/nologin pithead
+USER pithead
+
 ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]

--- a/build/monero/Dockerfile
+++ b/build/monero/Dockerfile
@@ -28,10 +28,10 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 COPY healthcheck.sh /usr/local/bin/monerod-healthcheck.sh
 RUN chmod +x /usr/local/bin/monerod-healthcheck.sh
 
-# Run non-root (#255). Reuse ubuntu:24.04's built-in 'ubuntu' user (uid 1000); pithead chowns the
-# blockchain bind-mount (/root/.bitmonero) to match. /root itself isn't bind-mounted, so make it
-# traversable+readable so uid 1000 can chdir there and read the bind-mounted config template.
-RUN chmod 0755 /root
-WORKDIR /root
+# Run non-root (#255). Reuse ubuntu:24.04's built-in 'ubuntu' user (uid 1000) and keep monerod's
+# data under that user's home — /home/ubuntu/.bitmonero, which is also monerod's native
+# $HOME/.bitmonero default. pithead chowns the blockchain bind-mount to match.
+RUN install -d -o ubuntu -g ubuntu /home/ubuntu
+WORKDIR /home/ubuntu
 USER ubuntu
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/monero/Dockerfile
+++ b/build/monero/Dockerfile
@@ -28,5 +28,10 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 COPY healthcheck.sh /usr/local/bin/monerod-healthcheck.sh
 RUN chmod +x /usr/local/bin/monerod-healthcheck.sh
 
+# Run non-root (#255). Reuse ubuntu:24.04's built-in 'ubuntu' user (uid 1000); pithead chowns the
+# blockchain bind-mount (/root/.bitmonero) to match. /root itself isn't bind-mounted, so make it
+# traversable+readable so uid 1000 can chdir there and read the bind-mounted config template.
+RUN chmod 0755 /root
 WORKDIR /root
+USER ubuntu
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/monero/bitmonero.conf.template
+++ b/build/monero/bitmonero.conf.template
@@ -1,7 +1,7 @@
 # --- Data & Logging Configuration ---
 # Internal container paths for blockchain data and logs
-data-dir=/root/.bitmonero
-log-file=/root/.bitmonero/bitmonero.log
+data-dir=/home/ubuntu/.bitmonero
+log-file=/home/ubuntu/.bitmonero/bitmonero.log
 log-level=0
 
 # --- Blockchain Pruning ---

--- a/build/monero/entrypoint.sh
+++ b/build/monero/entrypoint.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Define paths for configuration management (overridable for testing).
-TEMPLATE_PATH="${TEMPLATE_PATH:-/root/bitmonero.conf.template}"
-CONFIG_PATH="${CONFIG_PATH:-/root/.bitmonero/bitmonero.conf}"
+TEMPLATE_PATH="${TEMPLATE_PATH:-/home/ubuntu/bitmonero.conf.template}"
+CONFIG_PATH="${CONFIG_PATH:-/home/ubuntu/.bitmonero/bitmonero.conf}"
 # Shared, dashboard-writable state dir (#234). The dashboard drops this marker once monerod has
 # finished its clearnet initial sync and restarts the container; seeing it here means "the clearnet
 # sync already completed — come up on Tor." Default matches the compose mount; overridable for tests.

--- a/build/p2pool/Dockerfile
+++ b/build/p2pool/Dockerfile
@@ -27,7 +27,15 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 COPY healthcheck.sh /usr/local/bin/p2pool-healthcheck.sh
 RUN chmod +x /usr/local/bin/p2pool-healthcheck.sh
 
+# Run non-root (#255). Reuse ubuntu:24.04's built-in 'ubuntu' user (uid 1000); pithead chowns the
+# ${P2POOL_DATA_DIR} bind-mount (which replaces all of /root) + /stats to match, so p2pool's cache
+# and data-api writes succeed as uid 1000. The IPC_LOCK/SYS_NICE caps granted in compose are not
+# effective for a non-root process, but p2pool only needs them for mlock (covered by the unlimited
+# memlock ulimit) and best-effort thread priority — neither is fatal if unavailable. chmod /root so
+# a bare `docker run` without the bind-mount can still chdir here (in the stack it's always mounted).
+RUN chmod 0755 /root
 WORKDIR /root
+USER ubuntu
 
 # Use the wrapper script as the entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/p2pool/Dockerfile
+++ b/build/p2pool/Dockerfile
@@ -27,14 +27,13 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 COPY healthcheck.sh /usr/local/bin/p2pool-healthcheck.sh
 RUN chmod +x /usr/local/bin/p2pool-healthcheck.sh
 
-# Run non-root (#255). Reuse ubuntu:24.04's built-in 'ubuntu' user (uid 1000); pithead chowns the
-# ${P2POOL_DATA_DIR} bind-mount (which replaces all of /root) + /stats to match, so p2pool's cache
-# and data-api writes succeed as uid 1000. The IPC_LOCK/SYS_NICE caps granted in compose are not
-# effective for a non-root process, but p2pool only needs them for mlock (covered by the unlimited
-# memlock ulimit) and best-effort thread priority — neither is fatal if unavailable. chmod /root so
-# a bare `docker run` without the bind-mount can still chdir here (in the stack it's always mounted).
-RUN chmod 0755 /root
-WORKDIR /root
+# Run non-root (#255). Reuse ubuntu:24.04's built-in 'ubuntu' user (uid 1000) and keep p2pool's data
+# under that user's home; pithead chowns the ${P2POOL_DATA_DIR} bind-mount (mapped to /home/ubuntu)
+# + /stats to match, so the cache and data-api writes succeed as uid 1000. The IPC_LOCK/SYS_NICE
+# caps granted in compose are not effective for a non-root process, but p2pool only needs them for
+# mlock (covered by the unlimited memlock ulimit) and best-effort thread priority — neither is fatal.
+RUN install -d -o ubuntu -g ubuntu /home/ubuntu
+WORKDIR /home/ubuntu
 USER ubuntu
 
 # Use the wrapper script as the entrypoint

--- a/build/tari/config.toml.template
+++ b/build/tari/config.toml.template
@@ -41,7 +41,12 @@ mining_enabled = true
 grpc_enabled = true
 grpc_address = "/ip4/0.0.0.0/tcp/18142"
 
-# Allowed gRPC methods for interaction with the dashboard and miner
+# Allowed gRPC methods (#91): pruned to the node-status + merge-mining surface our two consumers
+# actually call. The dashboard's Tari client (tari_client.py) uses get_tip_info + get_sync_progress
+# (with get_version/get_sync_info as fallbacks); p2pool's merge-mining needs the block-template,
+# submit_block and tip methods. Everything else — the wallet/transaction, UTXO/kernel/payment-ref
+# search, mempool-tx and DAN validator-node calls — has no consumer here, so it's removed (smaller
+# attack surface on the gRPC port). Re-add a method if a future dashboard panel needs it.
 grpc_server_allow_methods = [
     "get_version",
     "get_sync_info",
@@ -56,7 +61,6 @@ grpc_server_allow_methods = [
     "get_constants",
     "get_block_size",
     "get_block_fees",
-    "get_tokens_in_circulation",
     "get_network_difficulty",
     "get_new_block_template",
     "get_new_block",
@@ -65,22 +69,8 @@ grpc_server_allow_methods = [
     "get_new_block_blob",
     "submit_block",
     "submit_block_blob",
-    "submit_transaction",
-    "search_kernels",
-    "search_utxos",
-    "fetch_matching_utxos",
     "get_peers",
-    "get_mempool_transactions",
-    "transaction_state",
     "list_connected_peers",
-    "get_mempool_stats",
-    "get_active_validator_nodes",
-    "get_validator_node_changes",
-    "get_shard_key",
-    "get_template_registrations",
-    "get_side_chain_utxos",
-    "search_payment_references",
-    "search_payment_references_via_output_hash",
 ]
 
 [base_node.p2p]

--- a/build/xmrig-proxy/Dockerfile
+++ b/build/xmrig-proxy/Dockerfile
@@ -19,5 +19,10 @@ RUN wget -O xmrig-proxy.tar.gz https://github.com/xmrig/xmrig-proxy/releases/dow
     && chmod +x /usr/local/bin/xmrig-proxy \
     && rm -rf xmrig-proxy*
 
-WORKDIR /root
+# Run non-root (#255) — the easy win: pure network proxy, no bind-mounts, already cap_drop:[ALL]
+# + no-new-privileges in compose. Reuse ubuntu:24.04's 'ubuntu' user (uid 1000) and give it a
+# writable home as the cwd in case xmrig-proxy drops a config/log there.
+RUN install -d -o ubuntu -g ubuntu /home/ubuntu
+WORKDIR /home/ubuntu
+USER ubuntu
 ENTRYPOINT ["xmrig-proxy"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,10 @@ services:
     # Pinned by digest (#135) so the v5.3.1-mainnet tag can't be silently re-pointed.
     image: quay.io/tarilabs/minotari_node:v5.3.1-mainnet@sha256:824fd6ec21d618805317d7eede374d6782906eeae17d2fc8aaad4df6205f94e0
     container_name: tari
+    # Run non-root (#255). Pulled image (not our Dockerfile), so set the uid via compose to match the
+    # uid pithead chowns ${TARI_DATA_DIR} to. The wrapper entrypoint reads the canonical config
+    # read-only and writes its runtime copy to /tmp, so only the data dir needs to be owned by 1000.
+    user: "1000:1000"
     restart: unless-stopped
     stop_grace_period: 1m
     logging: *default-logging
@@ -178,8 +182,10 @@ services:
     memswap_limit: 1g
     restart: unless-stopped
     logging: *default-logging
-    # Replaces 'privileged: true'. p2pool only needs to lock HugePages for the
-    # RandomX dataset (IPC_LOCK) and raise thread priority (SYS_NICE).
+    # Replaces 'privileged: true'. p2pool only needs to lock HugePages for the RandomX dataset
+    # (IPC_LOCK) and raise thread priority (SYS_NICE). NOTE (#255): the container now runs non-root,
+    # so these caps aren't in the process's effective set — but mlock is covered by the unlimited
+    # memlock ulimit below, and SYS_NICE is best-effort (p2pool warns and continues without it).
     cap_add:
       - IPC_LOCK
       - SYS_NICE
@@ -328,14 +334,19 @@ services:
     memswap_limit: 512m
     restart: unless-stopped
     logging: *default-logging
+    # Host networking, kept deliberately (#91 P5, evaluated & closed): the dashboard reaches the
+    # local monerod RPC on 127.0.0.1:18081 (Issue #29) plus the host-published proxy/Tor-SOCKS
+    # endpoints, and Caddy proxies it on the host. Moving to the bridge would mean re-plumbing the
+    # monerod address, the dashboard's bind, Caddy's upstream and LAN-worker reachability for a
+    # marginal gain — net negative, so host networking stays. It binds only 127.0.0.1 (HOST_IP).
     network_mode: "host"
-    # Hardened with no-new-privileges (#90). Deliberately NOT cap_drop: [ALL] like the other
-    # leaf services: the dashboard runs as root and persists its SQLite history into the
-    # ${DASHBOARD_DATA_DIR} bind mount, which pithead creates owned by the host user. Dropping
-    # all capabilities strips CAP_DAC_OVERRIDE, so root could no longer create the SQLite
-    # WAL/journal files in that user-owned directory and history writes would fail.
+    # Now runs non-root (uid 1000, #255) and owns ${DASHBOARD_DATA_DIR}, so it no longer needs
+    # root's CAP_DAC_OVERRIDE to write its SQLite history — drop all capabilities like the other
+    # leaf services (#90). no-new-privileges stays as defense-in-depth.
     security_opt:
       - no-new-privileges:true
+    cap_drop:
+      - ALL
     volumes:
       - ${P2POOL_DATA_DIR}/stats:/app/stats:ro
       - ${DASHBOARD_DATA_DIR}:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,9 +75,9 @@ services:
       # Subnet prefix (#180): the entrypoint envsubst's it into the Tor SOCKS IP in bitmonero.conf.
       - NETWORK_PREFIX=${NETWORK_PREFIX:-172.28.0}
     volumes:
-      - ${MONERO_DATA_DIR}:/root/.bitmonero
+      - ${MONERO_DATA_DIR}:/home/ubuntu/.bitmonero
       - /dev/hugepages:/dev/hugepages
-      - ./build/monero/bitmonero.conf.template:/root/bitmonero.conf.template:ro
+      - ./build/monero/bitmonero.conf.template:/home/ubuntu/bitmonero.conf.template:ro
       # Read-only view of the shared clearnet-state dir (#234): the entrypoint reads the
       # dashboard-written "sync complete" marker to decide clearnet-vs-Tor at startup.
       - ${CLEARNET_STATE_DIR:-./data/clearnet-state}:/clearnet-state:ro
@@ -194,7 +194,7 @@ services:
         soft: -1
         hard: -1
     volumes:
-      - ${P2POOL_DATA_DIR}:/root
+      - ${P2POOL_DATA_DIR}:/home/ubuntu
       - ${P2POOL_DATA_DIR}/stats:/stats
       - /dev/hugepages:/dev/hugepages
     command:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,16 +103,18 @@ connection-by-connection map and how to lock down the rest.
 
 ## Security posture
 
-- **Containerized & least-privilege.** Services run in containers; where privileges are needed
-  (e.g. P2Pool's memory locking) they're granted narrowly via specific Linux capabilities rather
-  than running fully privileged. The leaf services (Caddy, the dashboard, the two Docker socket
-  proxies, and `xmrig-proxy`) run with `no-new-privileges`, and all of them **except the
-  dashboard** also drop **every Linux capability** (`cap_drop: [ALL]`) — Caddy keeps only
-  `NET_BIND_SERVICE` so it can bind `:80`/`:443`. The dashboard is the exception because it runs
-  as root and writes its history database into a host-user-owned volume, which needs the default
-  file-permission capability. Caddy and both socket proxies additionally run with a **read-only
-  root filesystem**, writing only to a small ephemeral `tmpfs` and (for Caddy) the `caddy_data`
-  volume that holds its certs.
+- **Containerized, non-root & least-privilege.** Services run in containers, and every one runs
+  its main process as a **non-root user** (not uid 0) — pithead owns the data directories and
+  chowns each bind-mount to the uid its container uses, so a breakout or RCE in any daemon lands
+  as an unprivileged user. Where a privilege is genuinely needed (e.g. P2Pool's memory locking)
+  it's granted narrowly — P2Pool relies on an unlimited `memlock` ulimit rather than running
+  privileged. The leaf services (Caddy, the dashboard, the two Docker socket proxies, and
+  `xmrig-proxy`) run with `no-new-privileges`, and all of them **drop every Linux capability**
+  (`cap_drop: [ALL]`) — Caddy keeps only `NET_BIND_SERVICE` so it can bind `:80`/`:443`. The
+  dashboard now writes its history database as that non-root user into its (matching-owned) volume,
+  so it no longer needs root's file-permission capability and drops all caps like the others.
+  Caddy and both socket proxies additionally run with a **read-only root filesystem**, writing only
+  to a small ephemeral `tmpfs` and (for Caddy) the `caddy_data` volume that holds its certs.
 - **Mining endpoint stays on the LAN.** The stratum port (`3333`) your rigs connect to is meant
   for your local network, never the public internet. It's published on all interfaces by default
   so LAN rigs work out of the box; narrow it with `p2pool.stratum_bind` (a specific LAN IP, or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,9 +132,9 @@ default each one lives under `./data/<service>` inside the repo:
 
 | Service | Config key | Default path | Mounted in container at |
 |---|---|---|---|
-| Monero | `monero.data_dir` | `./data/monero` | `/root/.bitmonero` |
+| Monero | `monero.data_dir` | `./data/monero` | `/home/ubuntu/.bitmonero` |
 | Tari | `tari.data_dir` | `./data/tari` | `/var/tari/node` |
-| P2Pool | `p2pool.data_dir` | `./data/p2pool` | `/root` |
+| P2Pool | `p2pool.data_dir` | `./data/p2pool` | `/home/ubuntu` |
 | Tor | `tor.data_dir` | `./data/tor` | `/var/lib/tor` |
 | Dashboard | `dashboard.data_dir` | `./data/dashboard` | `/data` |
 
@@ -221,8 +221,8 @@ sync. There are two ways to do it.
 
 ### Option A — Point the bundled node at your existing blockchain
 
-The Monero data directory mounts to `/root/.bitmonero` inside the container, the same layout a
-standard `monerod` uses. To have the bundled node adopt a blockchain you've already downloaded,
+The Monero data directory mounts to `/home/ubuntu/.bitmonero` inside the container, the same layout a
+standard `monerod` uses (its native `$HOME/.bitmonero`). To have the bundled node adopt a blockchain you've already downloaded,
 point `monero.data_dir` at your existing `.bitmonero` directory:
 
 ```json

--- a/pithead
+++ b/pithead
@@ -1873,16 +1873,17 @@ warn_missing_data_dirs() {
     warn "move the data to these paths, or set the data_dir(s) in config.json (absolute) and run './pithead apply'."
 }
 
-# chown -R "$dir" to $uid:$gid, but ONLY when it isn't already owned by $uid. Keeps a routine apply
-# sudo-free in steady state, while migrating an existing install in one pass the first time the
-# owning uid changes — e.g. the root->non-root container switch (#255), whose already-synced chain
-# data was written by the old root containers. Portable stat: GNU (-c) on Linux deploy hosts, BSD
-# (-f) on a macOS dev checkout.
+# chown -R "$dir" to $uid:$gid, but ONLY when something in it isn't already owned by $uid. Keeps a
+# routine apply sudo-free in steady state, while migrating an existing install in one pass the first
+# time the owning uid changes — e.g. the root->non-root container switch (#255). We scan the whole
+# tree, not just the top-level dir: an install upgraded from the root-container era has a user-owned
+# data dir but root-owned *contents* (the daemons wrote bitmonero.conf, the SQLite DB, etc. as
+# root), and those are exactly what the non-root container can no longer overwrite. `find … -quit`
+# stops at the first foreign inode, so a clean dir stays a quick metadata scan with no chown/sudo.
 ensure_owner() {
-    local d="$1" want_u="$2" want_g="$3" cur
+    local d="$1" want_u="$2" want_g="$3"
     [ -d "$d" ] || return 0
-    cur=$(stat -c %u "$d" 2>/dev/null || stat -f %u "$d" 2>/dev/null || echo "")
-    [ "$cur" = "$want_u" ] && return 0
+    [ -z "$(find "$d" ! -uid "$want_u" -print -quit 2>/dev/null)" ] && return 0
     log "Setting ownership of $d to $want_u:$want_g (non-root containers, #255)..."
     sudo chown -R "$want_u":"$want_g" "$d"
 }

--- a/pithead
+++ b/pithead
@@ -48,6 +48,13 @@ readonly CONFIG_FILE="config.json"
 readonly ENV_FILE=".env"
 readonly REAL_USER="${SUDO_USER:-$USER}"
 
+# Non-root uid:gid the BUILT images run their main process as (#255). pithead owns the data dirs,
+# so it chowns each service's bind-mount to this id to match the in-image USER. Tor is the
+# exception — it keeps its own alpine 'tor' user (100:101). Was $REAL_USER when every container
+# ran as root; existing installs are migrated in place by ensure_owner on the next apply/upgrade.
+readonly APP_UID=1000
+readonly APP_GID=1000
+
 REBOOT_REQUIRED=false
 SKIP_OPTIMIZE=0
 SKIP_DEPS=0
@@ -843,7 +850,8 @@ reset_dashboard() {
 
     log "Recreating data directories..."
     mkdir -p "$dashboard_dir" "$p2pool_dir"
-    sudo chown -R "$REAL_USER":"$REAL_USER" "$p2pool_dir"
+    # Owned by the non-root uid the dashboard + p2pool containers run as (#255).
+    sudo chown -R "$APP_UID":"$APP_GID" "$p2pool_dir" "$dashboard_dir"
     mkdir -p "$p2pool_dir/stats"
     sudo chmod -R 755 "$p2pool_dir/stats"
 
@@ -1018,6 +1026,13 @@ stack_restore() {
     parse_and_validate_config
     log "Fixing Tor data ownership (100:101)..."
     sudo chown -R 100:101 "$TOR_DATA_DIR"
+    # The archive is extracted as root, so the restored dashboard DB (and any --with-chains data)
+    # comes back root-owned. The containers run non-root (#255), so hand each data dir back to the
+    # uid its container uses — conditional, so a same-owner archive is a no-op.
+    ensure_owner "$MONERO_DIR" "$APP_UID" "$APP_GID"
+    ensure_owner "$TARI_DIR" "$APP_UID" "$APP_GID"
+    ensure_owner "$P2POOL_DIR" "$APP_UID" "$APP_GID"
+    ensure_owner "$DASHBOARD_DIR" "$APP_UID" "$APP_GID"
 
     log "Restore complete. Start the stack with '$0 up'."
 }
@@ -1176,10 +1191,24 @@ require_deployed() {
 
 # Refuse data directories that would be catastrophic to chown -R / rm -rf.
 assert_safe_dir() {
-    case "$1" in
-    "" | / | // | /. | /root | /home | /etc | /usr | /var | /bin | /sbin | /lib | /lib64 | /boot | /dev | /proc | /sys)
-        error "Refusing to use '$1' as a data directory. Choose a dedicated folder in $CONFIG_FILE."
+    local d="$1"
+    # 1) System + top-level roots, the invoking and real user's homes, and the bare mount/parent
+    #    dirs people most often fat-finger a data_dir to. A dedicated SUBfolder of any of these
+    #    (e.g. /srv/pithead, /mnt/disk/monero) is still allowed — only the bare root is refused (#91).
+    case "$d" in
+    "" | / | // | /. | /root | /home | /etc | /usr | /var | /var/lib | /opt | /srv | /mnt | /media | /tmp | /bin | /sbin | /lib | /lib64 | /boot | /dev | /proc | /sys | /Users | /Applications | "$HOME" | "/home/$REAL_USER" | "/Users/$REAL_USER")
+        error "Refusing to use '$d' as a data directory — it's a system, home, or bare mount root. Choose a dedicated subfolder in $CONFIG_FILE (e.g. .../pithead-data)."
         ;;
+    esac
+    # 2) Data dirs are stored as ABSOLUTE paths in .env; reject anything relative or containing a
+    #    '..' traversal so a malformed config.json value can't resolve somewhere unexpected before
+    #    a chown -R / rm -rf runs against it (#91).
+    case "$d" in
+    /*) ;;
+    *) error "Refusing non-absolute data directory '$d' — set an absolute path in $CONFIG_FILE." ;;
+    esac
+    case "$d" in
+    *..*) error "Refusing data directory '$d' — '..' path traversal is not allowed." ;;
     esac
 }
 
@@ -1807,9 +1836,10 @@ prepare_directories() {
     log "Initializing data directories..."
     mkdir -p "$MONERO_DIR" "$TARI_DIR" "$P2POOL_DIR" "$TOR_DATA_DIR" "$DASHBOARD_DIR" "$CLEARNET_STATE_DIR"
 
-    # Enforce permissions
+    # Enforce permissions. Each data dir is owned by the uid its container runs as: Tor keeps its
+    # alpine 'tor' user (100:101); the built images + tari run non-root as APP_UID:APP_GID (#255).
     sudo chown -R 100:101 "$TOR_DATA_DIR"
-    sudo chown -R "$REAL_USER":"$REAL_USER" "$MONERO_DIR" "$TARI_DIR" "$P2POOL_DIR"
+    sudo chown -R "$APP_UID":"$APP_GID" "$MONERO_DIR" "$TARI_DIR" "$P2POOL_DIR" "$DASHBOARD_DIR"
     mkdir -p "$P2POOL_DIR/stats"
     sudo chmod -R 755 "$P2POOL_DIR/stats"
     # World-writable so the dashboard container (its own uid) can drop the clearnet auto-transition
@@ -1843,28 +1873,36 @@ warn_missing_data_dirs() {
     warn "move the data to these paths, or set the data_dir(s) in config.json (absolute) and run './pithead apply'."
 }
 
-# Lightweight directory check for `apply`: create any missing data dir and chown only the
-# ones we just created, so a routine apply does not require sudo on every run.
+# chown -R "$dir" to $uid:$gid, but ONLY when it isn't already owned by $uid. Keeps a routine apply
+# sudo-free in steady state, while migrating an existing install in one pass the first time the
+# owning uid changes — e.g. the root->non-root container switch (#255), whose already-synced chain
+# data was written by the old root containers. Portable stat: GNU (-c) on Linux deploy hosts, BSD
+# (-f) on a macOS dev checkout.
+ensure_owner() {
+    local d="$1" want_u="$2" want_g="$3" cur
+    [ -d "$d" ] || return 0
+    cur=$(stat -c %u "$d" 2>/dev/null || stat -f %u "$d" 2>/dev/null || echo "")
+    [ "$cur" = "$want_u" ] && return 0
+    log "Setting ownership of $d to $want_u:$want_g (non-root containers, #255)..."
+    sudo chown -R "$want_u":"$want_g" "$d"
+}
+
+# Lightweight directory check for `apply`/`upgrade`: create any missing data dir, then ensure each is
+# owned by the uid its container runs as. ensure_owner is conditional, so a routine apply stays
+# sudo-free once ownership is correct; the first run after the non-root switch migrates the data.
 ensure_directories() {
     local d created=()
     for d in "$MONERO_DIR" "$TARI_DIR" "$P2POOL_DIR" "$TOR_DATA_DIR" "$DASHBOARD_DIR"; do
-        if [ ! -d "$d" ]; then
-            mkdir -p "$d"
-            created+=("$d")
-        fi
+        [ -d "$d" ] || { mkdir -p "$d" && created+=("$d"); }
     done
     mkdir -p "$P2POOL_DIR/stats"
-    if [ "${#created[@]}" -gt 0 ]; then
-        log "Created new data directories; applying ownership..."
-        for d in "${created[@]}"; do
-            if [ "$d" == "$TOR_DATA_DIR" ]; then
-                sudo chown -R 100:101 "$d"
-            else
-                sudo chown -R "$REAL_USER":"$REAL_USER" "$d"
-            fi
-        done
-        sudo chmod -R 755 "$P2POOL_DIR/stats"
-    fi
+    ensure_owner "$TOR_DATA_DIR" 100 101
+    ensure_owner "$MONERO_DIR" "$APP_UID" "$APP_GID"
+    ensure_owner "$TARI_DIR" "$APP_UID" "$APP_GID"
+    ensure_owner "$P2POOL_DIR" "$APP_UID" "$APP_GID"
+    ensure_owner "$DASHBOARD_DIR" "$APP_UID" "$APP_GID"
+    [ "${#created[@]}" -gt 0 ] && sudo chmod -R 755 "$P2POOL_DIR/stats"
+    return 0
 }
 
 # Decide the hostname the dashboard is reached at: an explicit dashboard.host wins; otherwise

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -449,7 +449,7 @@ write_manifest() {
 
 # The host paths under ./build/ that docker-compose.yml MOUNTS at runtime (volumes:), as opposed to
 # build: contexts. A pull-based bundle builds nothing and the images do NOT bake these in — monerod, for
-# instance, reads /root/bitmonero.conf.template purely from this host mount — so every one MUST ship in
+# instance, reads /home/ubuntu/bitmonero.conf.template purely from this host mount — so every one MUST ship in
 # the bundle, or the container mounts an empty dir and fails to start (the v1.0.0 bundle missed monerod's
 # template this way). Matches the volume short-syntax source (between "- " and the first ":"); ignores
 # build:/context: lines so no Dockerfile lands in the bundle (which would flip is_source_checkout to true

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -414,7 +414,7 @@ assert_running_state() {
                 it_pass "monero auto-transitioned clearnet→Tor (#234)"
             else it_fail "monero auto-transitioned clearnet→Tor (#234)" "marker not written within 180s"; fi
             wait_for 240 10 "monerod restarted back on Tor — proxy restored (#234)" \
-                rx "docker exec monerod grep -qE '^proxy=' /root/.bitmonero/bitmonero.conf 2>/dev/null" || true
+                rx "docker exec monerod grep -qE '^proxy=' /home/ubuntu/.bitmonero/bitmonero.conf 2>/dev/null" || true
         fi
         if [ "$tari_clearnet" = "true" ]; then
             if wait_for 180 10 "tari clearnet→Tor transition marker (#234)" rx "test -f '$csdir/tari.synced'"; then
@@ -528,9 +528,9 @@ assert_running_state() {
             assert_num_gt "memory ceiling live on $svc (#132)" "${memlim:-0}" 0
         done
         assert_num_ge "monerod DNS checkpoints disabled (#161)" \
-            "$(rx "docker exec monerod grep -c '^disable-dns-checkpoints=1' /root/.bitmonero/bitmonero.conf 2>/dev/null")" 1
+            "$(rx "docker exec monerod grep -c '^disable-dns-checkpoints=1' /home/ubuntu/.bitmonero/bitmonero.conf 2>/dev/null")" 1
         assert_eq "monerod has no clearnet priority-node hostnames (#161)" \
-            "$(rx "docker exec monerod grep -cE 'xmrvsbeast.com|hashvault.pro' /root/.bitmonero/bitmonero.conf 2>/dev/null")" "0"
+            "$(rx "docker exec monerod grep -cE 'xmrvsbeast.com|hashvault.pro' /home/ubuntu/.bitmonero/bitmonero.conf 2>/dev/null")" "0"
         # Clearnet initial sync (#183) + auto-transition (#234). The flag propagates to .env; pithead
         # ALWAYS renders the canonical Tor config (the clearnet transform is applied per-start
         # in-container, gated on the flag AND the dashboard's marker). The dashboard switches a
@@ -541,7 +541,7 @@ assert_running_state() {
         assert_num_ge "tari canonical config is always Tor (#234)" \
             "$(rx "docker exec tari grep -c '^type = \"tor\"' /var/tari/config/config.toml 2>/dev/null")" 1
         assert_num_ge "monerod runs Tor-only in steady state — proxy present (#183/#234)" \
-            "$(rx "docker exec monerod grep -cE '^proxy=' /root/.bitmonero/bitmonero.conf 2>/dev/null")" 1
+            "$(rx "docker exec monerod grep -cE '^proxy=' /home/ubuntu/.bitmonero/bitmonero.conf 2>/dev/null")" 1
         # (The clearnet→Tor auto-transition was already awaited + asserted at the top of this function,
         # before the steady-state battery, so the assertions above see the settled post-flip state.)
         case "$(rx "docker inspect tari --format '{{.HostConfig.Dns}}' 2>/dev/null")" in

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -86,6 +86,18 @@ run_sourced "$SANDBOX" assert_safe_dir "" >/dev/null 2>&1
 assert_rc "rejects empty" "$?" "1"
 run_sourced "$SANDBOX" assert_safe_dir "/srv/p2pool/data" >/dev/null 2>&1
 assert_rc "allows real dir" "$?" "0"
+# Tightened guard (#91): bare mount/parent roots, non-absolute paths and '..' traversal are refused;
+# a dedicated subfolder of a mount root is still fine.
+run_sourced "$SANDBOX" assert_safe_dir "/srv" >/dev/null 2>&1
+assert_rc "rejects bare /srv" "$?" "1"
+run_sourced "$SANDBOX" assert_safe_dir "/mnt" >/dev/null 2>&1
+assert_rc "rejects bare /mnt" "$?" "1"
+run_sourced "$SANDBOX" assert_safe_dir "relative/data" >/dev/null 2>&1
+assert_rc "rejects relative path" "$?" "1"
+run_sourced "$SANDBOX" assert_safe_dir "/srv/../etc/data" >/dev/null 2>&1
+assert_rc "rejects .. traversal" "$?" "1"
+run_sourced "$SANDBOX" assert_safe_dir "/mnt/disk/monero" >/dev/null 2>&1
+assert_rc "allows mount subfolder" "$?" "0"
 
 echo "== unit: is_public_ip classifier (#113) =="
 # Globally-routable -> rc 0 (public). Includes boundaries just OUTSIDE each excluded range.

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -93,14 +93,18 @@ expect_absent() { # <label> <pattern>
 
 # no-new-privileges on all 5 leaf services.
 expect_min "no-new-privileges on leaf services" "no-new-privileges:true" 5
-# cap_drop: [ALL] on exactly 4 of them — caddy, xmrig-proxy, and the two socket proxies. The
-# dashboard is intentionally exempt (it writes its history DB as root into a user-owned volume,
-# which needs CAP_DAC_OVERRIDE); pin the count so re-adding cap_drop there fails CI.
+# cap_drop: [ALL] on all 5 leaf services — caddy, xmrig-proxy, the two socket proxies, AND the
+# dashboard. The dashboard now runs non-root and owns its volume (#255), so it no longer needs
+# CAP_DAC_OVERRIDE to write its history DB and joins the others; pin the count so dropping cap_drop
+# from any leaf fails CI.
 caps=$(printf '%s\n' "$RENDERED" | grep -c -- "- ALL")
-if [ "$caps" -eq 4 ]; then echo "  ✓ cap_drop: [ALL] on 4 leaves, dashboard exempt ($caps)"; else
-    echo "  ✗ cap_drop: [ALL]: expected 4 (dashboard exempt), got $caps"
+if [ "$caps" -eq 5 ]; then echo "  ✓ cap_drop: [ALL] on all 5 leaves incl. dashboard ($caps)"; else
+    echo "  ✗ cap_drop: [ALL]: expected 5 (incl. dashboard, #255), got $caps"
     fails=$((fails + 1))
 fi
+# Non-root containers (#255): the pulled tari image has no first-party Dockerfile USER, so its
+# non-root uid is pinned via compose. Guard it so a silent drop back to root fails CI.
+expect_min "tari runs non-root via compose user: (#255)" "user: 1000:1000" 1
 # Anchor to the 4-space service-level indent so read-only :ro *bind mounts* (rendered with the
 # same key, deeper-indented) don't inflate the count — we want exactly the 3 read-only roots.
 expect_min "read-only roots (caddy + 2 socket proxies)" "^    read_only: true" 3


### PR DESCRIPTION
Closes #255. Closes #91.

Wave-5 hardening: drop uid 0 inside the containers and clear the three #91 security follow-ups.

## #255 — non-root containers
Every built image now declares a non-root `USER` (uid **1000**), and the pulled Tari image runs non-root via compose `user:`.

| Service | How | Notes |
|---|---|---|
| monerod | `USER ubuntu` (ubuntu:24.04 uid 1000) | `/root` made traversable; only `/root/.bitmonero` (the bind-mount) is written |
| p2pool | `USER ubuntu` | bind-mount replaces all of `/root`; mlock via the unlimited `memlock` ulimit, `cap_add` is non-effective for non-root (documented) |
| xmrig-proxy | `USER ubuntu` + writable home | the easy win — no bind-mount, already `cap_drop:[ALL]` |
| dashboard | new `pithead` user (uid 1000) | now owns its volume → **finally `cap_drop:[ALL]`** (no more `CAP_DAC_OVERRIDE`) |
| tari | compose `user: "1000:1000"` | wrapper writes runtime config to `/tmp`, only the data dir needs uid 1000 |

**Ownership / migration.** pithead is the ownership authority (same pattern it already uses for Tor's `100:101`). Data dirs are chowned to `APP_UID:APP_GID`; a new `ensure_owner()` migrates an existing install's root-owned chain data in **one conditional `chown -R`** on the next `apply`/`upgrade` — and in the `restore` path — while staying sudo-free in steady state. The migration is gated to the same operation that pulls/builds the new non-root images.

`SECURITY.md` + `docs/architecture.md` updated to drop the "dashboard runs as root" caveat.

## #91 — security follow-ups
- **Dashboard `network_mode: host`** — evaluated and **consciously kept** (P5): it needs the `127.0.0.1:18081` monerod RPC + the host-published proxy/Tor-SOCKS endpoints, and Caddy proxies it on the host; moving to the bridge is a net-negative re-plumb. Rationale recorded in compose.
- **Tari gRPC `allow_methods`** — trimmed to the node-status + merge-mining surface our two consumers actually call (dashboard: `get_tip_info`/`get_sync_progress`; p2pool: block-template/`submit_block`/tip). Removed the wallet/transaction, UTXO/kernel/payment-ref, mempool-tx and DAN validator-node methods.
- **`assert_safe_dir`** — tightened from a pure blacklist: also refuses bare mount/parent roots (`/srv`, `/mnt`, …) and the user homes, plus non-absolute and `..`-traversal paths, before any `chown -R`/`rm -rf`. Dedicated subfolders still allowed.

## Tests
- `tests/stack/run.sh`: **404 passed**, incl. new `assert_safe_dir` cases.
- `shfmt -i 4 -d` clean; YAML structure verified (tari `user`, dashboard `cap_drop:[ALL]` render correctly).

## ⚠ Needs a live boot test before merge
Unit tests can't cover the runtime behaviour #255's acceptance calls out. Please run on a live host (gouda) and confirm `docker compose up` comes up healthy on **both a fresh install and an existing (root-owned data) install**:
- [ ] p2pool: HugePages/memlock still work as non-root; mining + merge-mine unaffected
- [ ] monerod: LMDB writes / sync fine as uid 1000
- [ ] dashboard: SQLite history writes as uid 1000; panels populate
- [ ] tari: the `user: 1000:1000` override starts cleanly (easiest to roll back — drop the line + re-chown if the upstream image objects)
- [ ] existing install: first `apply`/`upgrade` migrates ownership without data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)