### PR TITLE
fix(xmrig-proxy): stop rendering a stray empty command arg

### DIFF
--- a/build/xmrig-proxy/Dockerfile
+++ b/build/xmrig-proxy/Dockerfile
@@ -19,10 +19,15 @@ RUN wget -O xmrig-proxy.tar.gz https://github.com/xmrig/xmrig-proxy/releases/dow
     && chmod +x /usr/local/bin/xmrig-proxy \
     && rm -rf xmrig-proxy*
 
+# Wrapper entrypoint: appends the optional stratum-auth flag (#152) from an env var so an unset
+# password emits NO arg (a compose `${VAR:+..}` command item would leave a stray '' — see script).
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 # Run non-root (#255) — the easy win: pure network proxy, no bind-mounts, already cap_drop:[ALL]
 # + no-new-privileges in compose. Reuse ubuntu:24.04's 'ubuntu' user (uid 1000) and give it a
 # writable home as the cwd in case xmrig-proxy drops a config/log there.
 RUN install -d -o ubuntu -g ubuntu /home/ubuntu
 WORKDIR /home/ubuntu
 USER ubuntu
-ENTRYPOINT ["xmrig-proxy"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/xmrig-proxy/entrypoint.sh
+++ b/build/xmrig-proxy/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# Optional stratum-miner auth (#152). Compose's command LIST can't omit an element: a
+# `${PROXY_STRATUM_PASSWORD:+--access-password=...}` item renders a stray '' positional arg when the
+# password is unset (xmrig-proxy logs `unsupported non-option argument ''`). So the flag is passed as
+# an env var and appended HERE instead — an empty/unset value appends nothing, no stray arg. Mirrors
+# p2pool's entrypoint word-splitting of $P2POOL_FLAGS.
+if [ -n "${PROXY_STRATUM_PASSWORD:-}" ]; then
+    set -- "$@" "--access-password=$PROXY_STRATUM_PASSWORD"
+fi
+
+exec xmrig-proxy "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,6 +275,11 @@ services:
     environment:
       - PROXY_API_PORT=${PROXY_API_PORT}
       - PROXY_AUTH_TOKEN=${PROXY_AUTH_TOKEN}
+      # Optional stratum-miner auth (#152). Passed as an env var — NOT a `- ${VAR:+--flag}` command
+      # item — because a compose command LIST can't drop an empty element: when the password is unset
+      # that item renders a stray '' positional arg (xmrig-proxy warns `unsupported non-option
+      # argument ''`). The wrapper entrypoint appends the flag only when this is non-empty.
+      - PROXY_STRATUM_PASSWORD=${PROXY_STRATUM_PASSWORD:-}
     command:
       - -o
       - ${P2POOL_URL}
@@ -299,16 +304,12 @@ services:
       - --http-access-token
       - "${PROXY_AUTH_TOKEN:?PROXY_AUTH_TOKEN is empty; refusing to start an unauthenticated xmrig-proxy control API. Run 'pithead apply' to generate one (#153)}"
       - --http-no-restricted
-      # Optional miner authentication on the stratum port (#152). When p2pool.stratum_password is set,
-      # xmrig-proxy rejects rigs whose stratum 'pass' doesn't match — so only devices that know the
-      # secret can mine through the proxy (this also shrinks the #122 SSRF surface). The ':+' form is
-      # deliberate: when the password is SET this expands to the whole '--access-password=<secret>'
-      # flag; when it's EMPTY (the default) it expands to an empty token that xmrig-proxy ignores —
-      # i.e. NO flag, so any rig may mine, preserving today's open behavior. (A literal
-      # '--access-password=' with an empty value would instead demand an *empty* password and reject
-      # every normal rig — verified against xmrig-proxy 6.26.0.) Cleartext over stratum — pair with a
+      # Optional miner authentication on the stratum port (#152) is applied by the wrapper entrypoint
+      # from $PROXY_STRATUM_PASSWORD (see the environment block above) — NOT as a command item here,
+      # because a compose command LIST can't omit an empty element. When the password is set,
+      # xmrig-proxy rejects rigs whose stratum 'pass' doesn't match, so only devices that know the
+      # secret can mine (this also shrinks the #122 SSRF surface). Cleartext over stratum — pair with a
       # LAN-only stratum_bind / firewall; this is access control, not encryption.
-      - "${PROXY_STRATUM_PASSWORD:+--access-password=$PROXY_STRATUM_PASSWORD}"
       # xmrig-proxy dev-fee donation level (#173). Rendered from proxy.donate_level; xmrig-proxy's
       # own default is 0% (no fee), which we now pass EXPLICITLY so the effective level is visible
       # and operator-controllable instead of an invisible compiled-in default. NOT the XvB donation.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2236,6 +2236,25 @@ else
 fi
 rm -rf "$RELTMP"
 
+# xmrig-proxy wrapper entrypoint: optional stratum access-password (#152). The flag moved out of the
+# compose command (a `${VAR:+--flag}` list element rendered a stray '' positional arg when the password
+# was unset — xmrig-proxy warns `unsupported non-option argument ''`) into this wrapper, which appends
+# it only when PROXY_STRATUM_PASSWORD is set. Exercise the real script with a stub xmrig-proxy on PATH
+# that echoes its argv, so the set/unset branch is actually run.
+XP_ENTRY="$ROOT/build/xmrig-proxy/entrypoint.sh"
+xp_argv() { # <password value> -> the argv the wrapper would exec
+    local d
+    d="$(mktemp -d)"
+    printf '#!/bin/sh\nfor a in "$@"; do printf "[%%s]" "$a"; done\n' >"$d/xmrig-proxy"
+    chmod +x "$d/xmrig-proxy"
+    PATH="$d:$PATH" PROXY_STRATUM_PASSWORD="$1" sh "$XP_ENTRY" --http-no-restricted --donate-level=0
+    rm -rf "$d"
+}
+assert_eq "xmrig-proxy entrypoint: unset password appends no flag (#152)" \
+    "$(xp_argv '')" "[--http-no-restricted][--donate-level=0]"
+assert_eq "xmrig-proxy entrypoint: set password appends --access-password (#152)" \
+    "$(xp_argv 's3cret')" "[--http-no-restricted][--donate-level=0][--access-password=s3cret]"
+
 # ---------------------------------------------------------------------------
 echo ""
 printf 'pithead tests: \033[1;32m%d passed\033[0m, ' "$PASS"

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -179,25 +179,31 @@ else
     echo "  ✓ empty PROXY_AUTH_TOKEN makes the stack refuse to start (#153)"
 fi
 
-# xmrig-proxy config knobs (#152 stratum access-password, #173 dev-fee donate-level): both flags
-# render as a single '=' token carrying the value from .env.
-jq_assert "xmrig-proxy stratum access-password rendered (#152)" \
-    '.services["xmrig-proxy"].command | any(. == "--access-password=hunter2")'
+# xmrig-proxy config knobs (#152 stratum access-password, #173 dev-fee donate-level). donate-level is
+# a plain command item. The access-password flag is instead applied by the wrapper entrypoint from the
+# PROXY_STRATUM_PASSWORD env var — NOT a command item — because a compose command LIST can't drop an
+# empty element: a `${VAR:+--flag}` item rendered a stray '' positional arg when the password was unset
+# (xmrig-proxy warns `unsupported non-option argument ''`). So assert the env var is plumbed with the
+# value, and the command carries NO --access-password and NO empty element. The entrypoint's set/unset
+# append logic is covered by tests/stack/run.sh.
+jq_assert "xmrig-proxy stratum password plumbed via env (#152)" \
+    '.services["xmrig-proxy"].environment["PROXY_STRATUM_PASSWORD"] == "hunter2"'
+jq_assert "xmrig-proxy command has no empty arg or --access-password item (#152)" \
+    '.services["xmrig-proxy"].command | (any(. == "") | not) and (any(startswith("--access-password")) | not)'
 jq_assert "xmrig-proxy dev-fee donate-level rendered (#173)" \
     '.services["xmrig-proxy"].command | any(. == "--donate-level=1")'
-# Default-off path: an EMPTY PROXY_STRATUM_PASSWORD and a MISSING PROXY_DONATE_LEVEL (a stale .env
-# from before these keys) must render NO --access-password flag at all — the ':+' form drops it so
-# any rig may still mine (a literal empty '--access-password=' would demand an empty password and
-# reject every rig, the bug this guards). donate-level falls back to '0' (no dev fee).
+# Default-off path: an EMPTY PROXY_STRATUM_PASSWORD and a MISSING PROXY_DONATE_LEVEL (a stale .env from
+# before these keys) must leave the env var empty (the entrypoint then appends no flag, so any rig may
+# still mine) and fall back to --donate-level=0 (no dev fee).
 OFF_ENV="$(mktemp)"
 grep -vE '^PROXY_STRATUM_PASSWORD=|^PROXY_DONATE_LEVEL=' "$ENV_FILE" >"$OFF_ENV"
 echo 'PROXY_STRATUM_PASSWORD=' >>"$OFF_ENV"
 OFF_JSON="$(docker compose --env-file "$OFF_ENV" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
 rm -f "$OFF_ENV"
-if printf '%s' "$OFF_JSON" | jq -e '.services["xmrig-proxy"].command | ((any(startswith("--access-password")) | not) and any(. == "--donate-level=0"))' >/dev/null 2>&1; then
-    echo "  ✓ default-off omits --access-password (any rig may mine) + --donate-level=0 (#152/#173)"
+if printf '%s' "$OFF_JSON" | jq -e '.services["xmrig-proxy"] | (.environment["PROXY_STRATUM_PASSWORD"] == "") and (.command | any(. == "--donate-level=0"))' >/dev/null 2>&1; then
+    echo "  ✓ default-off: empty stratum password + --donate-level=0 (#152/#173)"
 else
-    echo "  ✗ default-off must omit --access-password and render --donate-level=0"
+    echo "  ✗ default-off must leave PROXY_STRATUM_PASSWORD empty and render --donate-level=0"
     fails=$((fails + 1))
 fi
 


### PR DESCRIPTION
## Problem

On a live v1.1.0 deploy, `docker inspect xmrig-proxy` shows a spurious empty positional argument in the rendered command:

```
... --http-no-restricted '' --donate-level=0
```

xmrig-proxy logs `unsupported non-option argument ''` on startup. Harmless (it warns and continues) but a real rendering bug.

## Root cause

Docker Compose command **lists** never drop or word-split an element. The optional stratum-auth flag was a list item:

```yaml
- "${PROXY_STRATUM_PASSWORD:+--access-password=$PROXY_STRATUM_PASSWORD}"
```

When `PROXY_STRATUM_PASSWORD` is unset (the default), this expands to an empty string that stays as a distinct `''` arg — it is *not* omitted. The old comment's premise ("expands to an empty token xmrig-proxy ignores") was wrong.

## Fix

Mirror p2pool's existing entrypoint pattern (env var + wrapper word-split, where empty ⇒ no arg):

- **`build/xmrig-proxy/entrypoint.sh`** (new) — appends `--access-password=…` only when `PROXY_STRATUM_PASSWORD` is non-empty.
- **`build/xmrig-proxy/Dockerfile`** — COPY + chmod the wrapper; `ENTRYPOINT` → it.
- **`docker-compose.yml`** — remove the empty-arg command item; pass `PROXY_STRATUM_PASSWORD` via `environment:`.

## Verification

- `docker compose config` renders the command with **zero** empty elements (`--http-no-restricted` → `--donate-level=0` directly).
- Entrypoint self-check: unset ⇒ no arg; set ⇒ single correct `--access-password=<pw>` arg (spaces preserved). `shellcheck` clean.
- Requires an image rebuild to take effect.

## Other services

Checked all command lists — line 305 was the **only** `:+` conditional. Other bare-var elements (`MONERO_WALLET_ADDRESS`, `TARI_WALLET_ADDRESS`) are always-required values, not optional flags, so they don't hit this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)