### PR TITLE
fix(pithead): repair rotate-dashboard-onion + capture onion address on upgrade (#356)

### DIFF
--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 796 dashboard unit tests · 12 contract tests · 66 frontend
-tests · 56 `pithead` shell sections · 18 harness self-test sections ·
+tests · 58 `pithead` shell sections · 18 harness self-test sections ·
 9 live config scenarios (17 axis values) · 8 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 56 `pithead` shell sections · 18 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 796 |
 | 1 — Unit | frontend (node --test) | 66 |
-| 1 — Unit | `pithead` shell suite | 56 sections |
+| 1 — Unit | `pithead` shell suite | 58 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 8 |
@@ -959,7 +959,7 @@ tests · 56 `pithead` shell sections · 18 harness self-test sections ·
 - edgePath: column-crossing edges route orthogonally through a clear lane
 - route palette + names cover every route the server can emit
 
-### `pithead` shell suite (tests/stack/run.sh) — 56 sections
+### `pithead` shell suite (tests/stack/run.sh) — 58 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -985,6 +985,8 @@ tests · 56 `pithead` shell sections · 18 harness self-test sections ·
 - unit: generate_caddyfile onion vhost (#343)
 - unit: onion client-auth crypto (#343)
 - unit: ensure_onion_password auto-generates (#343)
+- black-box: rotate-dashboard-onion command flow (#356)
+- black-box: upgrade captures a just-enabled dashboard onion address (#356)
 - unit: dashboard_onion_status surfaces the onion URL for status/doctor (#343)
 - unit: host detection (#140)
 - unit: release.sh pure logic (#44)
@@ -1177,5 +1179,5 @@ tests · 56 `pithead` shell sections · 18 harness self-test sections ·
 
 ---
 
-_Grand total: **965** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **967** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/pithead
+++ b/pithead
@@ -318,6 +318,13 @@ stack_upgrade() {
     else
         PITHEAD_PULL=always compose_up_checked -d || error "Upgrade failed during 'docker compose up' — see the error above."
     fi
+    # #356: if the dashboard onion (#343) was just turned on, the recreated tor generated its hostname —
+    # read it back into .env so `status`/`onion-client-key` show the address (mirrors apply's capture at
+    # the end of a change). No-op when the onion is off or already captured. Without this, enabling the
+    # onion via `upgrade` left the address uncaptured (apply's capture only runs when config changed).
+    if [ "${DASHBOARD_ONION_ENABLED:-false}" == "true" ] && { [ -z "${DASHBOARD_ONION:-}" ] || [ "${DASHBOARD_ONION:-}" == "placeholder" ]; }; then
+        provision_dashboard_onion && render_env
+    fi
     log "Stack upgraded."
 }
 
@@ -2238,8 +2245,14 @@ rotate_dashboard_onion() {
     DASHBOARD_ONION="placeholder"
     DASHBOARD_ONION_CLIENT_PUBKEY="placeholder"
     DASHBOARD_ONION_CLIENT_PRIVKEY="placeholder"
-    provision_tor # rewrites authorized_clients (fresh key), starts tor, reads the new address
-    render_env    # persist the new address + keys
+    provision_tor          # rewrites authorized_clients (fresh key), starts tor, reads the new address
+    resolve_dashboard_host # #356: sets HOST_IP for render_env — rotate skipped it, so render_env died
+    # on the unbound HOST_IP under `set -u` (setup/apply/upgrade all resolve the host before rendering).
+    # #356: render_env writes DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false} and load_preserved_state
+    # doesn't carry it, so preserve the current value — otherwise rotate silently reset the flag to false
+    # and the next apply/upgrade errored "Stack is not fully provisioned. Run setup first."
+    DEPLOYMENT_COMPLETED=$(env_get DEPLOYMENT_COMPLETED)
+    render_env # persist the new address + keys
     docker compose restart caddy >/dev/null 2>&1 || true
     log "Dashboard onion rotated."
     if [ "$DASHBOARD_ONION_CLIENT_AUTH" == "true" ]; then

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -830,6 +830,69 @@ printf '{"dashboard":{}}' >"$autopw_cfg"
 (cd "$autopw_dir" && source "$STACK" 2>/dev/null && ensure_onion_password >/dev/null 2>&1)
 assert_eq "ensure_onion_password no-op when onion off" "$(jq -r '.dashboard.auth.password // "none"' "$autopw_cfg")" "none"
 
+echo "== black-box: rotate-dashboard-onion command flow (#356) =="
+# The rotate command reprovisions the onion then persists via render_env. It must (a) resolve the host
+# so HOST_IP is set for render_env — rotate skipped that and crashed on the unbound var under set -u —
+# and (b) preserve DEPLOYMENT_COMPLETED, which render_env would otherwise reset to false, breaking the
+# next apply/upgrade. Drive the real command with stubs; render_env reports the two values it would write.
+rot_out=$(
+    cd "$SANDBOX" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    require_env() { :; }
+    parse_and_validate_config() { :; }
+    load_preserved_state() { :; }
+    export DASHBOARD_ONION_ENABLED=true
+    export DASHBOARD_ONION_CLIENT_AUTH=false
+    TOR_DATA_DIR="$SANDBOX/rot-tor"
+    mkdir -p "$TOR_DATA_DIR/dashboard"
+    warn() { :; }
+    log() { :; }
+    docker() { :; }
+    sudo() { :; }
+    env_get() { [ "$1" = "DEPLOYMENT_COMPLETED" ] && echo true || echo "x.onion"; }
+    resolve_dashboard_host() { HOST_IP="host.set"; }
+    provision_tor() { :; }
+    render_env() { echo "HOST_IP=${HOST_IP-UNSET} DC=${DEPLOYMENT_COMPLETED-UNSET}"; }
+    onion_client_key() { :; }
+    rotate_dashboard_onion -y
+)
+assert_contains "rotate resolves the host before render_env — no unbound HOST_IP (#356)" "$rot_out" "HOST_IP=host.set"
+assert_contains "rotate preserves DEPLOYMENT_COMPLETED across render_env (#356)" "$rot_out" "DC=true"
+
+echo "== black-box: upgrade captures a just-enabled dashboard onion address (#356) =="
+# Enabling the onion via `upgrade` must read the freshly-generated .onion back into .env; apply's
+# capture only runs when the config changed, so an upgrade-based enable left the address uncaptured.
+upg_capture() { # <onion_enabled> <current_onion> -> prints "captured" if provision_dashboard_onion ran
+    cd "$SANDBOX" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    require_env() { :; }
+    ensure_onion_password() { :; }
+    parse_and_validate_config() { :; }
+    load_preserved_state() { :; }
+    ensure_directories() { :; }
+    resolve_dashboard_host() { :; }
+    render_env() { :; }
+    mv() { :; }
+    inject_service_configs() { :; }
+    generate_caddyfile() { :; }
+    migrate_compose_project() { :; }
+    is_source_checkout() { return 1; }
+    log() { :; }
+    docker() { :; }
+    apply_tor_egress_firewall() { :; }
+    compose_up_checked() { :; }
+    provision_dashboard_onion() { echo captured; }
+    export DASHBOARD_ONION_ENABLED="$1"
+    export DASHBOARD_ONION="$2"
+    stack_upgrade
+}
+assert_contains "upgrade captures the onion address when enabled + uncaptured (#356)" "$(upg_capture true '')" "captured"
+assert_not_contains "upgrade skips capture when the onion is disabled (#356)" "$(upg_capture false '')" "captured"
+
 echo "== unit: dashboard_onion_status surfaces the onion URL for status/doctor (#343) =="
 # The shared resolver behind both `pithead status` and `pithead doctor`: it returns the onion URL +
 # reach-it hint ONLY when the onion is enabled AND provisioned, and NEVER the client private key.


### PR DESCRIPTION
Closes #356. Two dashboard-onion (#343) provisioning bugs found enabling the onion on a live v1.2.1 deploy.

## Bug 1 — `rotate-dashboard-onion` crashed
`./pithead rotate-dashboard-onion -y` aborted with `HOST_IP: unbound variable` (exit 1): the function calls `render_env` without first calling `resolve_dashboard_host` (which sets `HOST_IP`), unlike setup/apply/upgrade. It also let `render_env` reset `DEPLOYMENT_COMPLETED` to `false` (`load_preserved_state` doesn't carry it), so the **next** `apply`/`upgrade` then errored `Stack is not fully provisioned. Run setup first.`

**Fix:** resolve the host and preserve `DEPLOYMENT_COMPLETED` before `render_env`.

## Bug 2 — onion address not captured on `upgrade`-enable
Enabling `dashboard.onion.enabled` via `upgrade` generated the tor hostname but never read it into `.env`, so `status`/`onion-client-key` couldn't show the address (apply's capture only runs when the config changed).

**Fix:** capture the address at the end of `stack_upgrade` when the onion is enabled + uncaptured, mirroring apply.

## Why they slipped through
Same pattern as #355: the bugs are in the **command-flow wiring** (a missing call in a command's preamble/epilogue), but the onion tests only exercised individual functions. Added `tests/stack` black-box tests that drive `rotate_dashboard_onion` (asserts `HOST_IP` set + `DEPLOYMENT_COMPLETED` preserved) and `stack_upgrade` (asserts the address is captured when enabled, skipped when disabled). Verified **all fail without these fixes**.

`make test` + `make lint` green (540 stack tests); `docs/test-inventory.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)