### PR TITLE
fix(itest): egress verifier survives release-bundle --dir; distinguish "can't run" from "leak"

### DIFF
--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 609 dashboard unit tests · 12 contract tests · 64 frontend
-tests · 52 `pithead` shell sections · 17 harness self-test sections ·
+tests · 52 `pithead` shell sections · 18 harness self-test sections ·
 9 live config scenarios (17 axis values) · 7 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -21,7 +21,7 @@ tests · 52 `pithead` shell sections · 17 harness self-test sections ·
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 7 |
 | 4 — Live matrix | config scenarios | 9 (17 axis values) |
-| 4 — Live matrix | harness self-test | 17 sections |
+| 4 — Live matrix | harness self-test | 18 sections |
 
 ---
 
@@ -950,7 +950,7 @@ tests · 52 `pithead` shell sections · 17 harness self-test sections ·
 - xmrig-proxy dev-fee donate-level is explicit + live (#173)
 - xmrig-proxy stopped for failover
 
-### Harness self-test (tests/integration/selftest.sh) — 17 sections
+### Harness self-test (tests/integration/selftest.sh) — 18 sections
 - overrides_to_jq: value typing
 - resolve_overrides: prerequisite gate (never mutates the canonical chain)
 - render_scenario_config: applies overrides, stays valid JSON
@@ -967,9 +967,10 @@ tests · 52 `pithead` shell sections · 17 harness self-test sections ·
 - _pred_hashes_flowing: gates on stratum.total_hashes > 0
 - dispatch loop: a stdin-draining child must not skip iterations
 - service_state parsing (fault-injection predicates)
+- egress_verdict: clean / leak / verifier-couldn't-run are distinct
 - assertion helpers: counters behave
 
 ---
 
-_Grand total: **770** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **771** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -78,7 +78,7 @@ assert_num_gt() {
 egress_verdict() {
     case "$1" in
     *"[verify-egress] OK"*) printf 'ok' ;;
-    *LEAK*|*✗*) printf 'leak' ;;
+    *LEAK* | *✗*) printf 'leak' ;;
     *) printf 'inconclusive' ;;
     esac
 }

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -71,6 +71,18 @@ assert_num_gt() {
     if [ -n "$2" ] && [ "$2" -gt "$3" ] 2>/dev/null; then it_pass "$1"; else it_fail "$1" "expected > $3, got [$2]"; fi
 }
 
+# Classify bench-verify-egress.sh output: ok | leak | inconclusive.
+# "inconclusive" (neither the OK marker nor a leak line) means the verifier never produced a
+# verdict — e.g. the script wasn't found under a release-bundle --dir. That MUST NOT read as a
+# leak: a privacy check that can't run and a detected leak are different failures.
+egress_verdict() {
+    case "$1" in
+    *"[verify-egress] OK"*) printf 'ok' ;;
+    *LEAK*|*✗*) printf 'leak' ;;
+    *) printf 'inconclusive' ;;
+    esac
+}
+
 # --- Config rendering (pure) ------------------------------------------------
 # Map a space-separated list of `dotted.path=value` overrides into a jq program that applies
 # them to a config.json. Values are typed: true/false -> boolean, integers -> number,

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -604,10 +604,16 @@ assert_egress_posture() {
     fi
     prefix="$(env_on_box NETWORK_PREFIX)"
     [ -n "$prefix" ] || prefix="172.28.0"
-    out="$(rx "bash tests/integration/benchmarks/bench-verify-egress.sh tor --dir . --prefix '$prefix' --polls 3 --interval 8 2>&1")"
-    case "$out" in
-    *"[verify-egress] OK"*) it_pass "no clearnet egress — every app dials via Tor (#274/#270)" ;;
-    *) it_fail "no clearnet egress — every app dials via Tor (#274/#270)" "$(printf '%s' "$out" | grep -E 'LEAK|✗' | head -4)" ;;
+    # Resolve the verifier by absolute path off run.sh's $HERE so it runs even when the stack --dir is a
+    # release bundle with no tests/ tree (local mode: driver == box, so $HERE reaches it). SSH mode keeps
+    # the remote-relative path — the remote is a full checkout and $HERE is a driver path meaningless there.
+    local bench="tests/integration/benchmarks/bench-verify-egress.sh"
+    [ "$IT_MODE" = "local" ] && bench="$HERE/benchmarks/bench-verify-egress.sh"
+    out="$(rx "bash $(quote_arg "$bench") tor --dir . --prefix '$prefix' --polls 3 --interval 8 2>&1")"
+    case "$(egress_verdict "$out")" in
+    ok)   it_pass "no clearnet egress — every app dials via Tor (#274/#270)" ;;
+    leak) it_fail "no clearnet egress — every app dials via Tor (#274/#270)" "$(printf '%s' "$out" | grep -E 'LEAK|✗' | head -4)" ;;
+    *)    it_fail "egress verifier INCONCLUSIVE — could not run, not a detected leak (#274/#270)" "$(printf '%s' "$out" | tail -4)" ;;
     esac
 }
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -611,9 +611,9 @@ assert_egress_posture() {
     [ "$IT_MODE" = "local" ] && bench="$HERE/benchmarks/bench-verify-egress.sh"
     out="$(rx "bash $(quote_arg "$bench") tor --dir . --prefix '$prefix' --polls 3 --interval 8 2>&1")"
     case "$(egress_verdict "$out")" in
-    ok)   it_pass "no clearnet egress — every app dials via Tor (#274/#270)" ;;
+    ok) it_pass "no clearnet egress — every app dials via Tor (#274/#270)" ;;
     leak) it_fail "no clearnet egress — every app dials via Tor (#274/#270)" "$(printf '%s' "$out" | grep -E 'LEAK|✗' | head -4)" ;;
-    *)    it_fail "egress verifier INCONCLUSIVE — could not run, not a detected leak (#274/#270)" "$(printf '%s' "$out" | tail -4)" ;;
+    *) it_fail "egress verifier INCONCLUSIVE — could not run, not a detected leak (#274/#270)" "$(printf '%s' "$out" | tail -4)" ;;
     esac
 }
 

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -215,6 +215,12 @@ assert_eq "state of 'missing none'" "$(svc_state_of 'missing none')" "missing"
 assert_eq "health of 'running unhealthy'" "$(svc_health_of 'running unhealthy')" "unhealthy"
 assert_eq "state of 'exited none'" "$(svc_state_of 'exited none')" "exited"
 
+echo "== egress_verdict: clean / leak / verifier-couldn't-run are distinct =="
+assert_eq "OK marker -> ok" "$(egress_verdict $'poll 1/3\n[verify-egress] OK')" "ok"
+assert_eq "leak line -> leak" "$(egress_verdict $'  ✗ p2pool: 2 PERSISTENT PUBLIC connection(s) — CLEARNET LEAK:')" "leak"
+assert_eq "script-not-found -> inconclusive" "$(egress_verdict $'bash: bench-verify-egress.sh: No such file or directory')" "inconclusive"
+assert_eq "empty output -> inconclusive" "$(egress_verdict '')" "inconclusive"
+
 echo "== assertion helpers: counters behave =="
 _p="$IT_PASS"
 _f="$IT_FAIL"


### PR DESCRIPTION
## Problem

`tests/integration/run.sh` `assert_egress_posture()` shells out to `bench-verify-egress.sh` via a **repo-relative** path through `rx`. In local mode `rx` runs the snippet from the stack `--dir`. When `--dir` points at a **release bundle** (no `tests/` tree — e.g. a deployed `/srv/code/pithead-v1.1.0`), the script isn't found, so the output lacks the `[verify-egress] OK` marker and the assertion reports a false **"clearnet egress leak"** that's really just script-not-found.

This bit the real v1.1.0 release-deploy verification (41/42 — the 1 fail was this artifact; egress was actually clean).

## Fix

1. **Absolute path.** Resolve the verifier off `run.sh`'s own `$HERE` in local mode (driver == box), so it runs regardless of what `--dir` is. SSH mode keeps the remote-relative path — `$HERE` is a driver path, meaningless on the remote (which is a full checkout anyway).
2. **Distinguish "can't run" from "leak".** New pure `egress_verdict()` classifier → `ok | leak | inconclusive`. Output with neither the OK marker nor a `LEAK`/`✗` line means the verifier never produced a verdict → loud **INCONCLUSIVE** failure with captured stderr, not a silent egress FAIL. A privacy check that can't run must not look identical to a detected leak. (Kept as a hard `it_fail`, not a soft skip — a privacy gate that can't run shouldn't pass green.)

## Test

Extended `selftest.sh` with 4 asserts pinning the three verdicts apart (`ok` / `leak` / `inconclusive` from script-not-found and empty output). `selftest: 101 passed, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)