### PR TITLE
fix(pithead): run ensure_onion_password before validation in `upgrade` (#355)

### DIFF
--- a/pithead
+++ b/pithead
@@ -283,6 +283,9 @@ stack_upgrade() {
     # setup/apply (#128). Mirrors apply's render preamble; renders to a temp + swaps so preserved
     # secrets (Tor onions, RPC creds, proxy token) survive.
     require_env
+    ensure_onion_password # #343: auto-generate a dashboard password if the onion is on without one —
+    # MUST run before parse_and_validate_config, which rejects an onion enabled with an empty password
+    # (mirrors setup/apply; without this, enabling the onion via `upgrade` errored instead of #355).
     parse_and_validate_config
     load_preserved_state
     ensure_directories

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -460,6 +460,36 @@ upg_order=$(
 )
 assert_eq "upgrade applies the firewall before 'compose up' (#291)" "$(fw_then_compose "$upg_order")" "firewall,compose,"
 
+# #355: `upgrade` must run ensure_onion_password BEFORE parse_and_validate_config, so enabling the
+# dashboard onion (#343) with no password auto-generates one (login: admin) instead of failing the
+# "onion needs a 16+ char password" validation. setup/apply already do; upgrade didn't (prod hit it).
+# This exercises the command-flow ORDER — the wiring the unit test of ensure_onion_password can't see.
+upg_onion_order=$(
+    cd "$SANDBOX" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    require_env() { :; }
+    ensure_onion_password() { echo onionpw; }
+    parse_and_validate_config() { echo validate; }
+    load_preserved_state() { :; }
+    ensure_directories() { :; }
+    resolve_dashboard_host() { :; }
+    render_env() { :; }
+    mv() { :; }
+    inject_service_configs() { :; }
+    generate_caddyfile() { :; }
+    migrate_compose_project() { :; }
+    is_source_checkout() { return 1; }
+    log() { :; }
+    docker() { :; }
+    apply_tor_egress_firewall() { :; }
+    compose_up_checked() { :; }
+    stack_upgrade
+)
+assert_eq "upgrade runs ensure_onion_password before config validation (#355)" \
+    "$(printf '%s\n' "$upg_onion_order" | grep -xE 'onionpw|validate' | tr '\n' ',')" "onionpw,validate,"
+
 # apply had the same after-compose ordering bug as #272's stack_upgrade — fixed alongside #291. Take
 # the no-change-but-incomplete-marker retry path so apply recreates containers without the interactive
 # diff (env_changed_keys returns nothing; a pre-seeded .apply-incomplete marker forces the retry).


### PR DESCRIPTION
Closes #355.

## The bug
Enabling the dashboard onion (#343) with no `dashboard.auth.password` is documented to auto-generate a strong one, and `setup`/`apply` do — they call `ensure_onion_password` **before** `parse_and_validate_config`. But `stack_upgrade` validated first, so `./pithead upgrade` errored (`dashboard.onion.enabled is true but dashboard.auth.password is empty …`) instead of generating a password. Hit live enabling the onion on a v1.2.1 deploy.

## Fix
One line: call `ensure_onion_password` before `parse_and_validate_config` in `stack_upgrade`, mirroring setup/apply.

## Why it slipped through (and the test that now catches it)
The existing onion tests call `ensure_onion_password` in **isolation**; nothing exercised the `upgrade` **command flow** where the call ordering lives. Added a `tests/stack` ordering assertion that drives `stack_upgrade` with stubs and checks `ensure_onion_password` runs before validation. Verified it **fails without this fix**, passes with it.

`make test` + `make lint` green (537 stack tests); `docs/test-inventory.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)