### PR TITLE
feat(onion): serve the dashboard onion over HTTPS so default Tor Browser works (#343)

### DIFF
--- a/build/tor/entrypoint.sh
+++ b/build/tor/entrypoint.sh
@@ -16,12 +16,15 @@ sed "s/__NETWORK_PREFIX__/${NETWORK_PREFIX}/g" "$TORRC_TEMPLATE" >/tmp/torrc
 # the default stack publishes exactly the three mining onions and nothing else. The target is the
 # bridge gateway (NETWORK_PREFIX.1), where host-networked Caddy binds the auth-gated onion vhost —
 # NOT the dashboard's raw :8000 (which has no auth of its own). Tor supplies the transport encryption.
+# Two ports: 80 (plain HTTP) and 443 (HTTPS, self-signed) — Caddy serves both, so Tor Browser's
+# default http->https upgrade lands on the working :443 instead of a refused connection (#343).
 if [ "${DASHBOARD_ONION_ENABLED:-false}" = "true" ]; then
     cat >>/tmp/torrc <<EOF
 
 # Dashboard Hidden Service (#343)
 HiddenServiceDir /var/lib/tor/dashboard/
 HiddenServicePort 80 ${NETWORK_PREFIX}.1:80
+HiddenServicePort 443 ${NETWORK_PREFIX}.1:443
 EOF
 fi
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -236,9 +236,13 @@ Because a published `.onion` puts a control panel at a stable address, pithead *
 - **Client authorization is on by default** (`client_auth: true`). A client-auth'd onion does not
   respond at all without your client key, so the address cannot be scanned or brute-forced — the
   password becomes a second factor behind it. This is the strong primary gate.
-- The onion serves plain HTTP inside the Tor tunnel (Tor encrypts the transport), fronted by the
-  same login as the LAN path. It is bound to the internal Docker bridge, not the LAN, so it is
-  reachable only through Tor.
+- The onion is served over **both HTTP and HTTPS**, fronted by the same login as the LAN path, and
+  bound to the internal Docker bridge (not the LAN), so it is reachable only through Tor. Tor Browser
+  upgrades `http://` to `https://` by default, so it lands on the HTTPS side automatically — no
+  browser tweaks needed. The HTTPS cert is **self-signed** (Caddy's internal CA, for the `.onion`
+  name), exactly like the LAN dashboard's cert: a `.onion` can't obtain a browser-trusted certificate
+  without a manual CA process, and Tor already encrypts the transport, so the browser shows a one-time
+  "accept the risk" prompt — the same click you make for the LAN dashboard.
 
 After `apply`, read the address from `pithead status` or `pithead doctor` (printed only to that local
 output). Treat the `.onion` as a secret: anyone who has it can _attempt_ the login (and, without
@@ -249,18 +253,20 @@ until your Tor client presents the private key. Run `pithead onion-client-key` o
 prints the address and the key in both forms you might need (it's kept out of `status`, which is a
 shareable report). Then pick your client:
 
-- **Tor Browser (easiest).** Open `http://<address>.onion`. Tor Browser prompts for the onion's
-  private key — paste the bare key (the value after `x25519:`) and continue. Nothing else to set up.
+- **Tor Browser (easiest).** Open `http://<address>.onion` (Tor Browser upgrades it to `https://`
+  automatically). Accept the one-time self-signed-cert prompt ("Advanced" → "Accept the Risk and
+  Continue" — the same as the LAN dashboard). Tor Browser then prompts for the onion's private key —
+  paste the bare key (the value after `x25519:`) and continue. Nothing else to set up.
 - **System Tor or Orbot (persistent).** Add a line to your `torrc`:
   `ClientOnionAuthDir /var/lib/tor/onion_auth` (any dir you own, mode `0700`). Inside it, create
   `dashboard.auth_private` containing the one-line form
   `<address>:descriptor:x25519:<private-key>`, then reload Tor. Now any Tor-aware client on that
   machine can reach the onion.
 
-After that, browse to `http://<address>.onion` and log in with your dashboard username/password.
-Without the client key the onion is invisible — that's the point. Set `client_auth: false` for a
-deliberately password-only onion (weaker: the address becomes online-guessable, so lean on the
-password).
+After that, browse to `http://<address>.onion` (it becomes `https://` — accept the self-signed cert
+once) and log in with your dashboard username/password. Without the client key the onion is invisible
+— that's the point. Set `client_auth: false` for a deliberately password-only onion (weaker: the
+address becomes online-guessable, so lean on the password).
 
 **Rotation.** A leaked `.onion` address or client key is otherwise permanent. Run
 `pithead rotate-dashboard-onion` to mint a fresh address and client key; the old ones stop working

--- a/pithead
+++ b/pithead
@@ -2191,8 +2191,9 @@ Dashboard onion address:  http://$onion
 
 Pick whichever Tor client you use to reach it:
 
-• Tor Browser (easiest): open  http://$onion  — it prompts for the onion's
-  private key. Paste JUST this key:
+• Tor Browser (easiest): open  http://$onion  (Tor Browser upgrades it to https;
+  accept the one-time self-signed-cert prompt, same as the LAN dashboard). It
+  prompts for the onion's private key. Paste JUST this key:
 
     $privkey
 

--- a/pithead
+++ b/pithead
@@ -2648,6 +2648,24 @@ $auth
     reverse_proxy 127.0.0.1:8000
 }
 EOF
+        # Also serve HTTPS on the .onion name so Tor Browser's default http->https upgrade lands on a
+        # working :443 instead of a refused connection (#343). The cert is self-signed (Caddy's internal
+        # CA) for the .onion — a .onion can't get a browser-trusted cert without a manual CA process, and
+        # Tor already encrypts the tunnel, so the browser shows a one-time "accept the risk" prompt. SNI
+        # (the .onion name) routes this apart from the LAN vhost, both on host-networked :443. Rendered
+        # only once the address is provisioned; a fresh enable serves HTTP now and adds HTTPS on the next
+        # apply once the address is captured.
+        if [ -n "${DASHBOARD_ONION:-}" ] && [ "${DASHBOARD_ONION:-}" != "placeholder" ]; then
+            log "Adding HTTPS onion vhost (self-signed cert for the .onion)..."
+            cat <<EOF >>"Caddyfile"
+
+https://${DASHBOARD_ONION} {
+    tls internal
+$auth
+    reverse_proxy 127.0.0.1:8000
+}
+EOF
+        fi
     fi
 }
 

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -769,6 +769,36 @@ caddy_noonion="$(
     cat Caddyfile
 )"
 assert_not_contains "no onion vhost when disabled" "$caddy_noonion" "172.28.0.1"
+# Once the .onion address is provisioned, ALSO render an HTTPS onion vhost (self-signed cert for the
+# .onion name) so Tor Browser's default http->https upgrade lands on a working :443 (#343). Both the
+# http (:80, bridge IP) and https (:443, .onion name) onion sites must be present.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_onion_https="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_USER=admin DASHBOARD_AUTH_HASH_B64="$auth_hb64" \
+        DASHBOARD_ONION_ENABLED=true DASHBOARD_ONION=abcd234onionname.onion NETWORK_PREFIX=172.28.0 generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "onion HTTP vhost still present with the address set (#343)" "$caddy_onion_https" "http://172.28.0.1 {"
+assert_contains "onion HTTPS vhost on the .onion name (#343)" "$caddy_onion_https" "https://abcd234onionname.onion {"
+https_site="${caddy_onion_https#*https://abcd234onionname.onion}"
+case "$https_site" in
+*"tls internal"*) ok "onion HTTPS vhost uses a self-signed cert (tls internal)" ;;
+*) bad "onion HTTPS vhost uses tls internal" "no 'tls internal' on the https onion site" ;;
+esac
+assert_contains "onion HTTPS vhost carries the same basic_auth (#343)" "$https_site" "basic_auth"
+# Not yet provisioned (placeholder address) -> HTTP onion vhost only, no HTTPS one (a later apply adds it).
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_onion_ph="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_USER=admin DASHBOARD_AUTH_HASH_B64="$auth_hb64" \
+        DASHBOARD_ONION_ENABLED=true DASHBOARD_ONION=placeholder NETWORK_PREFIX=172.28.0 generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "onion HTTP vhost renders even before the address is captured (#343)" "$caddy_onion_ph" "http://172.28.0.1 {"
+assert_not_contains "no HTTPS onion vhost until the .onion address is provisioned (#343)" "$caddy_onion_ph" "https://placeholder"
 
 echo "== unit: onion client-auth crypto (#343) =="
 # Portable base32 (RFC 4648 vectors) — no external `base32` binary (absent on macOS).
@@ -2307,6 +2337,8 @@ assert_contains "tor entrypoint: dashboard HiddenService appended when enabled (
     "$tor_onion_on" "HiddenServiceDir /var/lib/tor/dashboard/"
 assert_contains "tor entrypoint: onion vhost targets the bridge gateway .1 (#343)" \
     "$tor_onion_on" "HiddenServicePort 80 10.9.0.1:80"
+assert_contains "tor entrypoint: onion also exposes :443 for the Tor-Browser https upgrade (#343)" \
+    "$tor_onion_on" "HiddenServicePort 443 10.9.0.1:443"
 assert_not_contains "tor entrypoint: no dashboard onion when disabled (default off) (#343)" \
     "$(tor_torrc false)" "Dashboard Hidden Service"
 


### PR DESCRIPTION
**Problem:** Tor Browser upgrades `http://` → `https://` by default (HTTPS-Only / HTTPS-First), but the dashboard onion only served plain HTTP on `:80`, so the upgraded request hit a refused `:443` and dead-ended. Every default-Tor-Browser user had to disable the upgrade in `about:config` just to reach the dashboard — confusing and easy to get stuck on (which is what prompted this).

**Fix:** the onion now serves **HTTPS too**:
- tor entrypoint exposes `HiddenServicePort 443 → bridge gateway :443`.
- `generate_caddyfile` adds an `https://<onion>.onion { tls internal; … }` vhost alongside the http one, once the address is provisioned. SNI routes it apart from the LAN vhost (both on host-networked `:443`). http now `308`-redirects to https.

The cert is **self-signed** (Caddy's internal CA, for the `.onion` name) — a `.onion` can't get a browser-trusted cert without a manual CA process, and Tor already encrypts the transport — so the browser shows a **one-time "accept the risk"**, the *same* prompt the LAN dashboard already uses (`dashboard.secure` → `tls internal`). No `about:config` needed.

## Verified end-to-end (gouda + prod)
- `HTTPS over the onion → HTTP/1.1 401` (dashboard served over https, auth-gated)
- `http → 308 → https://<onion>` (auto-redirect)
- Caddy starts cleanly with both https sites; cert issued for the `.onion` (issuer: local); tor exposes `:80` + `:443`.

## Tests
`generate_caddyfile` renders the https onion vhost (`tls internal` + same `basic_auth`) when the address is set and skips it while placeholder; tor entrypoint exposes `:443`. `make test` + `make lint` green (543 stack); docs + `onion-client-key` output updated; `docs/test-inventory.md` regenerated.

Supersedes #359 (the about:config workaround is no longer needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)