### PR TITLE
feat(pithead): surface the dashboard onion URL in `pithead status`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,8 +240,9 @@ Because a published `.onion` puts a control panel at a stable address, pithead *
   same login as the LAN path. It is bound to the internal Docker bridge, not the LAN, so it is
   reachable only through Tor.
 
-After `apply`, read the address from `pithead status` (printed only to that local output). Treat the
-`.onion` as a secret: anyone who has it can _attempt_ the login (and, without client-auth, reach it).
+After `apply`, read the address from `pithead status` or `pithead doctor` (printed only to that local
+output). Treat the `.onion` as a secret: anyone who has it can _attempt_ the login (and, without
+client-auth, reach it).
 
 **Connecting with client authorization.** With `client_auth: true` the onion won't answer at all
 until your Tor client presents the private key. Run `pithead onion-client-key` on the host — it

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 796 dashboard unit tests · 12 contract tests · 66 frontend
-tests · 55 `pithead` shell sections · 18 harness self-test sections ·
+tests · 56 `pithead` shell sections · 18 harness self-test sections ·
 9 live config scenarios (17 axis values) · 8 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 55 `pithead` shell sections · 18 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 796 |
 | 1 — Unit | frontend (node --test) | 66 |
-| 1 — Unit | `pithead` shell suite | 55 sections |
+| 1 — Unit | `pithead` shell suite | 56 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 8 |
@@ -959,7 +959,7 @@ tests · 55 `pithead` shell sections · 18 harness self-test sections ·
 - edgePath: column-crossing edges route orthogonally through a clear lane
 - route palette + names cover every route the server can emit
 
-### `pithead` shell suite (tests/stack/run.sh) — 55 sections
+### `pithead` shell suite (tests/stack/run.sh) — 56 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -985,6 +985,7 @@ tests · 55 `pithead` shell sections · 18 harness self-test sections ·
 - unit: generate_caddyfile onion vhost (#343)
 - unit: onion client-auth crypto (#343)
 - unit: ensure_onion_password auto-generates (#343)
+- unit: dashboard_onion_status surfaces the onion URL for status/doctor (#343)
 - unit: host detection (#140)
 - unit: release.sh pure logic (#44)
 - unit: pull-vs-build mode (#44)
@@ -1176,5 +1177,5 @@ tests · 55 `pithead` shell sections · 18 harness self-test sections ·
 
 ---
 
-_Grand total: **964** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **965** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/pithead
+++ b/pithead
@@ -354,6 +354,22 @@ print_clearnet_banner() {
     echo -e "${C_YELLOW}========================================================================${C_RESET}" >&2
 }
 
+# The dashboard onion (#343) as a single human line for `status`/`doctor`: the URL plus how to reach
+# it. Prints nothing and returns non-zero when the onion is off or not yet provisioned. NEVER includes
+# the client PRIVATE key — that lives behind the explicit 'onion-client-key' command, since these
+# reports are meant to be paste-able.
+dashboard_onion_status() {
+    [ "$(env_get DASHBOARD_ONION_ENABLED)" == "true" ] || return 1
+    local onion
+    onion=$(env_get DASHBOARD_ONION_ADDRESS)
+    { [ -n "$onion" ] && [ "$onion" != "placeholder" ]; } || return 1
+    if [ "$(env_get DASHBOARD_ONION_CLIENT_AUTH)" == "true" ]; then
+        printf "http://%s (client-auth ON + login; get your client key with '%s onion-client-key')" "$onion" "$0"
+    else
+        printf 'http://%s (login required)' "$onion"
+    fi
+}
+
 # Show the compose table, then health-check every service we expect to be running and warn
 # about anything that isn't. Returns non-zero if any service needs attention (handy for cron).
 # Profile-aware (the bundled monerod only counts in local-node mode), and aware that a stopped
@@ -453,6 +469,12 @@ stack_status() {
     # A clearnet initial sync (#183) is a privacy-relevant state, not a fault — surface it
     # prominently every time the operator checks status, separate from the service verdict.
     print_clearnet_banner
+    # When the remote-access onion (#343) is on, show its URL here too — `status` is where an operator
+    # looks first, not just `doctor`. The client key stays behind 'onion-client-key'.
+    local onion_line
+    if onion_line=$(dashboard_onion_status); then
+        log "Dashboard onion (remote access): $onion_line"
+    fi
     if [ "$problems" -eq 0 ]; then
         log "All expected services are up."
     else
@@ -756,13 +778,11 @@ doctor() {
         # it to reach the panel — but never the client PRIVATE key: this status is a paste-able report,
         # so the key lives behind the explicit 'onion-client-key' command instead.
         if [ "$(env_get DASHBOARD_ONION_ENABLED)" == "true" ]; then
-            onion=$(env_get DASHBOARD_ONION_ADDRESS)
-            if [ -z "$onion" ] || [ "$onion" == "placeholder" ]; then
-                dr_warn "DASHBOARD_ONION_ADDRESS is not provisioned yet — re-run 'pithead setup' or 'pithead apply'."
-            elif [ "$(env_get DASHBOARD_ONION_CLIENT_AUTH)" == "true" ]; then
-                dr_ok "Dashboard onion: http://$onion (client-auth ON + login; get your client key with '$0 onion-client-key')"
+            local onion_line
+            if onion_line=$(dashboard_onion_status); then
+                dr_ok "Dashboard onion: $onion_line"
             else
-                dr_ok "Dashboard onion: http://$onion (login required)"
+                dr_warn "DASHBOARD_ONION_ADDRESS is not provisioned yet — re-run 'pithead setup' or 'pithead apply'."
             fi
         fi
     fi

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -830,6 +830,38 @@ printf '{"dashboard":{}}' >"$autopw_cfg"
 (cd "$autopw_dir" && source "$STACK" 2>/dev/null && ensure_onion_password >/dev/null 2>&1)
 assert_eq "ensure_onion_password no-op when onion off" "$(jq -r '.dashboard.auth.password // "none"' "$autopw_cfg")" "none"
 
+echo "== unit: dashboard_onion_status surfaces the onion URL for status/doctor (#343) =="
+# The shared resolver behind both `pithead status` and `pithead doctor`: it returns the onion URL +
+# reach-it hint ONLY when the onion is enabled AND provisioned, and NEVER the client private key.
+onion_env_dir() { # <enabled> <address> <client_auth> -> a dir whose .env carries those keys
+    local d
+    d="$(mktemp -d)"
+    {
+        echo "DASHBOARD_ONION_ENABLED=$1"
+        echo "DASHBOARD_ONION_ADDRESS=$2"
+        echo "DASHBOARD_ONION_CLIENT_AUTH=$3"
+    } >"$d/.env"
+    echo "$d"
+}
+od_on="$(onion_env_dir true abcd.onion true)"
+# Enabled + provisioned + client-auth: URL plus the pointer to onion-client-key (assert the stable
+# prefix — the trailing "'<path> onion-client-key'" varies with $0).
+assert_contains "status onion: URL + client-key pointer when client-auth on" \
+    "$(run_sourced "$od_on" dashboard_onion_status)" "http://abcd.onion (client-auth ON + login; get your client key with"
+# And it must NOT leak a client private key.
+assert_not_contains "status onion: never prints a client key" \
+    "$(run_sourced "$od_on" dashboard_onion_status)" "descriptor:x25519:"
+od_noauth="$(onion_env_dir true abcd.onion false)"
+assert_eq "status onion: login-required line when client-auth off" \
+    "$(run_sourced "$od_noauth" dashboard_onion_status)" "http://abcd.onion (login required)"
+od_unprov="$(onion_env_dir true placeholder true)"
+assert_eq "status onion: nothing while unprovisioned (placeholder)" \
+    "$(run_sourced "$od_unprov" dashboard_onion_status)" ""
+od_off="$(onion_env_dir false abcd.onion true)"
+assert_eq "status onion: nothing when the onion is disabled" \
+    "$(run_sourced "$od_off" dashboard_onion_status)" ""
+rm -rf "$od_on" "$od_noauth" "$od_unprov" "$od_off"
+
 echo "== unit: host detection (#140) =="
 # detect_os reads ID / VERSION_ID / PRETTY_NAME from an overridable os-release (drives the
 # 'supported on Ubuntu 24.04' check); a missing file leaves the fields empty (caller warns).


### PR DESCRIPTION
The dashboard onion address (#343) was only printed by `pithead doctor`, but [docs/configuration.md](docs/configuration.md) told operators to *"read the address from `pithead status`"* — which never emitted it. This fixes both sides.

## Changes
- **`pithead status` now shows the onion URL.** New shared resolver `dashboard_onion_status()` returns the onion URL + reach-it hint, but only when the onion is **enabled and provisioned**, and **never** the client private key (that stays behind `pithead onion-client-key`, since status/doctor are paste-able reports). `stack_status()` prints it after the clearnet banner.
- **`doctor()` reuses the resolver** instead of duplicating the enable/provisioned/client-auth branching — output is byte-identical.
- **Doc fixed:** "read the address from `pithead status` or `pithead doctor`".

## Test
`tests/stack` covers the resolver's four cases (client-auth on → URL + `onion-client-key` pointer; client-auth off → login-required; unprovisioned → nothing; disabled → nothing) and asserts it never leaks a `descriptor:x25519:` client key.

`make test` + `make lint` green (849 dashboard 95.58% cov / 536 stack / 101 selftest / 12 fakes); `docs/test-inventory.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)