### PR TITLE
feat(security): audit what changed + Caddy access log for attack visibility (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   points a single invocation at a candidate config file.
 - **`pithead control-run-pending`.** The host-side runner behind the Configuration view; fired by
   the systemd path unit, runnable by hand.
+- **Audit + access logs for attack visibility (#349).** The #33 audit log now records *what*
+  changed — the env-key names from the same host-side dry-run the approval gate runs; never
+  values — and is size-bounded (trimmed to the newest 2000 entries past 512 KiB). Caddy gains a
+  JSON access log on every vhost (`./data/caddy-logs/access.log`, rolled natively at 4 MiB × 3
+  files, credential headers redacted). The Configuration view surfaces both read-only: recent
+  config changes, recent accesses, and a failed-login (401) count for the last 24 h with a
+  rotate-the-password/onion nudge when failures spike — over Tor there is no source IP, so the
+  rate of 401s *is* the intrusion signal. Every field read from either log is treated as hostile
+  input and whitelisted to a safe character set before display. See
+  [Operations › Watching for intruders](docs/operations.md#watching-for-intruders).
 - **`status` shows per-chain sync progress (#384).** While a chain is still syncing, `./pithead
   status` reads the dashboard's own `/api/state` and prints each chain's percent and blocks
   remaining inline, instead of only pointing you at the dashboard. No ETA is shown — block rate

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,6 +58,15 @@ The stack's defaults:
   list, and a key added in the future stays un-committable until deliberately listed. Those
   edits must be applied from the host CLI; out-of-band approval is tracked in
   [#338](https://github.com/p2pool-starter-stack/pithead/issues/338).
+- Attack visibility (#349): Caddy writes a JSON access log for every dashboard vhost (LAN and
+  onion), and the control channel's host-side audit log records who changed what (setting names
+  only, never values). The dashboard surfaces both read-only — a burst of 401s is the
+  rotate-the-password signal — and treats every logged field as hostile input: strings are
+  whitelisted to a safe character set before display, because the access log echoes
+  attacker-chosen bytes (request paths, attempted usernames) and rendering them raw would hand an
+  anonymous prober stored XSS against the operator. Both logs are size-bounded (Caddy's native
+  rolling; a trim-before-append cap in the audit writer). Neither ever records a secret: Caddy
+  redacts credential headers by default, and the audit writer logs key names only.
 
 ### Secret trust boundary for dashboard config editing
 

--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -156,6 +156,11 @@ DASHBOARD_CONTROL_ENABLED = (
 )
 CONTROL_REQUESTS_DIR = os.environ.get("CONTROL_REQUESTS_DIR", "/control/requests")
 CONTROL_RESULTS_DIR = os.environ.get("CONTROL_RESULTS_DIR", "/control/results")
+# Host-written security logs, surfaced read-only (#349). control.log is the #33 audit trail
+# (one JSON line per handled control request); access.log is Caddy's JSON access log — both are
+# written and rotated host-side, and every field read from them is sanitized before serving.
+CONTROL_AUDIT_LOG = os.environ.get("CONTROL_AUDIT_LOG", "/control/audit/control.log")
+ACCESS_LOG_PATH = os.environ.get("ACCESS_LOG_PATH", "/access-log/access.log")
 # The live config.json, bind-mounted read-only for form prefill; secrets are masked before serving.
 HOST_CONFIG_PATH = os.environ.get("HOST_CONFIG_PATH", "/host-config/config.json")
 # config.reference.json (every key with its default), bind-mounted read-only. read_config merges it

--- a/build/dashboard/mining_dashboard/service/audit_service.py
+++ b/build/dashboard/mining_dashboard/service/audit_service.py
@@ -1,0 +1,146 @@
+"""Read-only views over the host-written security logs (#349).
+
+Two sources, both mounted read-only: the #33 config-change audit trail
+(``/control/audit/control.log``, one JSON line per handled control request) and Caddy's JSON
+access log (``/access-log/access.log``) — the operator's brute-force signal, since over Tor there
+is no source IP and the only useful pattern is the rate of 401s.
+
+Every field read here is HOSTILE input: the access log echoes attacker-chosen strings (the
+request URI, the attempted username), and a log line rendered raw into the dashboard would be
+stored XSS against the operator — the exact attacker-to-operator direction the #33 reviews
+guarded. ``_clean`` therefore whitelists a conservative ASCII charset (no ``<``, ``>``, quotes,
+backslashes, or control characters) and caps length; nothing from either file is served
+unfiltered. Growth is bounded by the writers, not here: the audit log is trimmed by
+``control_audit`` and Caddy rolls its own access log — this module only ever reads a tail.
+"""
+
+import json
+import os
+import re
+import time
+
+from mining_dashboard.config import config
+
+# Whitelist, not escape: strip every character outside a conservative ASCII set. Keeps
+# timestamps, UUIDs, usernames, env-key names, and URL paths readable; drops anything that could
+# carry markup or terminal escapes.
+_SAFE_CHARS = re.compile(r"[^A-Za-z0-9 ._:;/@?&=%+#-]")
+
+# Only ever displayed; anything else (attacker-invented verbs included) collapses to "?".
+_KNOWN_METHODS = frozenset({"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"})
+
+# 401s in the last 24 h before the dashboard suggests rotating the password/onion. Low on
+# purpose: the only legitimate 401s are the operator's own typos.
+ROTATE_HINT_401S = 5
+
+_TAIL_BYTES = 256 * 1024
+
+
+def _clean(value, max_len=200):
+    """``value`` as a display-safe string: whitelisted charset, length-capped."""
+    if not isinstance(value, str):
+        value = "" if value is None else str(value)
+    return _SAFE_CHARS.sub("", value)[:max_len]
+
+
+def _tail_json_lines(path):
+    """The trailing complete JSON objects of ``path`` (newest last), or None if unreadable.
+
+    Reads at most the last ``_TAIL_BYTES`` so a large log costs one bounded read; a partial
+    first line from cutting into the middle of the file is dropped, as is any non-JSON line."""
+    try:
+        with open(path, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            f.seek(max(0, size - _TAIL_BYTES))
+            chunk = f.read()
+    except OSError:
+        return None
+    lines = chunk.split(b"\n")
+    if size > _TAIL_BYTES:
+        lines = lines[1:]
+    out = []
+    for line in lines:
+        try:
+            obj = json.loads(line.decode("utf-8", "replace"))
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def recent_changes(limit=50):
+    """The newest config-change audit entries, sanitized, newest first.
+
+    Explicit field whitelist — ts/id/actor/action/status/keys — so a foreign key smuggled into
+    the log never reaches the browser. ``keys`` names WHAT changed (env-key names only; the
+    writer never records values)."""
+    raw = _tail_json_lines(config.CONTROL_AUDIT_LOG)
+    if raw is None:
+        return []
+    entries = [
+        {
+            "ts": _clean(e.get("ts"), 32),
+            "id": _clean(e.get("id"), 36),
+            "actor": _clean(e.get("actor"), 64),
+            "action": _clean(e.get("action"), 16),
+            "status": _clean(e.get("status"), 32),
+            "keys": _clean(e.get("keys"), 400),
+        }
+        for e in raw
+    ]
+    return entries[::-1][:limit]
+
+
+def access_summary(limit=50, now=None):
+    """Recent dashboard accesses plus the rotate-signal: 401s in the last 24 h.
+
+    Shape: ``{available, entries, failures_24h, last_failure_ts, rotate_hint}``. ``available``
+    is False until Caddy has written the log (pre-#349 deployments, or no request yet). Entries
+    are newest first; ts is epoch seconds, status is clamped to a real HTTP range."""
+    raw = _tail_json_lines(config.ACCESS_LOG_PATH)
+    if raw is None:
+        return {
+            "available": False,
+            "entries": [],
+            "failures_24h": 0,
+            "last_failure_ts": None,
+            "rotate_hint": False,
+        }
+    now = time.time() if now is None else now
+    entries = []
+    failures = 0
+    last_failure = None
+    for e in raw:
+        req = e.get("request") if isinstance(e.get("request"), dict) else {}
+        try:
+            ts = float(e.get("ts") or 0)
+        except (TypeError, ValueError):
+            ts = 0.0
+        try:
+            status = int(e.get("status") or 0)
+        except (TypeError, ValueError):
+            status = 0
+        if not 100 <= status <= 599:
+            status = 0
+        method = req.get("method")
+        entries.append(
+            {
+                "ts": ts,
+                "status": status,
+                "method": method if method in _KNOWN_METHODS else "?",
+                "uri": _clean(req.get("uri")),
+                "user": _clean(e.get("user_id"), 64),
+            }
+        )
+        if status == 401 and now - ts <= 86400:
+            failures += 1
+            last_failure = ts if last_failure is None else max(last_failure, ts)
+    return {
+        "available": True,
+        "entries": entries[-limit:][::-1],
+        "failures_24h": failures,
+        "last_failure_ts": last_failure,
+        "rotate_hint": failures >= ROTATE_HINT_401S,
+    }

--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -5,7 +5,7 @@ import os
 from aiohttp import web
 
 from mining_dashboard.config import config
-from mining_dashboard.service import control_service
+from mining_dashboard.service import audit_service, control_service
 from mining_dashboard.service.metrics import build_metrics, share_reject_pct
 from mining_dashboard.web.prometheus import CONTENT_TYPE as PROMETHEUS_CONTENT_TYPE
 from mining_dashboard.web.prometheus import render_prometheus
@@ -160,6 +160,31 @@ async def handle_control_result(request):
     return web.json_response(res)
 
 
+# --- Security logs (#349) ---------------------------------------------------------------------
+# Read-only views over host-written files; audit_service sanitizes every field (whitelisted
+# charset) before it reaches the browser — log content is attacker-influenceable input.
+
+
+async def handle_audit_log(request):
+    """Recent config-change audit entries, from the read-only /control/audit mount. Registered
+    only alongside the control channel — the log is a #33 artifact."""
+    try:
+        return web.json_response({"entries": audit_service.recent_changes()})
+    except Exception:
+        logger.exception("Error reading the control audit log")
+        return web.json_response({"error": "Failed to read the audit log."}, status=500)
+
+
+async def handle_access_log(request):
+    """Recent dashboard accesses + failed-login count, from Caddy's JSON access log. Always
+    registered (Caddy always writes the log); behind the same Caddy basic_auth as every route."""
+    try:
+        return web.json_response(audit_service.access_summary())
+    except Exception:
+        logger.exception("Error reading the access log")
+        return web.json_response({"error": "Failed to read the access log."}, status=500)
+
+
 def _apply_security_headers(response):
     """Baseline hardening headers. CSP is self-only: HTML shell, CSS/JS (the vendored Preact,
     htm and Chart.js, plus the dashboard's own modules) and the JSON API are all same-origin,
@@ -204,6 +229,7 @@ def create_app(state_manager, latest_data_ref):
             web.get("/", handle_index),
             web.get("/api/state", handle_state),
             web.get("/metrics", handle_metrics),
+            web.get("/api/access", handle_access_log),
         ]
     )
     # Control channel (#33): routes exist only when the feature is on — off means 404, not 403,
@@ -216,6 +242,7 @@ def create_app(state_manager, latest_data_ref):
                 web.post("/api/control/preview", handle_control_preview),
                 web.post("/api/control/commit", handle_control_commit),
                 web.get("/api/control/result", handle_control_result),
+                web.get("/api/audit", handle_audit_log),
             ]
         )
 

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -24,6 +24,7 @@ import {
   xvbTierComparison,
 } from "./logic.mjs";
 import { Component, Fragment, html } from "./preact.mjs";
+import { SecurityPanel } from "./securityview.mjs";
 import { StackTopology } from "./topology.mjs";
 
 // Palette token -> text-colour class (defined in dashboard.css).
@@ -734,7 +735,7 @@ function DashboardView({
                 <button class=${"btn-toggle" + (configView ? " active" : "")} onClick=${() => onView("config")}>Configuration</button>
             </div>
         </div>
-        ${configView ? html`<${ConfigView} />` : null}
+        ${configView ? html`<${ConfigView} /><${SecurityPanel} />` : null}
         ${
           configView
             ? null

--- a/build/dashboard/mining_dashboard/web/static/securityview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/securityview.mjs
@@ -1,0 +1,120 @@
+// Security panel (#349): recent dashboard accesses (Caddy's access log, read-only) and the
+// config-change audit trail (the #33 host-side audit log, read-only). Both APIs serve
+// server-sanitized fields — the backend whitelists every character before it leaves the host
+// logs — and everything here renders through Preact text nodes, never markup, so a hostile log
+// line stays inert even if the server-side filter regressed.
+//
+// The operator story: over Tor there is no source IP, so the attack signal is the RATE of 401s.
+// A burst of failed logins shows a rotate nudge — change the password, or mint a fresh onion
+// with `./pithead rotate-dashboard-onion`.
+
+import { Component, html } from "./preact.mjs";
+
+const ACCESS_LIMIT_SHOWN = 20;
+
+// Epoch seconds -> local "YYYY-MM-DD HH:MM:SS"-style string; blank for a missing/zero ts.
+export function fmtEpoch(ts) {
+  if (!Number.isFinite(ts) || ts <= 0) return "";
+  return new Date(ts * 1000).toLocaleString();
+}
+
+const AccessCard = ({ access }) => {
+  if (!access) return null;
+  if (!access.available) {
+    return html`<div class="card">
+        <h3>Access log</h3>
+        <p class="text-muted">No access log yet — Caddy writes it from the first request after
+        an <code>apply</code>/<code>upgrade</code> on this version.</p>
+    </div>`;
+  }
+  const failures = access.failures_24h || 0;
+  return html`<div class="card">
+      <h3>Access log</h3>
+      <p class=${failures > 0 ? "status-warn" : "status-ok"}>
+          ${failures} failed login${failures === 1 ? "" : "s"} in the last 24 h${
+            access.last_failure_ts ? html` — last at ${fmtEpoch(access.last_failure_ts)}` : ""
+          }
+      </p>
+      ${
+        access.rotate_hint
+          ? html`<p class="status-bad">Repeated failed logins — someone who can reach the
+              dashboard is guessing the password. Rotate it (set a new
+              <code>dashboard.auth.password</code> and run <code>./pithead apply</code>) and, if
+              the onion address may have leaked, run
+              <code>./pithead rotate-dashboard-onion</code>.</p>`
+          : null
+      }
+      <div class="table-scroll">
+          <table>
+              <thead><tr><th>Time</th><th>Status</th><th>Method</th><th>Path</th><th>User</th></tr></thead>
+              <tbody>
+                  ${(access.entries || []).slice(0, ACCESS_LIMIT_SHOWN).map(
+                    (e) => html`<tr>
+                        <td>${fmtEpoch(e.ts)}</td>
+                        <td class=${e.status === 401 ? "status-bad" : ""}>${e.status || "?"}</td>
+                        <td>${e.method}</td>
+                        <td class="font-mono">${e.uri}</td>
+                        <td>${e.user}</td>
+                    </tr>`,
+                  )}
+              </tbody>
+          </table>
+      </div>
+  </div>`;
+};
+
+const AuditCard = ({ audit }) => {
+  // null = control channel off (the /api/audit route 404s) — no card at all.
+  if (!audit) return null;
+  return html`<div class="card">
+      <h3>Recent config changes</h3>
+      ${
+        audit.length === 0
+          ? html`<p class="text-muted">No config changes have gone through the dashboard yet.</p>`
+          : html`<div class="table-scroll">
+              <table>
+                  <thead><tr><th>Time (UTC)</th><th>User</th><th>Action</th><th>Outcome</th><th>Settings</th></tr></thead>
+                  <tbody>
+                      ${audit.map(
+                        (e) => html`<tr>
+                            <td>${e.ts}</td>
+                            <td>${e.actor}</td>
+                            <td>${e.action}</td>
+                            <td class=${e.status === "applied" ? "status-ok" : ""}>${e.status}</td>
+                            <td class="font-mono">${e.keys}</td>
+                        </tr>`,
+                      )}
+                  </tbody>
+              </table>
+          </div>`
+      }
+  </div>`;
+};
+
+export class SecurityPanel extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { access: null, audit: null, error: null };
+  }
+
+  async componentDidMount() {
+    try {
+      const res = await fetch("/api/access");
+      if (res.ok) this.setState({ access: await res.json() });
+      // /api/audit exists only when the control channel is on; a 404 just hides the card.
+      const auditRes = await fetch("/api/audit");
+      if (auditRes.ok) this.setState({ audit: (await auditRes.json()).entries || [] });
+    } catch (e) {
+      this.setState({ error: String(e) });
+    }
+  }
+
+  render() {
+    const { access, audit, error } = this.state;
+    if (error) return html`<div class="card"><p class="status-bad">${error}</p></div>`;
+    return html`<div class="grid">
+        <${AccessCard} access=${access} />
+        <${AuditCard} audit=${audit} />
+    </div>`;
+  }
+}

--- a/build/dashboard/tests/frontend/securityview.test.mjs
+++ b/build/dashboard/tests/frontend/securityview.test.mjs
@@ -1,0 +1,102 @@
+// Security panel (#349): render states of the access-log / audit-trail cards.
+//
+// The panel is a thin display layer — the server sanitizes every field before it ever reaches
+// this component, and Preact renders text nodes, not markup. What IS client logic and tested
+// here: the unavailable/empty/populated branches, the rotate nudge appearing only on
+// rotate_hint, the 401 rows getting the warning class, and the audit card hiding entirely when
+// the control channel is off (audit: null).
+//
+// Run with Node's built-in test runner:
+//     node --test build/dashboard/tests/frontend/*.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { fmtEpoch, SecurityPanel } from "../../mining_dashboard/web/static/securityview.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+// Render the panel with its state pre-set (the render probe runs no effects, so the fetches in
+// componentDidMount never fire — state is injected directly, like the configview tests).
+function renderPanel(state) {
+  const panel = new SecurityPanel({});
+  panel.state = { access: null, audit: null, error: null, ...state };
+  return renderToString(panel.render());
+}
+
+const access = (over = {}) => ({
+  available: true,
+  entries: [],
+  failures_24h: 0,
+  last_failure_ts: null,
+  rotate_hint: false,
+  ...over,
+});
+
+test("fmtEpoch: epoch seconds render, garbage renders blank", () => {
+  assert.equal(fmtEpoch(0), "");
+  assert.equal(fmtEpoch(Number.NaN), "");
+  assert.ok(fmtEpoch(1752148800).length > 0);
+});
+
+test("unavailable access log explains itself; no table", () => {
+  const out = renderPanel({ access: { available: false, entries: [] } });
+  assert.match(out, /No access log yet/);
+  assert.doesNotMatch(out, /<table/);
+});
+
+test("clean history: zero failures, no rotate nudge", () => {
+  const out = renderPanel({
+    access: access({ entries: [{ ts: 100, status: 200, method: "GET", uri: "/", user: "admin" }] }),
+  });
+  assert.match(out, /0 failed logins in the last 24 h/);
+  assert.doesNotMatch(out, /Repeated failed logins/);
+  assert.match(out, /status-ok/);
+});
+
+test("401 burst: rotate nudge names the password and onion rotation commands", () => {
+  const out = renderPanel({
+    access: access({
+      failures_24h: 7,
+      rotate_hint: true,
+      entries: [{ ts: 100, status: 401, method: "GET", uri: "/", user: "" }],
+    }),
+  });
+  assert.match(out, /7 failed logins/);
+  assert.match(out, /Repeated failed logins/);
+  assert.match(out, /rotate-dashboard-onion/);
+  assert.match(out, /dashboard.auth.password/);
+  // The 401 row is styled as a warning.
+  assert.match(out, /<td class="status-bad">401<\/td>/);
+});
+
+test("audit: null (control channel off) renders no config-changes card", () => {
+  const out = renderPanel({ access: access() });
+  assert.doesNotMatch(out, /Recent config changes/);
+});
+
+test("audit entries render actor, outcome, and the changed key names", () => {
+  const out = renderPanel({
+    access: access(),
+    audit: [
+      {
+        ts: "2026-07-10T12:00:00Z",
+        actor: "admin",
+        action: "commit",
+        status: "applied",
+        keys: "XVB_ENABLED P2POOL_PORT",
+      },
+    ],
+  });
+  assert.match(out, /Recent config changes/);
+  assert.match(out, /XVB_ENABLED P2POOL_PORT/);
+  assert.match(out, /<td class="status-ok">applied<\/td>/);
+});
+
+test("audit: empty list says so instead of an empty table", () => {
+  const out = renderPanel({ access: access(), audit: [] });
+  assert.match(out, /No config changes have gone through the dashboard yet/);
+});
+
+test("fetch error surfaces as a message, not a blank panel", () => {
+  const out = renderPanel({ error: "TypeError: fetch failed" });
+  assert.match(out, /fetch failed/);
+});

--- a/build/dashboard/tests/service/test_audit_service.py
+++ b/build/dashboard/tests/service/test_audit_service.py
@@ -1,0 +1,172 @@
+"""audit_service (#349): sanitized read-only views over the host-written security logs.
+
+The core property under test is the hostile-input posture: every string read from either log is
+attacker-influenceable (the access log echoes request URIs and attempted usernames verbatim), so
+anything outside the whitelisted charset must be stripped before it can reach the browser —
+a raw ``<script>`` surviving to the API is stored XSS against the operator.
+"""
+
+import json
+
+import pytest
+
+from mining_dashboard.service import audit_service
+
+XSS = "<script>alert(1)</script>"
+
+
+def audit_line(**overrides):
+    entry = {
+        "ts": "2026-07-10T12:00:00Z",
+        "id": "11111111-1111-4111-8111-111111111111",
+        "actor": "admin",
+        "action": "commit",
+        "status": "applied",
+        "keys": "XVB_ENABLED P2POOL_PORT",
+    }
+    entry.update(overrides)
+    return json.dumps(entry)
+
+
+def access_line(ts=1000.0, status=200, method="GET", uri="/api/state", user="admin"):
+    return json.dumps(
+        {"ts": ts, "status": status, "user_id": user, "request": {"method": method, "uri": uri}}
+    )
+
+
+@pytest.fixture
+def audit_log(tmp_path, monkeypatch):
+    path = tmp_path / "control.log"
+    monkeypatch.setattr(audit_service.config, "CONTROL_AUDIT_LOG", str(path))
+    return path
+
+
+@pytest.fixture
+def access_log(tmp_path, monkeypatch):
+    path = tmp_path / "access.log"
+    monkeypatch.setattr(audit_service.config, "ACCESS_LOG_PATH", str(path))
+    return path
+
+
+class TestClean:
+    def test_strips_markup_and_quotes(self):
+        assert "<" not in audit_service._clean(XSS)
+        assert ">" not in audit_service._clean(XSS)
+        # The readable remainder survives — strip, don't blank.
+        assert "script" in audit_service._clean(XSS)
+        assert audit_service._clean("a\"b'c\\d\x1b[31m") == "abcd31m"
+
+    def test_non_strings_coerced(self):
+        assert audit_service._clean(None) == ""
+        assert audit_service._clean(42) == "42"
+
+    def test_length_capped(self):
+        assert len(audit_service._clean("a" * 500, 200)) == 200
+
+
+class TestRecentChanges:
+    def test_missing_file_is_empty(self, audit_log):
+        assert audit_service.recent_changes() == []
+
+    def test_entries_newest_first_and_whitelisted_fields(self, audit_log):
+        audit_log.write_text(
+            audit_line(status="previewed", action="preview")
+            + "\n"
+            + audit_line(status="applied", secret_extra="LEAKME")
+            + "\n"
+        )
+        entries = audit_service.recent_changes()
+        assert [e["status"] for e in entries] == ["applied", "previewed"]
+        assert entries[0]["keys"] == "XVB_ENABLED P2POOL_PORT"
+        # Field whitelist: a foreign key in the log never reaches the API payload.
+        assert "secret_extra" not in entries[0]
+        assert "LEAKME" not in json.dumps(entries)
+
+    def test_hostile_content_is_neutralized(self, audit_log):
+        # RED-THEN-GREEN guard: with _clean removed this test fails — the exact stored-XSS
+        # (attacker -> operator) direction #33's reviews cared about.
+        audit_log.write_text(audit_line(actor=XSS, keys='"><img src=x onerror=alert(1)>') + "\n")
+        payload = json.dumps(audit_service.recent_changes())
+        assert "<" not in payload and ">" not in payload
+        assert "onerror=alert1" in payload  # readable remainder, but inert
+
+    def test_garbage_lines_skipped(self, audit_log):
+        audit_log.write_text('not json\n[1,2,3]\n"str"\n' + audit_line() + "\n")
+        entries = audit_service.recent_changes()
+        assert len(entries) == 1
+        assert entries[0]["actor"] == "admin"
+
+    def test_limit_applies(self, audit_log):
+        audit_log.write_text("".join(audit_line(actor=f"u{i}") + "\n" for i in range(60)))
+        entries = audit_service.recent_changes(limit=50)
+        assert len(entries) == 50
+        assert entries[0]["actor"] == "u59"  # newest first
+
+    def test_reads_only_a_bounded_tail(self, audit_log, monkeypatch):
+        # A large log costs one bounded read; the partial line cut at the window edge is dropped.
+        monkeypatch.setattr(audit_service, "_TAIL_BYTES", 4096)
+        audit_log.write_text("".join(audit_line(actor=f"user{i:06d}") + "\n" for i in range(200)))
+        entries = audit_service.recent_changes(limit=200)
+        assert 0 < len(entries) < 200
+        assert entries[0]["actor"] == "user000199"
+
+
+class TestAccessSummary:
+    def test_missing_file_reports_unavailable(self, access_log):
+        summary = audit_service.access_summary()
+        assert summary == {
+            "available": False,
+            "entries": [],
+            "failures_24h": 0,
+            "last_failure_ts": None,
+            "rotate_hint": False,
+        }
+
+    def test_counts_401s_inside_24h_only(self, access_log):
+        now = 200000.0
+        lines = [
+            access_line(ts=now - 90000, status=401),  # outside the window — not counted
+            access_line(ts=now - 100, status=200),
+            access_line(ts=now - 50, status=401, user=""),
+            access_line(ts=now - 10, status=401, user=""),
+        ]
+        access_log.write_text("\n".join(lines) + "\n")
+        summary = audit_service.access_summary(now=now)
+        assert summary["available"] is True
+        assert summary["failures_24h"] == 2
+        assert summary["last_failure_ts"] == now - 10
+        assert summary["rotate_hint"] is False  # 2 < threshold
+
+    def test_rotate_hint_at_threshold(self, access_log):
+        now = 200000.0
+        lines = [access_line(ts=now - i, status=401) for i in range(audit_service.ROTATE_HINT_401S)]
+        access_log.write_text("\n".join(lines) + "\n")
+        assert audit_service.access_summary(now=now)["rotate_hint"] is True
+
+    def test_hostile_uri_and_user_neutralized(self, access_log):
+        # RED-THEN-GREEN guard: the URI and attempted username are attacker-chosen bytes.
+        access_log.write_text(access_line(uri="/%3Cscript%3E" + XSS, user=XSS) + "\n")
+        payload = json.dumps(audit_service.access_summary(now=2000.0))
+        assert "<" not in payload and ">" not in payload
+
+    def test_fields_clamped_and_whitelisted(self, access_log):
+        access_log.write_text(
+            json.dumps({"ts": "garbage", "status": 9999, "user_id": None, "request": "not-a-dict"})
+            + "\n"
+            + json.dumps({"ts": 1.0, "status": "junk", "request": {}})
+            + "\n"
+            + access_line(method="EVILVERB")
+            + "\n"
+        )
+        entries = audit_service.access_summary(now=2000.0)["entries"]
+        assert entries[0]["method"] == "?"  # unknown verb collapses
+        assert entries[1]["status"] == 0  # non-numeric status clamps to 0
+        assert entries[2] == {"ts": 0.0, "status": 0, "method": "?", "uri": "", "user": ""}
+
+    def test_entries_newest_first_and_limited(self, access_log):
+        access_log.write_text(
+            "".join(access_line(ts=float(i), uri=f"/p{i}") + "\n" for i in range(60))
+        )
+        entries = audit_service.access_summary(limit=50, now=100.0)["entries"]
+        assert len(entries) == 50
+        assert entries[0]["uri"] == "/p59"

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mining_dashboard.service import control_service
+from mining_dashboard.service import audit_service, control_service
 from mining_dashboard.service.storage_service import StateManager
 from mining_dashboard.web.server import _apply_security_headers, create_app
 
@@ -181,6 +181,8 @@ class TestControlRoutesDisabled:
         assert (await client.post("/api/control/preview", json={})).status == 404
         assert (await client.post("/api/control/commit", json={})).status == 404
         assert (await client.get("/api/control/result?id=x")).status == 404
+        # The config-change audit view is a control-channel artifact — absent with it (#349).
+        assert (await client.get("/api/audit")).status == 404
 
 
 @pytest.fixture
@@ -340,6 +342,87 @@ class TestControlRoutesEnabled:
         resp = await control_client.get("/api/config")
         assert resp.status == 500
         assert "nonexistent" not in json.dumps(await resp.json())
+
+
+class TestSecurityLogRoutes:
+    """/api/access (always on) and /api/audit (with the control channel) — #349. Both are GET-only
+    reads over host-written, read-only-mounted files; every served field is sanitized because log
+    content is attacker-influenceable (the access log echoes attacker-chosen URIs/usernames)."""
+
+    async def test_access_route_reports_unavailable_without_log(self, client, monkeypatch):
+        monkeypatch.setattr(audit_service.config, "ACCESS_LOG_PATH", "/nonexistent/access.log")
+        resp = await client.get("/api/access")
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["available"] is False
+        assert body["entries"] == []
+
+    async def test_access_route_serves_sanitized_entries(self, client, tmp_path, monkeypatch):
+        log = tmp_path / "access.log"
+        log.write_text(
+            json.dumps(
+                {
+                    "ts": 100.0,
+                    "status": 401,
+                    "user_id": "<script>alert(1)</script>",
+                    "request": {"method": "GET", "uri": "/<svg onload=alert(1)>"},
+                }
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(audit_service.config, "ACCESS_LOG_PATH", str(log))
+        resp = await client.get("/api/access")
+        assert resp.status == 200
+        text = json.dumps(await resp.json())
+        # A hostile log line must arrive inert — no markup survives to the browser.
+        assert "<" not in text and ">" not in text
+        assert (await client.get("/api/access")).status == 200
+
+    async def test_audit_route_serves_sanitized_entries(
+        self, control_client, tmp_path, monkeypatch
+    ):
+        log = tmp_path / "control.log"
+        log.write_text(
+            json.dumps(
+                {
+                    "ts": "2026-07-10T12:00:00Z",
+                    "id": "11111111-1111-4111-8111-111111111111",
+                    "actor": "<img src=x onerror=alert(1)>",
+                    "action": "commit",
+                    "status": "applied",
+                    "keys": "XVB_ENABLED",
+                }
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        resp = await control_client.get("/api/audit")
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["entries"][0]["keys"] == "XVB_ENABLED"
+        assert "<" not in json.dumps(body) and ">" not in json.dumps(body)
+
+    async def test_audit_route_missing_log_is_empty(self, control_client, monkeypatch):
+        monkeypatch.setattr(audit_service.config, "CONTROL_AUDIT_LOG", "/nonexistent/control.log")
+        resp = await control_client.get("/api/audit")
+        assert resp.status == 200
+        assert (await resp.json())["entries"] == []
+
+    async def test_access_route_failure_is_sanitized(self, client, monkeypatch):
+        monkeypatch.setattr(
+            audit_service, "access_summary", MagicMock(side_effect=RuntimeError("/host/secret"))
+        )
+        resp = await client.get("/api/access")
+        assert resp.status == 500
+        assert "secret" not in json.dumps(await resp.json())
+
+    async def test_audit_route_failure_is_sanitized(self, control_client, monkeypatch):
+        monkeypatch.setattr(
+            audit_service, "recent_changes", MagicMock(side_effect=RuntimeError("/host/secret"))
+        )
+        resp = await control_client.get("/api/audit")
+        assert resp.status == 500
+        assert "secret" not in json.dumps(await resp.json())
 
 
 class TestSecurityHeaders:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -369,6 +369,10 @@ services:
       - ${CONTROL_DIR:-./data/control}/requests:/control/requests
       - ${CONTROL_DIR:-./data/control}/results:/control/results:ro
       - ${CONTROL_DIR:-./data/control}/audit:/control/audit:ro
+      # Caddy's JSON access log (#349), read-only: the dashboard tails it to show recent accesses
+      # and a failed-login count (a burst of 401s = rotate the password / onion). Caddy owns the
+      # write side and the rotation; every field read from here is treated as hostile input.
+      - ${CADDY_LOG_DIR:-./data/caddy-logs}:/access-log:ro
       # The live config, read-only, prefills the Configuration view (#33). Secret leaves are masked
       # server-side (control_service.read_config); the raw values never leave the API. NOTE: this
       # bind-mount — not the API masking — is the real secret trust boundary; a backend compromise
@@ -599,6 +603,9 @@ services:
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
+      # JSON access log (#349): Caddy rolls it natively (4 MiB × 3 files, see generate_caddyfile);
+      # the dashboard mounts the same dir read-only to show recent accesses and failed logins.
+      - ${CADDY_LOG_DIR:-./data/caddy-logs}:/var/log/caddy
 
 # --- Volumes ---
 volumes:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -367,11 +367,35 @@ How it works underneath: the dashboard container cannot run `pithead` or write h
 drops a typed JSON change request into `./data/control/requests/` — its only writable leg of the
 spool — and a root systemd path unit (`pithead-control`) runs `pithead control-run-pending`, which
 validates the request, dry-runs or applies the staged copy, and writes the outcome to the
-read-only `results/` mount plus an audit line (timestamp, logged-in user, action, outcome) to
-`audit/control.log`. The container cannot forge results, alter a staged config between preview and
-commit, or rewrite the audit log. A failed apply keeps the previous config at
-`config.json.bak-control` and surfaces pithead's error in the view. Operational details:
+read-only `results/` mount plus an audit line (timestamp, logged-in user, action, outcome, and
+the names of the changed settings) to `audit/control.log`. The container cannot forge results,
+alter a staged config between preview and commit, or rewrite the audit log. A failed apply keeps
+the previous config at `config.json.bak-control` and surfaces pithead's error in the view.
+Operational details:
 [Operations › Editing config from the dashboard](operations.md#editing-config-from-the-dashboard).
+
+### Access log and recent config changes
+
+Below the form, the Configuration view shows two read-only security panels
+([#349](https://github.com/p2pool-starter-stack/pithead/issues/349)):
+
+- **Access log.** Recent dashboard requests from Caddy's access log — time, HTTP status, method,
+  path, and the logged-in user — plus a count of failed logins (401s) in the last 24 hours. Over
+  Tor there is no source IP to trace or block, so the signal is the *rate* of failures: five or
+  more in a day shows a warning to rotate the dashboard password (set a new
+  `dashboard.auth.password`, run `./pithead apply`) and, if the onion address may have leaked,
+  `./pithead rotate-dashboard-onion`. The log is always on; entries appear once Caddy has handled
+  a request on this version.
+- **Recent config changes.** The control channel's host-side audit trail: one row per handled
+  request — timestamp, dashboard user, preview/commit, outcome, and the *names* of the settings
+  that changed. Values are never recorded (several are secrets). Shown only when
+  `dashboard.control.enabled` is on.
+
+Both panels read host-written files through read-only mounts, and the dashboard treats every
+field in them as hostile input — a request path is attacker-chosen bytes — so each string is
+stripped to a safe character set before it is served. See
+[Operations › Watching for intruders](operations.md#watching-for-intruders) for the log paths,
+size bounds, and rotation steps.
 
 ## Tips
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -92,7 +92,9 @@ on, and remove them when it is off:
 The spool lives under `./data/control/`: `requests/` (the only directory the dashboard container
 can write), `staged/` (host-only), and `results/` + `audit/` (container read-only).
 `audit/control.log` records one JSON line per handled request — timestamp, the logged-in dashboard
-user, action, outcome — and the container cannot rewrite it.
+user, action, outcome, and the names of the changed settings (never their values) — and the
+container cannot rewrite it. The writer trims the log to its newest 2000 entries once it passes
+512 KiB, so it never grows unbounded.
 
 To disable the channel, set `dashboard.control.enabled: false` and run `./pithead apply`: the
 units are disabled and removed, the routes disappear from the dashboard (404), and the spool
@@ -100,6 +102,37 @@ directory is left in place. To inspect or drain the queue by hand, run
 `./pithead control-run-pending`. A commit keeps the previous config at `config.json.bak-control`;
 a failed apply names it in the result and retries container recreation on the next apply, same as
 the CLI.
+
+---
+
+## Watching for intruders
+
+Caddy writes a JSON access log — one line per dashboard request, with timestamp, HTTP status,
+method, path, and the authenticated user — to `./data/caddy-logs/access.log`
+([#349](https://github.com/p2pool-starter-stack/pithead/issues/349)). It is always on. Caddy
+redacts credential headers by default, so no password material lands in it, and Caddy's native
+rolling caps it at 4 MiB per file, the current file plus two rolled ones (~12 MiB worst case).
+The dashboard's Configuration view surfaces the same data:
+[recent accesses and a failed-login count](dashboard.md#access-log-and-recent-config-changes).
+
+How to read it, given the dashboard is reachable over a Tor onion
+([#343](https://github.com/p2pool-starter-stack/pithead/issues/343)): every request arrives via
+the local Tor daemon, so there is **no source IP** to trace or block — the attack signal is the
+rate and pattern of failures, not identity.
+
+- **A burst of 401s** means someone who can already reach the dashboard — they have the onion
+  address, and the client-auth key if `dashboard.onion.client_auth` is on (the default) — is
+  guessing the password. Rotate it: set a new `dashboard.auth.password` in `config.json` and run
+  `./pithead apply`.
+- **Unexplained traffic on a client-auth-off onion** means the address itself has leaked (it is
+  online-guessable in that mode). Rotate the address: `./pithead rotate-dashboard-onion` mints a
+  fresh onion and client key; the old ones stop working immediately
+  ([details](configuration.md#remote-access-over-tor-onion-service)).
+
+Config tampering shows in the other log: `./data/control/audit/control.log` (above) names every
+change staged through the dashboard and who committed it. A change you didn't make is the same
+rotate-now signal. Secret rotation beyond the dashboard password is tracked in
+[#378](https://github.com/p2pool-starter-stack/pithead/issues/378).
 
 ---
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -111,6 +111,7 @@ The deploy-time axes — each changes a real runtime path. Full table and assert
 | `backup`/`restore`, `reset-dashboard` | real box | 1 ✅ (partial) · 4 ▶ (`--lifecycle`/`--safety-backup`) |
 | `doctor` runtime verdicts (#383): egress firewall, stratum listening, dashboard answers | real box | 1 ✅ (stubbed toolchain) · 4 ▶ (`--check`) |
 | Control channel (#33): `apply --dry-run` preview, runner claim/validate/commit, fail-closed flag, rw/ro spool mounts | spool files / sourced fns | 1 ✅ (shell + pytest + compose) · 4 (systemd path unit on a real box — not yet a matrix row) |
+| Audit + access logs (#349): key-names-not-values audit entries, bounded log growth, Caddyfile log block, hostile log content served inert | spool/log fixtures | 1 ✅ (shell + pytest + node) · 4 (real Caddy writes over Tor — covered by the same onion matrix row) |
 
 ### H. Host / infrastructure (real-only)
 

--- a/pithead
+++ b/pithead
@@ -3781,8 +3781,9 @@ control_write_result() { # <results-dir> <id> <json>
 # One JSON line per handled request. `keys` (optional 6th arg) is the space-separated list of
 # changed env-key NAMES from the same dry-run porcelain the approval gate re-derives — names only,
 # NEVER values: several allowlist-adjacent keys are secrets host-side, and the audit log is mounted
-# into the (semi-trusted) dashboard container. The charset strip is the JSON-injection guard for
-# that field; id/actor are validated upstream and action/status are fixed strings.
+# into the (semi-trusted) dashboard container. Every free-form field is charset-stripped at write
+# time (below) so none can forge a second JSON line — `action` in particular can arrive raw from a
+# container-supplied intent on the unknown-action path, so it is NOT a fixed string.
 control_audit() { # <audit-file> <id> <actor> <action> <status> [keys]
     # Size bound (#349, same posture as #123): once the log passes 512 KiB, keep the newest 2000
     # entries. Trim-before-append, so the file is complete JSONL at all times and the entry being
@@ -3790,8 +3791,17 @@ control_audit() { # <audit-file> <id> <actor> <action> <status> [keys]
     if [ -f "$1" ] && [ "$(wc -c <"$1" | tr -d ' ')" -gt 524288 ]; then
         tail -n 2000 "$1" >"$1.tmp" && mv "$1.tmp" "$1"
     fi
+    # Sanitize the free-form fields at the write chokepoint so nothing can forge a second JSON line
+    # into this tamper-evidence log: `action` may arrive straight from a container-supplied intent
+    # on the unknown-action path (a newline + `{...}` would otherwise inject an entry), and `keys`
+    # is defense-in-depth over its upstream guard. `id` is a validated uuid4, `status` is
+    # code-set, and `actor` is regex-whitelisted upstream — but strip them here too, cheaply.
     printf '{"ts":"%s","id":"%s","actor":"%s","action":"%s","status":"%s","keys":"%s"}\n' \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$2" "$3" "$4" "$5" \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$(printf '%s' "$2" | tr -cd 'A-Za-z0-9-')" \
+        "$(printf '%s' "$3" | tr -cd 'A-Za-z0-9._@-')" \
+        "$(printf '%s' "$4" | tr -cd 'a-z-')" \
+        "$(printf '%s' "$5" | tr -cd 'a-z-')" \
         "$(printf '%s' "${6:-}" | tr -cd 'A-Z0-9_ ')" >>"$1"
 }
 

--- a/pithead
+++ b/pithead
@@ -2113,10 +2113,13 @@ parse_and_validate_config() {
     # container ro). Fixed under ./data like CLEARNET_STATE_DIR — not a user-facing data dir.
     # Deliberately NOT inside DASHBOARD_DIR, which is mounted rw wholesale into the container.
     CONTROL_DIR="$PWD/data/control"
+    # Caddy access log (#349): Caddy (rw) writes access.log here, the dashboard mounts it
+    # read-only. Fixed under ./data like the spool above — internal, not a user-facing data dir.
+    CADDY_LOG_DIR="$PWD/data/caddy-logs"
 
     # Guard every data dir against catastrophic chown -R / rm -rf targets before we touch them.
     local d
-    for d in "$MONERO_DIR" "$TARI_DIR" "$P2POOL_DIR" "$TOR_DATA_DIR" "$DASHBOARD_DIR" "$CLEARNET_STATE_DIR" "$CONTROL_DIR"; do
+    for d in "$MONERO_DIR" "$TARI_DIR" "$P2POOL_DIR" "$TOR_DATA_DIR" "$DASHBOARD_DIR" "$CLEARNET_STATE_DIR" "$CONTROL_DIR" "$CADDY_LOG_DIR"; do
         assert_safe_dir "$d"
     done
 
@@ -2270,6 +2273,11 @@ prepare_directories() {
 prepare_control_dirs() {
     mkdir -p "$CONTROL_DIR/requests" "$CONTROL_DIR/staged" "$CONTROL_DIR/results" "$CONTROL_DIR/audit"
     ensure_owner "$CONTROL_DIR/requests" "$APP_UID" "$APP_GID"
+    # Caddy access-log dir (#349): root-owned so the capability-stripped caddy container (uid 0,
+    # no CAP_DAC_OVERRIDE) can write it; the dashboard (uid 1000) reads it via a ro mount — the
+    # Caddyfile's `mode 0644` keeps the files readable.
+    mkdir -p "$CADDY_LOG_DIR"
+    ensure_owner "$CADDY_LOG_DIR" 0 0
 }
 
 # List "*_DATA_DIR=path" lines from .env whose directory is MISSING — the signature of a relocated
@@ -2844,6 +2852,7 @@ DASHBOARD_AUTH_HASH_B64=$DASHBOARD_AUTH_HASH_B64
 DASHBOARD_AUTH_PW_FP=$DASHBOARD_AUTH_PW_FP
 DASHBOARD_CONTROL_ENABLED=$DASHBOARD_CONTROL_ENABLED
 CONTROL_DIR=$CONTROL_DIR
+CADDY_LOG_DIR=$CADDY_LOG_DIR
 HOST_IP=$HOST_IP
 DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false}
 EOF
@@ -2912,12 +2921,29 @@ generate_caddyfile() {
         hash=$(printf '%s' "$DASHBOARD_AUTH_HASH_B64" | openssl base64 -d -A)
         auth=$(printf '    basic_auth {\n        %s %s\n    }' "$DASHBOARD_AUTH_USER" "$hash")
     fi
+    # Access log (#349): every vhost writes a JSON line per request (timestamp, status, method,
+    # URI, authenticated user) to one shared file under the host-mounted CADDY_LOG_DIR; the
+    # dashboard tails it read-only, and repeated 401s there are the operator's "someone is
+    # guessing the password" signal. Caddy redacts credential headers (Authorization, Cookie)
+    # unless the log_credentials global option is set — it never is here — so no password material
+    # lands in the log. Growth is bounded by Caddy's native rolling: 4 MiB per file, the current
+    # file plus 2 rolled ones. mode 0644 lets the non-root dashboard read what root-run Caddy
+    # writes (Caddy's default is 0600).
+    local logblk='    log {
+        output file /var/log/caddy/access.log {
+            roll_size 4MiB
+            roll_keep 2
+            mode 0644
+        }
+        format json
+    }'
     if [ "$DASHBOARD_SECURE" == "true" ]; then
         log "Generating Caddyfile for automatic HTTPS ($HOST_IP)$([ -n "$auth" ] && echo ' with login')..."
         cat <<EOF >"Caddyfile"
 https://$HOST_IP {
     tls internal
 $auth
+$logblk
     reverse_proxy 127.0.0.1:8000 {
         header_up X-Auth-User {http.auth.user.id}
     }
@@ -2928,6 +2954,7 @@ EOF
         cat <<EOF >"Caddyfile"
 http://$HOST_IP {
 $auth
+$logblk
     reverse_proxy 127.0.0.1:8000 {
         header_up X-Auth-User {http.auth.user.id}
     }
@@ -2949,6 +2976,7 @@ EOF
 
 http://${NETWORK_PREFIX}.1 {
 $auth
+$logblk
     reverse_proxy 127.0.0.1:8000 {
         header_up X-Auth-User {http.auth.user.id}
     }
@@ -2968,6 +2996,7 @@ EOF
 https://${DASHBOARD_ONION} {
     tls internal
 $auth
+$logblk
     reverse_proxy 127.0.0.1:8000 {
         header_up X-Auth-User {http.auth.user.id}
     }
@@ -3374,8 +3403,8 @@ describe_change() {
             msg="Dashboard configuration editing disabled (#33) — the control runner units are removed; the dashboard container is recreated."
         fi
         ;;
-    CONTROL_DIR)
-        # Fixed spool path under ./data — internal, changes only when the checkout moves.
+    CONTROL_DIR | CADDY_LOG_DIR)
+        # Fixed paths under ./data — internal, change only when the checkout moves.
         msg=""
         ;;
     DASHBOARD_ONION_ENABLED)
@@ -3739,6 +3768,9 @@ control_approval_gate() { # <staged-file>
         printf 'this change is destructive and cannot be committed from the dashboard — out-of-band approval is tracked in #338. Apply it from the host with `%s apply`.' "$0"
         return 1
     fi
+    # Approved: echo the changed key NAMES so the commit's audit entry can record WHAT changed
+    # (#349) without a third dry-run. Names only, never values.
+    porcelain_keys "$porcelain"
     return 0
 }
 
@@ -3746,9 +3778,27 @@ control_write_result() { # <results-dir> <id> <json>
     printf '%s\n' "$3" >"$1/.$2.tmp" && mv "$1/.$2.tmp" "$1/$2.json"
 }
 
-control_audit() { # <audit-file> <id> <actor> <action> <status>
-    printf '{"ts":"%s","id":"%s","actor":"%s","action":"%s","status":"%s"}\n' \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$2" "$3" "$4" "$5" >>"$1"
+# One JSON line per handled request. `keys` (optional 6th arg) is the space-separated list of
+# changed env-key NAMES from the same dry-run porcelain the approval gate re-derives — names only,
+# NEVER values: several allowlist-adjacent keys are secrets host-side, and the audit log is mounted
+# into the (semi-trusted) dashboard container. The charset strip is the JSON-injection guard for
+# that field; id/actor are validated upstream and action/status are fixed strings.
+control_audit() { # <audit-file> <id> <actor> <action> <status> [keys]
+    # Size bound (#349, same posture as #123): once the log passes 512 KiB, keep the newest 2000
+    # entries. Trim-before-append, so the file is complete JSONL at all times and the entry being
+    # written is never the one trimmed.
+    if [ -f "$1" ] && [ "$(wc -c <"$1" | tr -d ' ')" -gt 524288 ]; then
+        tail -n 2000 "$1" >"$1.tmp" && mv "$1.tmp" "$1"
+    fi
+    printf '{"ts":"%s","id":"%s","actor":"%s","action":"%s","status":"%s","keys":"%s"}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$2" "$3" "$4" "$5" \
+        "$(printf '%s' "${6:-}" | tr -cd 'A-Z0-9_ ')" >>"$1"
+}
+
+# The unique changed env-key names in a dry-run porcelain, one space-separated line (for the
+# audit `keys` field). Key NAMES only — the porcelain MSG column is dropped here.
+porcelain_keys() {
+    printf '%s' "$1" | awk -F'\t' 'NF' | cut -f2 | sort -u | tr '\n' ' ' | sed 's/ $//'
 }
 
 # Preview: stage the candidate config host-side, dry-run it, report the describe_change rows.
@@ -3773,7 +3823,7 @@ control_preview() { # <request-file> <id> <actor> <control-dir>
             [split("\n")[] | select(length > 0) | split("\t") | {flag: .[0], key: .[1], msg: (.[2:] | join("\t"))}]
             | {status: "previewed", changes: ., destructive: (map(.flag == "DEST") | any), ts: (now | floor)}')
         control_write_result "$cdir/results" "$id" "$result"
-        control_audit "$cdir/audit/control.log" "$id" "$actor" "preview" "previewed"
+        control_audit "$cdir/audit/control.log" "$id" "$actor" "preview" "previewed" "$(porcelain_keys "$out")"
     else
         # Validation failed — reject with pithead's own error tail; nothing stays staged.
         control_write_result "$cdir/results" "$id" "$(jq -n --arg e "$(tail -c 2000 "$errf")" '{status:"rejected",error:$e,ts:(now|floor)}')"
@@ -3799,14 +3849,17 @@ control_commit() { # <id> <actor> <control-dir>
         control_audit "$cdir/audit/control.log" "$id" "$actor" "commit" "rejected"
         return 0
     fi
-    local gate_reason
-    if ! gate_reason=$(control_approval_gate "$staged"); then
-        [ -n "$gate_reason" ] || gate_reason="approval denied"
-        control_write_result "$cdir/results" "$id" "$(jq -n --arg e "$gate_reason" '{status:"rejected",error:$e,ts:(now|floor)}')"
+    # On refusal the gate's stdout is the reason; on approval it is the changed key names, which
+    # the audit entries below record — WHAT changed, by name only (#349).
+    local gate_out keys=""
+    if ! gate_out=$(control_approval_gate "$staged"); then
+        [ -n "$gate_out" ] || gate_out="approval denied"
+        control_write_result "$cdir/results" "$id" "$(jq -n --arg e "$gate_out" '{status:"rejected",error:$e,ts:(now|floor)}')"
         rm -f "$staged"
         control_audit "$cdir/audit/control.log" "$id" "$actor" "commit" "rejected"
         return 0
     fi
+    keys="$gate_out"
     # Keep a pre-change backup; on failure it is named in the result and left in place. cp (not mv)
     # keeps config.json's inode stable — the container bind-mounts the file read-only for prefill.
     cp "$CONFIG_FILE" "${CONFIG_FILE}.bak-control"
@@ -3814,12 +3867,12 @@ control_commit() { # <id> <actor> <control-dir>
     "$0" apply -y >"$logf" 2>&1 || rc=$?
     if [ "$rc" -eq 0 ]; then
         control_write_result "$cdir/results" "$id" "$(jq -n '{status:"applied",ts:(now|floor)}')"
-        control_audit "$cdir/audit/control.log" "$id" "$actor" "commit" "applied"
+        control_audit "$cdir/audit/control.log" "$id" "$actor" "commit" "applied" "$keys"
     else
         # apply's own .apply-incomplete marker handles the container-recreate retry; the config
         # backup lets the operator revert by hand if the new config itself is the problem.
         control_write_result "$cdir/results" "$id" "$(jq -n --arg e "$(tail -c 2000 "$logf")" --arg b "${CONFIG_FILE}.bak-control" '{status:"failed",error:$e,backup:$b,ts:(now|floor)}')"
-        control_audit "$cdir/audit/control.log" "$id" "$actor" "commit" "failed"
+        control_audit "$cdir/audit/control.log" "$id" "$actor" "commit" "failed" "$keys"
     fi
     rm -f "$staged" "$logf"
 }

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -929,6 +929,18 @@ caddy_onion_ph="$(
 assert_contains "onion HTTP vhost renders even before the address is captured (#343)" "$caddy_onion_ph" "http://172.28.0.1 {"
 assert_not_contains "no HTTPS onion vhost until the .onion address is provisioned (#343)" "$caddy_onion_ph" "https://placeholder"
 
+echo "== unit: generate_caddyfile access log (#349) =="
+# Every vhost logs each request as one JSON line to a shared file. Growth is bounded by Caddy's
+# native rolling (4 MiB per file, current + 2 rolled); mode 0644 lets the non-root dashboard
+# read what root-run Caddy writes (Caddy's own default is 0600, unreadable across the mount).
+assert_contains "access log block rendered" "$caddy_https" "output file /var/log/caddy/access.log"
+assert_contains "access log is JSON" "$caddy_https" "format json"
+assert_contains "access log growth is bounded (roll_size)" "$caddy_https" "roll_size 4MiB"
+assert_contains "rolled files are capped (roll_keep)" "$caddy_https" "roll_keep 2"
+assert_contains "access log stays dashboard-readable (mode 0644)" "$caddy_https" "mode 0644"
+log_count="$(printf '%s' "$caddy_onion_https" | grep -c 'output file /var/log/caddy/access.log')"
+assert_eq "every vhost (LAN + onion HTTP + onion HTTPS) writes the shared log" "$log_count" "3"
+
 echo "== unit: onion client-auth crypto (#343) =="
 # Portable base32 (RFC 4648 vectors) — no external `base32` binary (absent on macOS).
 assert_eq "b32encode_hex('f') = MY" "$(run_sourced "$SANDBOX" b32encode_hex 66)" "MY"
@@ -2845,6 +2857,8 @@ assert_contains "control spool dir rendered to .env" "$(cat "$C/.env")" "CONTROL
 [ -d "$C/data/control/requests" ] && [ -d "$C/data/control/staged" ] &&
     [ -d "$C/data/control/results" ] && [ -d "$C/data/control/audit" ] &&
     ok "control spool dirs created" || bad "control spool dirs created" "missing under $C/data/control"
+assert_contains "caddy access-log dir rendered to .env (#349)" "$(cat "$C/.env")" "CADDY_LOG_DIR=$C/data/caddy-logs"
+[ -d "$C/data/caddy-logs" ] && ok "caddy access-log dir created (#349)" || bad "caddy access-log dir created (#349)" "missing"
 
 echo "== black-box: apply --dry-run [--porcelain] (#33) =="
 control_config mini # candidate change: pool main -> mini
@@ -2951,6 +2965,16 @@ assert_eq "committed config landed in config.json" "$(jq -r '.p2pool.pool' "$C/c
 assert_contains "commit ran the real apply (containers recreated)" "$(cat "$CTRL_LOG")" "compose up"
 assert_contains "commit audited with the actor" "$(cat "$AUDIT")" "\"actor\":\"admin\",\"action\":\"commit\",\"status\":\"applied\""
 [ ! -f "$STAGED/$UUID1.json" ] && ok "staged intent consumed on commit" || bad "staged intent consumed on commit" "still staged"
+
+echo "== black-box: audit log records names, never values (#349) =="
+# WHAT changed rides in the audit entry as env-key NAMES (main -> mini touches the p2pool keys);
+# no config or secret VALUE may ever land in the log — it is mounted into the dashboard container.
+assert_contains "commit audit records the changed key names" "$(cat "$AUDIT")" '"keys":"P2POOL'
+assert_contains "preview audit records the changed key names" "$(grep '"status":"previewed"' "$AUDIT" | tail -n 1)" '"keys":"P2POOL'
+case "$(cat "$AUDIT")" in
+*"a control passphrase"* | *"$WALLET"* | *mini*) bad "audit log holds no config or secret values" "a value leaked into audit/control.log" ;;
+*) ok "audit log holds no config or secret values" ;;
+esac
 
 # Expired staged intent (older than the 10-min commit window) → rejected as expired and cleared.
 # Age it ~15 min: past the 10-min expiry the commit enforces, but INSIDE the 60-min stale sweep so
@@ -3170,6 +3194,24 @@ jq '.p2pool.pool="mini"' "$C/config.json" >"$C/cand.json"
 gate_try "$C/cand.json"
 assert_eq "non-security change on a security-laden config still applies" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
 assert_eq "pool tier change landed in config.json" "$(jq -r '.p2pool.pool' "$C/config.json")" "mini"
+
+echo "== black-box: audit log growth is bounded (#349) =="
+# Seed the log past the 512 KiB cap, then let the runner audit one more event: the writer trims
+# to the newest 2000 lines BEFORE appending, so the file shrinks instead of growing forever and
+# the fresh entry is always the last line.
+for _ in $(seq 1 6000); do
+    printf '{"ts":"old","id":"","actor":"filler","action":"preview","status":"previewed","keys":""}\n'
+done >>"$AUDIT"
+[ "$(wc -c <"$AUDIT" | tr -d ' ')" -gt 524288 ] || bad "audit log seeded past the cap" "seed too small"
+printf '{"id":"%s","action":"commit","actor":"admin"}\n' "$UUID5" >"$REQS/$UUID5.json" # no staged intent -> rejected, still audited
+run_pending >/dev/null
+audit_size="$(wc -c <"$AUDIT" | tr -d ' ')"
+if [ "$audit_size" -lt 300000 ]; then
+    ok "audit log trimmed back under the cap ($audit_size bytes)"
+else
+    bad "audit log trimmed back under the cap" "$audit_size bytes"
+fi
+assert_eq "trim keeps the newest entries (fresh entry is the last line)" "$(tail -n 1 "$AUDIT" | jq -r '.action')" "commit"
 
 echo "== black-box: spool intake cap + symlink refusal + stale sweep (#33 hardening) =="
 UUID4="44444444-4444-4444-8444-444444444444"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2937,6 +2937,21 @@ assert_contains "non-v4 uuid id is discarded" "$out" "malformed id"
 printf '{"id":"%s","action":"exec","actor":"x"}\n' "$UUID2" >"$REQS/$UUID2.json"
 run_pending >/dev/null
 assert_eq "unknown action is rejected" "$(jq -r '.status' "$RESULTS/$UUID2.json" 2>/dev/null)" "rejected"
+# A malicious action string on the unknown-action path cannot forge a second line into the
+# tamper-evidence audit log: the field is charset-stripped at the write chokepoint. Feed an action
+# carrying a newline + a fake JSON entry, then assert every audit line is still valid JSON and no
+# forged status leaked in (#349 review).
+audit_before=$(wc -l <"$AUDIT" 2>/dev/null || echo 0)
+# jq decodes the \n and quotes into REAL characters in the action value, so the host-side
+# jq -r '.action' hands control_audit a string with an embedded newline + fake JSON object —
+# the exact shape that would append a forged line without the charset strip.
+jq -nc --arg id "$UUID2" '{id:$id,actor:"x",action:"evil\n{\"ts\":\"0\",\"forged\":\"yes\"}"}' >"$REQS/$UUID2.json"
+run_pending >/dev/null
+audit_after=$(wc -l <"$AUDIT" 2>/dev/null || echo 0)
+assert_eq "forged-action intent adds exactly one audit line" "$((audit_after - audit_before))" "1"
+while IFS= read -r line; do printf '%s' "$line" | jq -e . >/dev/null 2>&1 || bad "every audit line is valid JSON" "unparseable: $line"; done <"$AUDIT"
+ok "every audit line is valid JSON after a forged-action intent"
+assert_not_contains "no forged audit entry leaked in" "$(cat "$AUDIT")" '"forged":"yes"'
 printf '{"id":"%s","action":"preview","actor":"x","config":{},"cmd":"rm -rf /"}\n' "$UUID2" >"$REQS/$UUID2.json"
 run_pending >/dev/null
 assert_contains "extra request keys are rejected" "$(jq -r '.error' "$RESULTS/$UUID2.json" 2>/dev/null)" "unexpected keys"


### PR DESCRIPTION
Implements #349 on top of the merged #33 control channel: a durable record of **what changed** in the stack config, and an **access/auth-attempt log** for the Tor-published dashboard. The operator payoff is concrete — spot a brute-force in progress, rotate the password/onion before it lands.

## What is logged

**Config-change audit** (`./data/control/audit/control.log`, extends #33's writer)
- Each entry now carries `keys`: the changed env-key **names**, re-derived host-side from the same `apply --dry-run --porcelain` the approval gate already runs (previews take them from the preview dry-run — no extra dry-run anywhere).
- Existing fields unchanged: ts, intent id, authenticated actor (Caddy's `X-Auth-User`), action, outcome.

**Access log** (`./data/caddy-logs/access.log`, new)
- Every generated Caddy vhost (LAN + onion HTTP + onion HTTPS) writes one JSON line per request: timestamp, status, method, URI, authenticated user. This is where the 401s live — the "someone is guessing the password" signal the issue asks for.
- The rendered log block was validated against the pinned `caddy:2.11.4` image (`caddy validate`: Valid configuration).

**Dashboard surface** (Configuration view, read-only mounts)
- `/api/access` (always registered — the log is always on; behind Caddy basic_auth like every route): recent accesses, 24 h failed-login count, and a rotate nudge at ≥5 401s that names the exact steps (`dashboard.auth.password` + `./pithead apply`; `./pithead rotate-dashboard-onion`).
- `/api/audit` (registered only with `dashboard.control.enabled`, matching #33's conditional-route pattern): recent config changes — who, when, preview/commit, outcome, which settings.

## What is deliberately NOT logged, and why
- **No config or secret values** — the audit log records key *names* only. Several settings adjacent to the editable allowlist are credentials, and the log is mounted into the semi-trusted dashboard container; names carry the forensic value ("the XvB donation level changed at 03:12 by admin") without the exposure.
- **No credential headers** — Caddy redacts `Authorization`/`Cookie` by default (`log_credentials` is never set), so failed password guesses don't land in the access log.
- **No source IPs worth logging** — over Tor every request reaches Caddy from the local Tor daemon; the docs state this honestly and steer the operator to the failure *rate* instead.

## Growth bounds
- Audit log: trim-before-append in `control_audit` — past **512 KiB**, keep the newest **2000 entries** (file stays valid JSONL at all times).
- Access log: Caddy's native rolling — **4 MiB per file, current + 2 rolled** (~12 MiB worst case), per #123's reuse-the-writer posture.
- The dashboard only ever reads a bounded 256 KiB tail of either file.

## Escaping posture (attacker → operator)
Every field read from either log is hostile input — the access log echoes attacker-chosen bytes (request paths, attempted usernames). The dashboard **whitelists** each string to a conservative ASCII charset (no `<>`, quotes, backslashes, control chars) and length-caps it server-side; fields are also whitelisted by name, methods by enum, statuses clamped to 100–599. The Preact frontend renders text nodes only, as a second layer. **Red-then-green:** with the `_clean` charset guard removed, 4 tests fail (hostile `<script>` reaching the API); with the audit writer sabotaged to log values, the black-box no-secret-values + keys tests fail; with the trim removed, the bounded-growth test fails. All restored green.

## Rotation guidance
`docs/operations.md` gains **Watching for intruders**: how to read the signals (401 burst → rotate the password; traffic on a client-auth-off onion → `rotate-dashboard-onion`) with pointers to the existing procedures. No rotation machinery built here — secret rotation is #378 and its code paths are untouched.

## Tests & gates
- Tier 1 shell black-box: keys-recorded/no-values, bounded growth, Caddyfile log block on every vhost, `CADDY_LOG_DIR` rendered + dir created (754 pass).
- pytest: sanitizer + `/api/audit`//`/api/access` routes, 404-when-disabled, sanitized 500s (dashboard coverage 96%, patch coverage **100%**).
- `node --test`: security-panel render states, rotate nudge, hidden audit card (106 pass).
- `make lint` + `make test` green; docs in house voice (`lint-docs-voice` OK).

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)