### PR TITLE
feat(#378): `pithead rotate-secrets` — regenerate the stack's internal credentials in one command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- **`pithead rotate-secrets` regenerates the stack's internal credentials in one command (#378).**
+  After a suspected leak (a backup that left the box, a pasted `.env`), one command rotates the
+  local Monero RPC password (skipped in remote mode — that credential belongs to the remote node),
+  the stratum access-password when `p2pool.stratum_password` is `"auto"` (the new value is printed
+  and every rig must update its `pass`; a literal is left in `config.json` with a pointer), and the
+  xmrig-proxy control-API token (always), then recreates the containers that consume them. The old
+  values stay recoverable in owner-only `config.json.bak-<timestamp>` / `.env.bak-<timestamp>`
+  copies taken before anything changes, and a failed recreate leaves the retry marker so
+  `./pithead apply` finishes the job. The dashboard onion keeps its own `rotate-dashboard-onion`.
+  See [Operations › Rotating the internal secrets](docs/operations.md#rotating-the-internal-secrets).
 - **Edit config from the dashboard (#33).** A new **Configuration** view — opt-in via
   `dashboard.control.enabled` (default off; requires a `dashboard.auth.password`) — prefills a
   form from the live `config.json` with secrets masked ("set — leave blank to keep"), previews

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,6 +18,7 @@ Command reference for `pithead`, the CLI that manages the stack. Run `./pithead 
 | `./pithead backup` | Save `config.json`, `.env`, `Caddyfile`, the Tor onion keys, and the dashboard's database (your hashrate history & settings) to a timestamped `tar.gz` under `backups/` (checks free space first; stops a running stack for a clean copy, then restarts it). `--with-chains` also includes the blockchain data; `-y` / `--yes` skips the prompts (low free space and stopping the stack). |
 | `./pithead restore <archive>` | Restore those files from a backup archive (asks before overwriting; fixes Tor key ownership). `-y` / `--yes` skips the prompt. |
 | `./pithead reset-dashboard` | **DESTRUCTIVE**. Wipes and recreates the dashboard and P2Pool data. `-y` / `--yes` skips the prompt. |
+| `./pithead rotate-secrets` | Regenerate the stack's internal credentials after a suspected leak: the local Monero RPC password, the stratum access-password (only when `p2pool.stratum_password` is `"auto"`), and the xmrig-proxy control-API token. Recreates the affected containers. `-y` / `--yes` skips the prompt. See [Rotating the internal secrets](#rotating-the-internal-secrets). |
 | `./pithead version` | Print the installed stack version on one line (also `-V` / `--version`). Offline; no update check. `doctor` repeats it in its header. |
 | `./pithead help` | Show all commands. |
 
@@ -209,6 +210,44 @@ dashboard settings.
 
 > NOTE: After a restore, Caddy regenerates the dashboard's HTTPS certificate, so the browser shows
 > its "not trusted" warning once. Accept it as on first setup.
+
+---
+
+## Rotating the internal secrets
+
+`.env` and `config.json` carry three credentials that are generated once and otherwise live
+forever. If either file may have leaked — a backup left the box, a `.env` was pasted into a bug
+report, an operator with access left — rotate them:
+
+```bash
+./pithead rotate-secrets
+```
+
+The command previews exactly what your config rotates, asks for confirmation (`-y` / `--yes`
+skips it), regenerates the secrets, re-renders `.env`, and recreates the containers that consume
+them (a brief restart; chain data and dashboard history are untouched):
+
+- **Monero node RPC password** (`monero.node_password`) — rotated in local mode only; internal to
+  the stack, no follow-up needed. With `monero.mode: "remote"` the credential belongs to the
+  remote node and is skipped.
+- **Stratum access-password** (`PROXY_STRATUM_PASSWORD`) — rotated only when
+  `p2pool.stratum_password` is `"auto"`. The new value is printed at the end. Every rig is
+  rejected until its stratum `pass` is updated to it — see
+  [Workers › Authentication](workers.md#authentication). A literal password lives in
+  `config.json`: change it there and run `./pithead apply`. When stratum auth is off there is
+  nothing to rotate.
+- **xmrig-proxy control-API token** (`PROXY_AUTH_TOKEN`) — always rotated; internal to the stack,
+  no follow-up needed.
+
+Before changing anything, `rotate-secrets` saves owner-only copies of `config.json` and `.env` as
+`config.json.bak-<timestamp>` and `.env.bak-<timestamp>`. They hold the OLD secrets: delete them
+once the stack is confirmed healthy. If the container recreate fails, the new values are already
+committed — fix the cause and run `./pithead apply` to retry the recreate, or restore the two
+copies and run `./pithead apply` to roll back.
+
+The dashboard's `.onion` address and client-auth key have their own command,
+`./pithead rotate-dashboard-onion` — see
+[Configuration › Dashboard onion](configuration.md#reaching-the-dashboard-from-anywhere-tor-onion).
 
 ---
 

--- a/pithead
+++ b/pithead
@@ -1222,6 +1222,14 @@ Maintenance:
                             'apply -y' (commit). Normally fired by the pithead-control
                             systemd path unit when dashboard.control.enabled is true.
 
+  rotate-secrets [-y|--yes]
+                            Regenerate the stack's internal credentials (#378): the local Monero
+                            RPC password, the stratum access-password (only when
+                            p2pool.stratum_password is "auto" — every rig must then update its
+                            'pass'), and the xmrig-proxy control-API token. Recreates the
+                            affected containers; old values stay in timestamped .bak-* copies.
+                              -y, --yes        skip the confirmation prompt.
+
   help, -h, --help          Show this message.
 
 Workflow: edit config.json, then run '$0 apply'.
@@ -2523,6 +2531,103 @@ rotate_dashboard_onion() {
         onion_client_key
     else
         log "New dashboard onion: http://$(env_get DASHBOARD_ONION_ADDRESS)"
+    fi
+}
+
+# `rotate-secrets` (#378): regenerate the stack's internal credentials in one command. After a
+# suspected leak (a backup that left the box, a `.env` pasted into a bug report) the only
+# alternative is hand-editing files and knowing which containers to recreate. Rotates the local
+# Monero RPC password (skipped in remote mode — that credential belongs to the remote node), the
+# stratum access-password when p2pool.stratum_password is "auto" (a literal lives in config.json;
+# empty means auth is off), and PROXY_AUTH_TOKEN (always). The dashboard onion keys/address have
+# their own command (rotate-dashboard-onion) and are not touched. The old values stay recoverable
+# in timestamped owner-only copies of config.json and .env taken before anything changes.
+rotate_secrets() {
+    local assume_yes=0 arg
+    for arg in "$@"; do
+        case "$arg" in
+        -y | --yes) assume_yes=1 ;;
+        *) error "Unknown option for rotate-secrets: $arg. Run '$0 help'." ;;
+        esac
+    done
+    require_deployed
+    parse_and_validate_config
+    load_preserved_state
+
+    # Compute the "what will rotate" preview from the PARSED config, not by grepping .env — the
+    # stratum mode in config.json (auto vs literal vs empty) decides the behavior, not the rendered value.
+    local stratum_mode rotate_stratum=0
+    stratum_mode=$(jq -r '.p2pool.stratum_password // ""' "$CONFIG_FILE")
+
+    log "This rotates the stack's internal credentials:"
+    if [ "$MONERO_MODE" == "local" ]; then
+        log "  • Monero node RPC password — internal to the stack; no follow-up needed."
+    else
+        log "  • Monero RPC password: skipped — monero.mode is \"remote\", so the credential belongs to the remote node, not this stack."
+    fi
+    if [ "$stratum_mode" == "auto" ]; then
+        warn "  • Stratum access-password (#152) — EVERY RIG must update its stratum 'pass' to the new value or it is rejected."
+    elif [ -n "$stratum_mode" ]; then
+        log "  • Stratum access-password: skipped — p2pool.stratum_password is set explicitly in config.json; change it there and run '$0 apply'."
+    fi
+    log "  • xmrig-proxy control-API token (#153) — internal to the stack; no follow-up needed."
+    log "The containers that consume them are recreated (brief restart; chain data and dashboard history are untouched)."
+    if [ "$assume_yes" -eq 0 ]; then
+        read -r -p "Rotate these secrets now? (y/N): " CONFIRM || true
+        [[ "$CONFIRM" =~ ^[Yy] ]] || {
+            log "Rotation cancelled."
+            return 0
+        }
+    fi
+
+    # Keep the OLD values recoverable before anything changes: timestamped owner-only copies of the
+    # two files that carry them. Refuse to rotate at all if the safety copies can't be written.
+    local stamp
+    stamp=$(date +%Y%m%d-%H%M%S)
+    (
+        umask 077
+        cp "$CONFIG_FILE" "${CONFIG_FILE}.bak-${stamp}" &&
+            cp "$ENV_FILE" "${ENV_FILE}.bak-${stamp}"
+    ) || error "Could not write the pre-rotation safety copies — nothing was rotated."
+    log "Pre-rotation copies saved (${CONFIG_FILE}.bak-${stamp}, ${ENV_FILE}.bak-${stamp}) — they hold the OLD secrets; delete them once the stack is confirmed healthy."
+
+    # Regenerate, overriding what parse_and_validate_config / load_preserved_state just preserved.
+    # Same generators as the originals, so every consumer's validation keeps holding.
+    if [ "$MONERO_MODE" == "local" ]; then
+        MONERO_PASS=$(generate_node_password)
+        persist_node_credentials "$MONERO_USER" "$MONERO_PASS" # atomic write-back to config.json
+    fi
+    if [ "$stratum_mode" == "auto" ]; then
+        STRATUM_PASSWORD=$(openssl rand -hex 12)
+        rotate_stratum=1
+    fi
+    PROXY_AUTH_TOKEN=$(openssl rand -hex 12)
+
+    resolve_dashboard_host # #356: sets HOST_IP for render_env, which dies unbound without it
+    # #356: render_env writes DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false} and
+    # load_preserved_state doesn't carry it — preserve it or the next apply errors "run setup".
+    DEPLOYMENT_COMPLETED=$(env_get DEPLOYMENT_COMPLETED)
+    render_env
+    inject_service_configs # keep the generated service configs current before the recreate
+    # Recreate marker (#125): .env is committed now, so if the recreate below fails, a plain
+    # `apply` would diff no changes and no-op — the marker makes it retry the recreate instead.
+    local apply_marker="${ENV_FILE}.apply-incomplete"
+    : >"$apply_marker"
+    log "Recreating the containers that consume the rotated secrets..."
+    # `up` recreates exactly the services whose env/args changed (monerod, p2pool, xmrig-proxy,
+    # dashboard). Never `compose restart` here: restart reuses the OLD container args, so p2pool
+    # would keep dialing monerod with the retired --rpc-login.
+    if ! compose_up_checked -d; then
+        warn "Secrets were rotated in config.json/.env but the containers were NOT recreated ('docker compose up' failed)."
+        warn "Fix the cause above, then run '$0 apply' to retry the recreate — or restore the pre-rotation copies (${CONFIG_FILE}.bak-${stamp}, ${ENV_FILE}.bak-${stamp}) and run '$0 apply'."
+        exit 1 # leave $apply_marker so the retry re-attempts the recreate
+    fi
+    rm -f "$apply_marker"
+
+    log "Secrets rotated. The old values are invalid; only the safety copies above still hold them."
+    if [ "$rotate_stratum" -eq 1 ]; then
+        announce_stratum_auth
+        warn "The stratum access-password CHANGED — every rig is rejected until its stratum 'pass' is updated to the value above."
     fi
 }
 
@@ -4028,6 +4133,7 @@ main() {
         ;;
     onion-client-key) onion_client_key ;;
     rotate-dashboard-onion) rotate_dashboard_onion "$@" ;;
+    rotate-secrets) rotate_secrets "$@" ;;
     version | -V | --version) show_version ;;
     help | -h | --help) show_help ;;
     *) error "Unknown command: $cmd. Run '$0 help'." ;;

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2722,6 +2722,107 @@ rc=$?
 assert_rc "reset refuses with no data dirs in .env" "$rc" "1"
 assert_contains "reset refuse message" "$out" "refusing to guess"
 
+echo "== black-box: rotate-secrets regenerates the internal credentials (#378) =="
+# One command rotates the local Monero RPC password, the "auto" stratum password, and
+# PROXY_AUTH_TOKEN — the three values apply/load_preserved_state otherwise preserve forever.
+# Baseline: an applied local-mode config with stratum auth on "auto".
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"oldrpcpass"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"mini","stratum_password":"auto"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+rot_sp_old="$(run_sourced "$V" env_get_file "$V/.env" PROXY_STRATUM_PASSWORD)"
+rm -f "$V"/config.json.bak-* "$V"/.env.bak-*
+: >"$DOCKER_LOG"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead rotate-secrets -y 2>&1)"
+rc=$?
+assert_rc "rotate-secrets exits 0" "$rc" "0"
+rot_pass="$(run_sourced "$V" env_get_file "$V/.env" MONERO_NODE_PASSWORD)"
+rot_sp="$(run_sourced "$V" env_get_file "$V/.env" PROXY_STRATUM_PASSWORD)"
+rot_token="$(run_sourced "$V" env_get_file "$V/.env" PROXY_AUTH_TOKEN)"
+assert_eq "RPC password rotated (32 chars)" "${#rot_pass}" "32"
+assert_eq "RPC password changed" "$([ "$rot_pass" != "oldrpcpass" ] && echo changed)" "changed"
+assert_eq "new RPC password persisted to config.json" "$(jq -r '.monero.node_password' "$V/config.json")" "$rot_pass"
+assert_eq "stratum password changed" "$([ -n "$rot_sp" ] && [ "$rot_sp" != "$rot_sp_old" ] && echo changed)" "changed"
+assert_eq "proxy token changed" "$([ -n "$rot_token" ] && [ "$rot_token" != "ORIGINALTOKEN" ] && echo changed)" "changed"
+assert_eq "DEPLOYMENT_COMPLETED survives the rotate (#356)" "$(run_sourced "$V" env_get_file "$V/.env" DEPLOYMENT_COMPLETED)" "true"
+# Consumers: the containers are RECREATED via compose up (env/args re-read), never `compose restart`
+# (which would reuse p2pool's old --rpc-login args).
+assert_contains "rotate recreates via compose up" "$(cat "$DOCKER_LOG")" "compose up"
+assert_not_contains "rotate never uses compose restart" "$(cat "$DOCKER_LOG")" "compose restart"
+# Secrets stay out of the command output — except the stratum password, deliberately surfaced via
+# announce_stratum_auth so the operator can update each rig's 'pass'.
+case "$out" in
+*"$rot_pass"* | *"$rot_token"*) bad "rotate never prints the RPC password / proxy token" "leaked in: $out" ;;
+*) ok "rotate never prints the RPC password / proxy token" ;;
+esac
+assert_contains "rotate surfaces the new stratum password for rigs" "$out" "Stratum authentication is ON"
+assert_contains "rotate warns that rigs are rejected until updated" "$out" "rejected"
+# Recoverability: the pre-rotation copies hold the OLD values, owner-only.
+rot_cfg_bak="$(ls "$V"/config.json.bak-* 2>/dev/null | head -1)"
+rot_env_bak="$(ls "$V"/.env.bak-* 2>/dev/null | head -1)"
+assert_eq "config.json safety copy holds the old RPC password" "$(jq -r '.monero.node_password' "${rot_cfg_bak:-/dev/null}" 2>/dev/null)" "oldrpcpass"
+assert_contains ".env safety copy holds the old proxy token" "$(cat "${rot_env_bak:-/dev/null}" 2>/dev/null)" "ORIGINALTOKEN"
+rot_bak_mode="$(stat -c '%a' "$rot_env_bak" 2>/dev/null || stat -f '%Lp' "$rot_env_bak" 2>/dev/null)"
+assert_eq "safety copies are owner-only (600)" "$rot_bak_mode" "600"
+# Persistence: a follow-up apply reports no changes — the preservation logic now carries the NEW
+# values instead of resurrecting the old ones. (This is exactly the assertion that fails if
+# rotate silently no-ops: the preserved values would never have changed.)
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_contains "apply after rotate reports no changes" "$out" "No configuration changes detected"
+assert_eq "rotated token survives the next apply" "$(run_sourced "$V" env_get_file "$V/.env" PROXY_AUTH_TOKEN)" "$rot_token"
+
+echo "== black-box: rotate-secrets skips what it must (#378) =="
+# Remote mode: the RPC credential belongs to the remote node — config.json stays untouched.
+seed_env
+printf '{ "monero": {"mode":"remote","wallet_address":"%s","node_username":"ru","node_password":"remotepass","remote":{"host":"node.example.com"}}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead rotate-secrets -y 2>&1)"
+assert_rc "rotate-secrets (remote) exits 0" "$?" "0"
+assert_eq "remote RPC password untouched" "$(jq -r '.monero.node_password' "$V/config.json")" "remotepass"
+assert_contains "remote skip is explained" "$out" "remote"
+assert_eq "proxy token still rotates in remote mode" "$([ "$(run_sourced "$V" env_get_file "$V/.env" PROXY_AUTH_TOKEN)" != "ORIGINALTOKEN" ] && echo changed)" "changed"
+
+# Literal stratum password: lives in config.json, so rotate leaves it and points there instead.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"mini","stratum_password":"my.literal-pass"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead rotate-secrets -y 2>&1)"
+assert_eq "literal stratum password untouched" "$(run_sourced "$V" env_get_file "$V/.env" PROXY_STRATUM_PASSWORD)" "my.literal-pass"
+assert_contains "literal skip points at config.json" "$out" "config.json"
+
+# Declined prompt (no -y): nothing changes.
+rot_token_now="$(run_sourced "$V" env_get_file "$V/.env" PROXY_AUTH_TOKEN)"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" sh -c 'echo n | ./pithead rotate-secrets' 2>&1)"
+assert_rc "declined rotate exits 0" "$?" "0"
+assert_contains "declined rotate says cancelled" "$out" "cancelled"
+assert_eq "declined rotate changes nothing" "$(run_sourced "$V" env_get_file "$V/.env" PROXY_AUTH_TOKEN)" "$rot_token_now"
+
+echo "== black-box: rotate-secrets failure path keeps the old values recoverable (#378) =="
+# A failed recreate must exit non-zero, leave the retry marker (#125) so `apply` re-attempts the
+# recreate, and point at the safety copies that still hold the old secrets.
+FDOCK="$SANDBOX/faildocker"
+mkdir -p "$FDOCK"
+cat >"$FDOCK/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "compose version"|"info") exit 0 ;;
+  compose\ up*) echo "boom: no space left on device"; exit 1 ;;
+esac
+exit 0
+EOF
+chmod +x "$FDOCK/docker"
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"failoldpass"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+rm -f "$V"/config.json.bak-* "$V"/.env.bak-* "$V/.env.apply-incomplete"
+out="$(cd "$V" && PATH="$FDOCK:$V/bin:$PATH" ./pithead rotate-secrets -y 2>&1)"
+rc=$?
+assert_rc "failed recreate exits non-zero" "$rc" "1"
+assert_contains "failure names the retry path" "$out" "apply"
+[ -f "$V/.env.apply-incomplete" ] && ok "failure leaves the retry marker (#125)" || bad "failure leaves the retry marker (#125)" "marker missing"
+assert_eq "safety copy still holds the pre-rotation RPC password" "$(jq -r '.monero.node_password' "$(ls "$V"/config.json.bak-* | head -1)")" "failoldpass"
+assert_contains "safety copy still holds the pre-rotation token" "$(cat "$(ls "$V"/.env.bak-* | head -1)")" "ORIGINALTOKEN"
+rm -f "$V/.env.apply-incomplete" "$V"/config.json.bak-* "$V"/.env.bak-*
+
 echo "== release: install bundle is free of macOS xattr pax headers (#252) =="
 # Static guard: make_bundle must keep `--no-xattrs` AND the post-bundle xattr assertion, so the
 # fix can't be silently reverted in a future edit.


### PR DESCRIPTION
## Summary

Closes #378.

One command rotates the internal secrets that are otherwise generated once and live forever, then recreates exactly the containers that consume them:

- **Monero node RPC password** — local mode only, via the existing `generate_node_password` + atomic `persist_node_credentials` write-back to `config.json`. In `monero.mode: "remote"` the credential belongs to the remote node and is skipped with a message.
- **Stratum access-password (#152)** — only when `p2pool.stratum_password` is `"auto"` (same `openssl rand -hex 12` generator), announced via the existing `announce_stratum_auth` plus an unmissable warning that every rig is rejected until its `pass` is updated. A literal password is skipped with a pointer to `config.json`; empty (auth off) is skipped silently.
- **xmrig-proxy control-API token (#153)** — always.

Deliberately excluded: the dashboard onion address/keys keep their own `rotate-dashboard-onion` (external coordination differs), and the dashboard login password lives in `config.json` under the operator's control. No dashboard surface — the #33 control channel default-denies these keys; rotation is a host-CLI operation.

## Atomicity / recoverability

- Owner-only `config.json.bak-<timestamp>` / `.env.bak-<timestamp>` copies are taken **before anything changes**; rotation refuses to start if they can't be written.
- Consumers are recreated via `compose up -d` (never `restart`, which would reuse p2pool's old `--rpc-login` args); `render_env` + `inject_service_configs` run first, and the `#356` HOST_IP / DEPLOYMENT_COMPLETED gotchas are handled like `rotate-dashboard-onion`.
- A failed recreate exits non-zero, leaves the `#125` apply-incomplete marker so `./pithead apply` retries the recreate, and names the safety copies for a manual rollback.
- New secret values are never printed, except the stratum password via the existing `announce_stratum_auth` (that's the point — rigs need it).

## Tests (tier 1, `tests/stack/run.sh`)

- local + auto stratum: all three values change in `.env`/`config.json`, `DEPLOYMENT_COMPLETED` stays true, recreate is `compose up` (not `restart`), RPC password/token never appear in output, safety copies hold the old values at mode 600, and a follow-up `apply` reports **no changes** (preservation carries the new values instead of resurrecting the old — red-checked: neutering the regeneration block fails 6 assertions).
- remote mode: `config.json` untouched, skip explained, token still rotates.
- literal stratum password: untouched, pointer to `config.json` printed.
- declined prompt: nothing changes; `-y` skips it.
- failure path: non-zero exit, retry marker left, old values recoverable from the copies.

## Docs

`docs/operations.md` command-table row + a "Rotating the internal secrets" section, `show_help` entry, CHANGELOG under Unreleased. `make lint` (incl. docs voice), `make test` (772 stack + 1041 dashboard + 120 selftest, 0 failed), and `make test-patch-coverage` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)