### PR TITLE
feat(dashboard): one-click release upgrade through the control channel (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   points a single invocation at a candidate config file.
 - **`pithead control-run-pending`.** The host-side runner behind the Configuration view; fired by
   the systemd path unit, runnable by hand.
+- **One-click upgrade from the dashboard (#59).** With `dashboard.control.enabled` on, a release
+  install shows an **Upgrade to vX.Y.Z** button next to the existing new-release badge (#224).
+  After a typed `UPGRADE` confirm, the host-side control runner performs the documented update —
+  download the new release bundle, run `pithead upgrade` — surviving the dashboard container's own
+  recreation, and the page rides out the restart and reports the outcome. The intent carries only
+  the version the operator saw: the runner re-derives the latest release from the GitHub API over
+  Tor and refuses a mismatch, an older-or-equal version, a source checkout, or more than one
+  attempt per 10 minutes, and audits every attempt. A failed release lookup or bundle download
+  changes nothing; a failure inside `pithead upgrade` leaves not-yet-recreated containers on the
+  previous images and is finished with `./pithead upgrade` on the host.
 - **`status` shows per-chain sync progress (#384).** While a chain is still syncing, `./pithead
   status` reads the dashboard's own `/api/state` and prints each chain's percent and blocks
   remaining inline, instead of only pointing you at the dashboard. No ETA is shown — block rate

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,14 +43,17 @@ The stack's defaults:
 - LAN-scoped (and narrowable) stratum port.
 - Scoped Docker socket proxies.
 - Tor for all node networking.
-- A one-way host-control boundary for dashboard config editing (`dashboard.control`, default
-  off): the dashboard container can only *ask* — it writes typed JSON intents into a spool
+- A one-way host-control boundary for dashboard config editing and upgrades (`dashboard.control`,
+  default off): the dashboard container can only *ask* — it writes typed JSON intents into a spool
   directory whose other legs (staged configs, results, the audit log) are host-owned and mounted
   read-only. A root systemd unit re-validates every intent with pithead's own config validation
-  and dispatches exactly two fixed actions (`apply --dry-run`, `apply -y`); no string from the
-  container is ever executed. Enabling the channel without a dashboard password is a validation
-  error, on a published onion it additionally requires Tor client authorization, and every
-  mutation is audited host-side. Commits are default-denied against an explicit allowlist of
+  and dispatches exactly three fixed actions (`apply --dry-run`, `apply -y`, and a release
+  upgrade); no string from the container is ever executed. The upgrade intent carries only the
+  version the operator confirmed: the runner re-derives the target itself from the GitHub release
+  API (over the stack's Tor SOCKS), refuses any mismatch or non-release tag, and limits attempts
+  to one per 10 minutes — the container cannot choose an image, tag, or registry. Enabling the
+  channel without a dashboard password is a validation error, on a published onion it additionally
+  requires Tor client authorization, and every mutation is audited host-side. Commits are default-denied against an explicit allowlist of
   operational settings: a commit that changes any env key off that list — in every direction
   (enabling, changing, or disabling) — is refused, as is anything the change preview flags
   destructive. Wallets, dashboard auth and onion exposure, the control channel itself, the Tor

--- a/build/dashboard/mining_dashboard/service/control_service.py
+++ b/build/dashboard/mining_dashboard/service/control_service.py
@@ -112,14 +112,18 @@ def merge_secrets(proposed):
     return proposed
 
 
-def submit(action, cfg=None, actor="", intent_id=None):
+def submit(action, cfg=None, actor="", intent_id=None, version=None):
     """Write one intent into the requests spool (atomic: temp + rename, so the runner never
     reads a half-written file). Returns the request id — always a UUID, because the id becomes
-    a host-side filename and the runner rejects anything else."""
+    a host-side filename and the runner rejects anything else. ``version`` rides only on the
+    upgrade intent (#59): the version the operator confirmed, which the host re-verifies
+    against the GitHub release API — a proposal, never a target the container picks."""
     rid = str(uuid.UUID(intent_id)) if intent_id else str(uuid.uuid4())
     request = {"id": rid, "action": action, "actor": actor}
     if cfg is not None:
         request["config"] = cfg
+    if version is not None:
+        request["version"] = version
     tmp = os.path.join(config.CONTROL_REQUESTS_DIR, f".{rid}.tmp")
     with open(tmp, "w") as f:
         json.dump(request, f)

--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -1,6 +1,7 @@
 import logging
 import mimetypes
 import os
+import re
 
 from aiohttp import web
 
@@ -149,6 +150,30 @@ async def handle_control_commit(request):
     return web.json_response({"id": rid, **res})
 
 
+async def handle_control_upgrade(request):
+    """Ask the host runner to upgrade the stack to the latest release (#59). The body's version
+    is only what the operator confirmed seeing ("upgrade to vX.Y.Z"); the host re-derives the real
+    target from the GitHub release API and refuses a mismatch — the container cannot choose what
+    gets installed. Returns 202 immediately: the upgrade recreates this very container, so the
+    client polls /api/control/result and rides out the restart."""
+    _require_control_header(request)
+    try:
+        body = await request.json()
+    except Exception:
+        raise web.HTTPBadRequest(text="Body must be JSON.") from None
+    version = body.get("version")
+    if not isinstance(version, str) or not re.fullmatch(r"v\d+\.\d+\.\d+", version):
+        raise web.HTTPBadRequest(text="'version' must look like vX.Y.Z.")
+    try:
+        rid = control_service.submit(
+            "upgrade", actor=request.headers.get("X-Auth-User", ""), version=version
+        )
+    except Exception:
+        logger.exception("Error submitting control upgrade")
+        return web.json_response({"error": "Failed to submit the upgrade request."}, status=500)
+    return web.json_response({"id": rid, "status": "pending"}, status=202)
+
+
 async def handle_control_result(request):
     """Client-side polling endpoint for a 202'd preview/commit."""
     try:
@@ -215,6 +240,7 @@ def create_app(state_manager, latest_data_ref):
                 web.get("/api/config", handle_config),
                 web.post("/api/control/preview", handle_control_preview),
                 web.post("/api/control/commit", handle_control_commit),
+                web.post("/api/control/upgrade", handle_control_upgrade),
                 web.get("/api/control/result", handle_control_result),
             ]
         )

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -4,7 +4,7 @@
 // classes — it does no number formatting or business logic of its own.
 
 import { ChartCard } from "./chart.mjs";
-import { ConfigView } from "./configview.mjs";
+import { ConfigView, UpgradeControl } from "./configview.mjs";
 import {
   computeEarnings,
   computeXvbTier,
@@ -71,8 +71,8 @@ const VersionBadge = ({ version }) =>
     : null;
 
 // New-release callout (#224). Shown only when the server reports a newer GitHub release is available
-// (opt-in `dashboard.check_for_updates`, off by default). Notify-only — it's a link to the release,
-// not an upgrade button (#59). Accent so it's noticeable; opens the release page in a new tab.
+// (`dashboard.check_for_updates`). Notify-only — a link to the release notes; the one-click upgrade
+// is the separate UpgradeControl (#59). Accent so it's noticeable; opens the release page in a new tab.
 const UpdateBadge = ({ update }) =>
   update && update.available && update.url
     ? html`<a class="badge badge-accent version-badge ml-2" href=${update.url}
@@ -137,6 +137,7 @@ function Header({ state }) {
                         <${Badges} badges=${state.badges} />
                         <${VersionBadge} version=${state.version} />
                         <${UpdateBadge} update=${state.update} />
+                        <${UpgradeControl} update=${state.update} enabled=${state.control_enabled} />
                     </div>
                     <div class="brand-host font-mono text-muted">${state.host_ip}${state.host_addr ? html`<span class="brand-host-at">@</span>${state.host_addr}` : null}</div>
                 </div>

--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -11,6 +11,32 @@ import { Component, html } from "./preact.mjs";
 const CONTROL_HEADERS = { "Content-Type": "application/json", "X-Pithead-Control": "1" };
 const POLL_MS = 2000;
 const POLL_MAX = 90; // 3 minutes — a commit recreates containers, which can take a while
+const UPGRADE_POLL_MAX = 450; // 15 minutes — an upgrade pulls a whole release of images first
+
+// Poll /api/control/result until a terminal result lands; shared by the Configuration view and
+// the Upgrade button (#59). `skip` ignores an intermediate status under the same id (the
+// still-present "previewed" result while a commit runs; "running" while an upgrade runs). Both
+// flows recreate the dashboard container itself, so a fetch here can transiently fail (connection
+// refused mid-restart) — ride it out and keep polling until the result file answers.
+async function pollResult(id, skip, max = POLL_MAX) {
+  for (let i = 0; i < max; i++) {
+    await new Promise((r) => setTimeout(r, POLL_MS));
+    let res;
+    try {
+      res = await fetch(`/api/control/result?id=${encodeURIComponent(id)}`);
+    } catch {
+      continue;
+    }
+    if (res.status === 202) continue;
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const out = await res.json();
+    if (out.status === skip) continue;
+    return out;
+  }
+  throw new Error(
+    "Timed out waiting for the host runner — is dashboard.control enabled and the pithead-control unit running?",
+  );
+}
 
 const Field = ({ field, edits, onEdit }) => {
   const value = field.key in edits ? edits[field.key] : field.value;
@@ -107,29 +133,10 @@ export class ConfigView extends Component {
     }
   }
 
-  // Poll the result endpoint until a terminal result lands. `skip` ignores the still-present
-  // preview result while waiting for the commit outcome under the same id.
-  async poll(id, skip) {
-    for (let i = 0; i < POLL_MAX; i++) {
-      await new Promise((r) => setTimeout(r, POLL_MS));
-      // A commit recreates the dashboard container itself, so a fetch here can transiently fail
-      // (connection refused mid-restart). Ride it out — keep polling until the result file answers
-      // rather than dropping to an error state (graft #437 pollResult).
-      let res;
-      try {
-        res = await fetch(`/api/control/result?id=${encodeURIComponent(id)}`);
-      } catch {
-        continue;
-      }
-      if (res.status === 202) continue;
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const out = await res.json();
-      if (out.status === skip) continue;
-      return out;
-    }
-    throw new Error(
-      "Timed out waiting for the host runner — is dashboard.control enabled and the pithead-control unit running?",
-    );
+  // Poll the result endpoint until a terminal result lands (shared pollResult above; kept as a
+  // method because the view's flows and tests drive it through the instance).
+  poll(id, skip) {
+    return pollResult(id, skip);
   }
 
   async save() {
@@ -237,5 +244,104 @@ export class ConfigView extends Component {
             : null
         }
     </div>`;
+  }
+}
+
+// --- One-click upgrade (#59) ---------------------------------------------------------
+
+// POST the upgrade intent, then wait out the whole run. Exported for node --test — this network
+// flow is the logic; UpgradeControl only maps its outcome onto UI state. The server answers 202
+// straight away (the upgrade recreates the dashboard container itself), so the real outcome
+// arrives via pollResult, skipping the intermediate "running" result and riding out the restart.
+export async function runUpgrade(version) {
+  const res = await fetch("/api/control/upgrade", {
+    method: "POST",
+    headers: CONTROL_HEADERS,
+    body: JSON.stringify({ version }),
+  });
+  if (!res.ok && res.status !== 202) throw new Error(`HTTP ${res.status}`);
+  const out = await res.json();
+  return pollResult(out.id, "running", UPGRADE_POLL_MAX);
+}
+
+// Header control for #59, rendered next to the new-release badge only when the server reports
+// BOTH a newer release and an enabled control channel. The typed UPGRADE confirm is UX, not a
+// security control — the host runner re-derives the target from the GitHub release API and
+// refuses anything that isn't the latest published release.
+export class UpgradeControl extends Component {
+  constructor(props) {
+    super(props);
+    // idle | confirm | upgrading | done | failed
+    this.state = { phase: "idle", confirmText: "", result: null };
+  }
+
+  async run() {
+    this.setState({ phase: "upgrading" });
+    try {
+      const out = await runUpgrade(this.props.update.latest);
+      this.setState({ phase: out.status === "upgraded" ? "done" : "failed", result: out });
+    } catch (e) {
+      this.setState({ phase: "failed", result: { error: String(e) } });
+    }
+  }
+
+  render() {
+    const { update, enabled } = this.props;
+    if (!enabled || !update || !update.available) return null;
+    const { phase, confirmText, result } = this.state;
+    const version = update.latest;
+    let modal = null;
+    if (phase === "confirm") {
+      modal = html`<div class="config-modal-backdrop">
+          <div class="card config-modal">
+              <h3>Upgrade to ${version}</h3>
+              <p>The host pulls the ${version} release and recreates every container — including
+              this dashboard, which goes away for a moment, and the miners' stratum connection,
+              which reconnects. Your config, wallet, and chain data are kept.</p>
+              <label class="config-confirm-type">Type <code>UPGRADE</code> to confirm:
+                  <input type="text" value=${confirmText}
+                      onInput=${(e) => this.setState({ confirmText: e.target.value })} /></label>
+              <div class="config-modal-actions">
+                  <button class="btn-toggle" onClick=${() => this.setState({ phase: "idle", confirmText: "" })}>Cancel</button>
+                  <button class="btn-toggle active" disabled=${confirmText !== "UPGRADE"}
+                      onClick=${() => this.run()}>Upgrade</button>
+              </div>
+          </div>
+      </div>`;
+    } else if (phase === "upgrading") {
+      modal = html`<div class="config-modal-backdrop">
+          <div class="card config-modal">
+              <h3>Upgrading to ${version}…</h3>
+              <p class="text-muted">The host is pulling images and recreating containers. This page
+              will briefly disconnect while the dashboard restarts — leave it open; it reports the
+              outcome when the new version is up.</p>
+          </div>
+      </div>`;
+    } else if (phase === "done") {
+      modal = html`<div class="config-modal-backdrop">
+          <div class="card config-modal">
+              <h3>Upgraded to ${result.version || version}</h3>
+              <p class="status-ok">The stack is running the new release.</p>
+              <div class="config-modal-actions">
+                  <button class="btn-toggle active" onClick=${() => window.location.reload()}>Reload the dashboard</button>
+              </div>
+          </div>
+      </div>`;
+    } else if (phase === "failed") {
+      modal = html`<div class="config-modal-backdrop">
+          <div class="card config-modal">
+              <h3>Upgrade did not complete</h3>
+              <p class="status-bad">${result.error || "The host runner reported a failure."}</p>
+              <div class="config-modal-actions">
+                  <button class="btn-toggle" onClick=${() => this.setState({ phase: "idle", confirmText: "" })}>Close</button>
+              </div>
+          </div>
+      </div>`;
+    }
+    return html`<button class="badge badge-accent version-badge upgrade-btn ml-2"
+            title=${"Upgrade the stack to " + version + " from the dashboard"}
+            onClick=${() => this.setState({ phase: "confirm", confirmText: "" })}>
+            Upgrade to ${version}
+        </button>${modal}`;
   }
 }

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -469,6 +469,11 @@ tr:last-child td {
 .version-badge.version-dev {
   border-style: dashed;
 }
+/* One-click upgrade button (#59): a badge-shaped <button>, so reset the UA button chrome. */
+button.upgrade-btn {
+  border: none;
+  cursor: pointer;
+}
 
 .wallet-text {
   font-size: 0.7rem;

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -16,6 +16,7 @@ import math
 import os
 import time
 
+from mining_dashboard.config import config
 from mining_dashboard.config.config import (
     DEFAULT_HASHRATE_WINDOW,
     DISK_CRITICAL_PERCENT,
@@ -1198,6 +1199,10 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
         "host_addr": host_display_addr(HOST_IP),
         "version": resolve_version(),
         "update": data.get("update"),  # {available, latest, url} | None — new-release badge (#224)
+        # Whether the control channel is on (#33) — gates the header Upgrade button (#59). The
+        # routes 404 when off, so this is display gating only, not a security control. Read at
+        # call time (module attribute, not from-import) so tests can flip the flag per-app.
+        "control_enabled": config.DASHBOARD_CONTROL_ENABLED,
         "last_update": format_time_abs(time.time()),
         "range": range_arg,
         "window": {"from": window[0], "to": window[1]} if window else None,

--- a/build/dashboard/tests/frontend/configview.test.mjs
+++ b/build/dashboard/tests/frontend/configview.test.mjs
@@ -58,3 +58,66 @@ test("poll skips the still-present preview result until the commit outcome lands
   const out = await withFastPoll(fetchStub, () => view.poll(ID, "previewed"));
   assert.equal(out.status, "applied");
 });
+
+// --- One-click upgrade (#59) ----------------------------------------------------------
+//
+// runUpgrade is the whole client-side flow: POST the version the operator saw, then poll the
+// result file to the terminal outcome — skipping the runner's intermediate "running" status and
+// riding out the window where the upgrade recreates the dashboard container itself. The typed
+// UPGRADE confirm is UX only; the host runner re-derives the real target (tier-2 spool tests).
+
+import { runUpgrade, UpgradeControl } from "../../mining_dashboard/web/static/configview.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+const UPDATE = { available: true, latest: "v9.9.9", url: "https://example.invalid/rel" };
+
+test("runUpgrade posts the seen version, skips 'running', rides out the restart, returns the outcome", async () => {
+  let posted = null;
+  let polls = 0;
+  const fetchStub = async (url, opts) => {
+    if (url === "/api/control/upgrade") {
+      posted = { body: JSON.parse(opts.body), headers: opts.headers };
+      return { status: 202, ok: false, json: async () => ({ id: ID, status: "pending" }) };
+    }
+    polls++;
+    if (polls === 1) return okResult({ status: "running", version: "v9.9.9" });
+    if (polls === 2) throw new TypeError("Failed to fetch"); // dashboard recreated mid-upgrade
+    return okResult({ status: "upgraded", version: "v9.9.9" });
+  };
+  const out = await withFastPoll(fetchStub, () => runUpgrade("v9.9.9"));
+  assert.equal(out.status, "upgraded");
+  assert.deepEqual(posted.body, { version: "v9.9.9" }); // the proposal — nothing else crosses
+  assert.equal(posted.headers["X-Pithead-Control"], "1"); // CSRF guard rides every mutation
+});
+
+test("runUpgrade surfaces a host-side rejection as the outcome, not a throw", async () => {
+  const fetchStub = async (url) =>
+    url === "/api/control/upgrade"
+      ? { status: 202, ok: false, json: async () => ({ id: ID, status: "pending" }) }
+      : okResult({ status: "rejected", error: "already up to date" });
+  const out = await withFastPoll(fetchStub, () => runUpgrade("v9.9.9"));
+  assert.equal(out.status, "rejected");
+  assert.match(out.error, /up to date/);
+});
+
+test("UpgradeControl renders nothing without a newer release or with the channel off", () => {
+  const inst = (props) => {
+    const c = new UpgradeControl(props);
+    c.props = props;
+    return renderToString(c.render());
+  };
+  assert.equal(inst({ update: null, enabled: true }), "");
+  assert.equal(inst({ update: { available: false }, enabled: true }), "");
+  assert.equal(inst({ update: UPDATE, enabled: false }), "");
+  assert.match(inst({ update: UPDATE, enabled: true }), /Upgrade to v9\.9\.9/);
+});
+
+test("the confirm modal arms only on a typed UPGRADE", () => {
+  const props = { update: UPDATE, enabled: true };
+  const inst = new UpgradeControl(props);
+  inst.props = props;
+  inst.state.phase = "confirm";
+  assert.match(renderToString(inst.render()), /disabled/); // unarmed until typed
+  inst.state.confirmText = "UPGRADE";
+  assert.doesNotMatch(renderToString(inst.render()), /disabled/);
+});

--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -115,6 +115,13 @@ class TestSubmit:
         req = json.loads((spool / "requests" / f"{rid}.json").read_text())
         assert "config" not in req
 
+    def test_upgrade_intent_carries_version_only(self, spool):
+        # The upgrade intent (#59) proposes a version and nothing else — no config leg, no
+        # free-form target; the host runner re-derives what actually gets installed.
+        rid = control_service.submit("upgrade", actor="admin", version="v9.9.9")
+        req = json.loads((spool / "requests" / f"{rid}.json").read_text())
+        assert req == {"id": rid, "action": "upgrade", "actor": "admin", "version": "v9.9.9"}
+
     def test_garbage_intent_id_rejected(self, spool):
         # The id becomes a host-side filename; anything that isn't a UUID never leaves the app.
         with pytest.raises(ValueError):

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -180,6 +180,7 @@ class TestControlRoutesDisabled:
         assert (await client.get("/api/config")).status == 404
         assert (await client.post("/api/control/preview", json={})).status == 404
         assert (await client.post("/api/control/commit", json={})).status == 404
+        assert (await client.post("/api/control/upgrade", json={})).status == 404
         assert (await client.get("/api/control/result?id=x")).status == 404
 
 
@@ -233,7 +234,7 @@ class TestControlRoutesEnabled:
 
     async def test_post_without_control_header_forbidden(self, control_client):
         # The custom header forces a CORS preflight cross-site, which is never granted (CSRF).
-        for path in ("/api/control/preview", "/api/control/commit"):
+        for path in ("/api/control/preview", "/api/control/commit", "/api/control/upgrade"):
             resp = await control_client.post(path, json={"config": {}})
             assert resp.status == 403, path
 
@@ -313,6 +314,45 @@ class TestControlRoutesEnabled:
         assert resp.status == 200
         assert (await resp.json())["status"] == "applied"
 
+    async def test_upgrade_submits_typed_intent_and_returns_pending(
+        self, control_client, control_spool
+    ):
+        # 202 straight away: the upgrade recreates this container, so the outcome is polled.
+        resp = await control_client.post(
+            "/api/control/upgrade",
+            json={"version": "v9.9.9"},
+            headers={**CONTROL_HEADERS, "X-Auth-User": "admin"},
+        )
+        assert resp.status == 202
+        body = await resp.json()
+        assert body["status"] == "pending"
+        req = json.loads((control_spool / "requests" / f"{body['id']}.json").read_text())
+        # Closed shape: exactly these keys — no config leg, no free-form target for the runner.
+        assert req == {
+            "id": body["id"],
+            "action": "upgrade",
+            "actor": "admin",
+            "version": "v9.9.9",
+        }
+
+    @pytest.mark.parametrize(
+        "version",
+        ["", "9.9.9", "latest", "v9.9", "v9.9.9; rm -rf /", "v9.9.9\n", 42, None],
+    )
+    async def test_upgrade_rejects_malformed_version(self, control_client, control_spool, version):
+        # Shape-checked before anything touches the spool (the host re-validates regardless).
+        resp = await control_client.post(
+            "/api/control/upgrade", json={"version": version}, headers=CONTROL_HEADERS
+        )
+        assert resp.status == 400
+        assert list((control_spool / "requests").iterdir()) == []
+
+    async def test_upgrade_rejects_non_json_body(self, control_client):
+        resp = await control_client.post(
+            "/api/control/upgrade", data=b"not json", headers=CONTROL_HEADERS
+        )
+        assert resp.status == 400
+
     async def test_result_endpoint_polling(self, control_client, control_spool):
         rid = str(uuid.uuid4())
         resp = await control_client.get(f"/api/control/result?id={rid}")
@@ -331,6 +371,15 @@ class TestControlRoutesEnabled:
         monkeypatch.setattr(control_service.config, "HOST_CONFIG_PATH", "/nonexistent/config.json")
         resp = await control_client.post(
             "/api/control/preview", json={"config": {"p2pool": {}}}, headers=CONTROL_HEADERS
+        )
+        assert resp.status == 500
+        assert "nonexistent" not in json.dumps(await resp.json())
+
+    async def test_upgrade_spool_failure_is_sanitized(self, control_client, monkeypatch):
+        # A broken spool (unwritable requests dir) must come back as a sanitized 500.
+        monkeypatch.setattr(control_service.config, "CONTROL_REQUESTS_DIR", "/nonexistent/requests")
+        resp = await control_client.post(
+            "/api/control/upgrade", json={"version": "v9.9.9"}, headers=CONTROL_HEADERS
         )
         assert resp.status == 500
         assert "nonexistent" not in json.dumps(await resp.json())

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -432,6 +432,16 @@ class TestChartWindow:
         assert state["avg_window"] == DEFAULT_HASHRATE_WINDOW
         assert state["chart"]["p2pool"][0]["y"] == 1000  # the original 10m series
 
+    def test_build_state_exposes_control_flag_for_upgrade_button(self, monkeypatch):
+        # Off by default; flipping the module attribute flips the state key (#59 button gating).
+        import mining_dashboard.config.config as cfg
+
+        state = build_state(_data(), _state_mgr(history=[self._row()]), "all")
+        assert state["control_enabled"] is False
+        monkeypatch.setattr(cfg, "DASHBOARD_CONTROL_ENABLED", True)
+        state = build_state(_data(), _state_mgr(history=[self._row()]), "all")
+        assert state["control_enabled"] is True
+
 
 # --- Hashrate / mode / tier formatting ------------------------------------------------
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -397,6 +397,14 @@ the host, with no SSH:
    pulls the new images. The page rides out its own restart and reports the outcome; reload when
    it says the new version is up.
 
+The version the container proposes is never trusted as the target: the host independently fetches
+the latest tag from GitHub, and the bundle it downloads is for that host-derived tag. Today the
+bundle's authenticity rests on TLS to GitHub (over Tor) plus that tag pinning — it is not yet
+cryptographically signed, so a compromise of the release pipeline or GitHub account could serve a
+malicious bundle. Signing releases and verifying the signature in `pithead upgrade` is tracked in
+[#376](https://github.com/p2pool-starter-stack/pithead/issues/376); until it lands, treat the
+one-click upgrade with the same trust you place in GitHub itself.
+
 The button never appears on a source checkout — the runner refuses the request there, since a dev
 install updates with `git pull`. If the upgrade fails, the result says so in the view: a failed
 release lookup or bundle download changes nothing; a failure during `pithead upgrade` leaves

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -87,10 +87,13 @@ report shows the build. To switch a `dev` build to a published release, see
 [Switching a source checkout to release images](operations.md#switching-a-source-checkout-to-release-images).
 
 When a newer Pithead release is out, a clickable `New release vX.Y.Z available ↗` badge appears next
-to the version badge, linking to the GitHub release. It never updates anything; upgrade with
-`./pithead upgrade` when ready. The check is on by default and routed over Tor, so it does not reveal
-your IP. Turn it off with `dashboard.check_for_updates: false` (see
-[Configuration](configuration.md#configuration-reference)).
+to the version badge, linking to the GitHub release. The badge itself never updates anything. The
+check is on by default and routed over Tor, so it does not reveal your IP. Turn it off with
+`dashboard.check_for_updates: false` (see [Configuration](configuration.md#configuration-reference)).
+
+With the [control channel](#configuration-view) enabled, an **Upgrade to vX.Y.Z** button appears
+beside the badge — see [Upgrading from the dashboard](#upgrading-from-the-dashboard). Without it,
+upgrade from the host per [Operations › Updating the stack](operations.md#updating-the-stack).
 
 ### Host & performance warnings
 
@@ -372,6 +375,35 @@ read-only `results/` mount plus an audit line (timestamp, logged-in user, action
 commit, or rewrite the audit log. A failed apply keeps the previous config at
 `config.json.bak-control` and surfaces pithead's error in the view. Operational details:
 [Operations › Editing config from the dashboard](operations.md#editing-config-from-the-dashboard).
+
+## Upgrading from the dashboard
+
+With `dashboard.control.enabled: true` (the same flag as the Configuration view) and a newer
+release detected, an **Upgrade to vX.Y.Z** button appears next to the new-release badge. It runs
+the release install's documented update — download the new bundle, run `./pithead upgrade` — on
+the host, with no SSH:
+
+1. Click the button and type `UPGRADE` to confirm. An upgrade recreates every container, so the
+   dashboard disconnects briefly and miners reconnect to the stratum port; config, wallet, and
+   chain data are untouched.
+2. The dashboard drops an upgrade request into the same control spool the Configuration view
+   uses. The host-side runner asks the GitHub release API (over Tor) for the latest release
+   itself and refuses the request unless the version you confirmed **is** that latest release and
+   it is newer than the running version — the container proposes, the host decides what gets
+   installed. Attempts are limited to one per 10 minutes, and every one is written to the audit
+   log.
+3. The runner downloads the release bundle (over Tor), extracts it over the install directory,
+   and runs the new release's `./pithead upgrade`, which re-renders the generated config and
+   pulls the new images. The page rides out its own restart and reports the outcome; reload when
+   it says the new version is up.
+
+The button never appears on a source checkout — the runner refuses the request there, since a dev
+install updates with `git pull`. If the upgrade fails, the result says so in the view: a failed
+release lookup or bundle download changes nothing; a failure during `pithead upgrade` leaves
+containers that were not yet recreated on the previous images, and finishing up is one
+`./pithead upgrade` on the host. There is no automatic rollback — the images of the previous
+release stay on disk, and `docker compose` state is recoverable the same way as a failed
+CLI upgrade.
 
 ## Tips
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -89,6 +89,11 @@ on, and remove them when it is off:
 - `pithead-control.service` — a root oneshot running `pithead control-run-pending` from the
   install directory. Fixed command, no parameters from the container.
 
+The runner dispatches exactly three actions: `apply --dry-run --porcelain` (preview), `apply -y`
+(commit), and a release upgrade — the dashboard's
+[Upgrade button](dashboard.md#upgrading-from-the-dashboard), for which the runner re-derives the
+target from the GitHub release API itself and refuses any other version.
+
 The spool lives under `./data/control/`: `requests/` (the only directory the dashboard container
 can write), `staged/` (host-only), and `results/` + `audit/` (container read-only).
 `audit/control.log` records one JSON line per handled request — timestamp, the logged-in dashboard
@@ -106,6 +111,11 @@ the CLI.
 ## Updating the stack
 
 The update path depends on how you installed (see [Getting Started](getting-started.md#2-get-the-code)).
+
+**From the dashboard:** with `dashboard.control.enabled: true`, a release install can run this
+whole sequence from the browser — see
+[Dashboard › Upgrading from the dashboard](dashboard.md#upgrading-from-the-dashboard). The steps
+below are what that button performs, and the only path for source checkouts.
 
 **Release bundle (the default):** from the install directory, re-download the latest bundle over it,
 then upgrade. `upgrade` **pulls** the new published images:

--- a/pithead
+++ b/pithead
@@ -3877,6 +3877,13 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         _upg_reject "cannot determine the running version (VERSION file missing) — upgrade from the host."
         return 0
     fi
+    # Claim the throttle now — BEFORE the network dial — so every well-formed attempt costs the
+    # 10-minute window, even one that will be rejected as non-latest. Otherwise a compromised
+    # container floods well-formed-but-stale version intents and turns the root runner into an
+    # unthrottled GitHub-API / Tor-egress beacon (each fails only at the proposed!=tag check, past
+    # the dial). A genuine probe that fails to reach GitHub costing the operator a 10-minute wait
+    # is the right trade.
+    touch "$stamp"
     # Host-side re-derivation of the target: the latest tag according to GitHub, not the request.
     local prefix socks rel tag
     prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
@@ -3901,7 +3908,6 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         _upg_reject "already up to date (running v$PITHEAD_VERSION; latest release is $tag)."
         return 0
     fi
-    touch "$stamp"
     control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"running",version:$v,ts:(now|floor)}')"
     control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "started"
     # Bundle URL built from the HOST-derived tag only; fetched over the same Tor SOCKS.

--- a/pithead
+++ b/pithead
@@ -1217,9 +1217,10 @@ Maintenance:
                             the old address and any client keys you handed out stop working.
                               -y, --yes        skip the confirmation prompt.
 
-  control-run-pending       Process queued dashboard config-change requests (#33): validate
-                            each staged intent and run 'apply --dry-run' (preview) or
-                            'apply -y' (commit). Normally fired by the pithead-control
+  control-run-pending       Process queued dashboard control requests (#33): validate each
+                            intent and run 'apply --dry-run' (preview), 'apply -y' (commit),
+                            or a release upgrade (#59, target verified against the GitHub
+                            release API host-side). Normally fired by the pithead-control
                             systemd path unit when dashboard.control.enabled is true.
 
   help, -h, --help          Show this message.
@@ -3664,7 +3665,8 @@ apply() {
 # --- Dashboard control channel (#33) ---
 # The dashboard container can only ASK: it drops typed JSON intents into $CONTROL_DIR/requests
 # (its single writable spool mount). This host-side runner claims each request, validates it, and
-# dispatches EXACTLY two actions — `apply --dry-run --porcelain` (preview) and `apply -y` (commit).
+# dispatches EXACTLY three actions — `apply --dry-run --porcelain` (preview), `apply -y` (commit),
+# and `upgrade` to the latest published release (#59, target re-derived host-side).
 # Outcomes land in results/ and an audit line in audit/, both mounted read-only in the container.
 # No string from the container is ever executed or interpolated into a command; the candidate
 # config crosses the boundary only as a FILE handed to `apply` via PITHEAD_CONFIG_FILE.
@@ -3824,9 +3826,118 @@ control_commit() { # <id> <actor> <control-dir>
     rm -f "$staged" "$logf"
 }
 
+# True when SemVer $1 is strictly newer than $2 (either may carry a leading `v`). Both arguments
+# are shape-checked (vX.Y.Z) before the call. Pure bash/awk — macOS sort has no -V.
+semver_newer() {
+    local a b
+    a=$(printf '%s' "${1#v}" | awk -F. '{printf "%d%05d%05d",$1,$2,$3}')
+    b=$(printf '%s' "${2#v}" | awk -F. '{printf "%d%05d%05d",$1,$2,$3}')
+    [ "$a" -gt "$b" ]
+}
+
+# Upgrade the install to the latest published release (#59). The container only PROPOSES ("the
+# operator confirmed vX.Y.Z"); this host side re-derives the target itself: it asks the GitHub
+# release API — over the stack's own Tor SOCKS, like every other stack egress — for the latest
+# tag, refuses unless the proposed version matches that tag exactly AND the tag is strictly newer
+# than the running VERSION, then downloads the release bundle for the HOST-derived tag and runs
+# `pithead upgrade`: the same two steps docs/operations.md documents for a manual update. No
+# container string ever reaches a command line or URL — the proposed version is shape-checked and
+# used only in an equality comparison, so a container-supplied tag/registry cannot steer what is
+# installed (the image-swap RCE the #33 review closed). Source checkouts are refused: their
+# update is `git pull`, a judgment the operator makes at a shell. One attempt per 10 minutes,
+# so a compromised container cannot use the root runner as an egress beacon or grind GitHub.
+control_upgrade() { # <request-file> <id> <actor> <control-dir>
+    local file="$1" id="$2" actor="$3" cdir="$4"
+    _upg_reject() { # <reason> — refuse before anything changed on the host
+        control_write_result "$cdir/results" "$id" "$(jq -n --arg e "$1" '{status:"rejected",error:$e,ts:(now|floor)}')"
+        control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "rejected"
+    }
+    _upg_fail() { # <reason> — the attempt started and did not finish
+        control_write_result "$cdir/results" "$id" "$(jq -n --arg e "$1" '{status:"failed",error:$e,ts:(now|floor)}')"
+        control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
+    }
+    if is_source_checkout; then
+        _upg_reject "this install builds from source — upgrade from the host with 'git pull' then './pithead upgrade'."
+        return 0
+    fi
+    # Throttle: one attempt per 10 minutes, checked before any network dial.
+    local stamp="$cdir/staged/.upgrade-stamp"
+    if [ -n "$(find "$stamp" -mmin -10 2>/dev/null)" ]; then
+        _upg_reject "an upgrade was attempted less than 10 minutes ago — wait for it to finish, then retry."
+        return 0
+    fi
+    # The proposed version must LOOK like a release tag before it is even compared.
+    local proposed
+    proposed=$(jq -r '.version // ""' "$file")
+    if ! printf '%s' "$proposed" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        _upg_reject "malformed or missing 'version' in the upgrade request."
+        return 0
+    fi
+    if [ -z "${PITHEAD_VERSION:-}" ]; then
+        _upg_reject "cannot determine the running version (VERSION file missing) — upgrade from the host."
+        return 0
+    fi
+    # Host-side re-derivation of the target: the latest tag according to GitHub, not the request.
+    local prefix socks rel tag
+    prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
+    [ -n "$prefix" ] || prefix="172.28.0"
+    socks="${prefix}.25:9050"
+    if ! rel=$(curl -fsS --max-time 60 --socks5-hostname "$socks" \
+        -H 'Accept: application/vnd.github+json' \
+        "https://api.github.com/repos/p2pool-starter-stack/pithead/releases/latest" 2>/dev/null); then
+        _upg_reject "could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
+        return 0
+    fi
+    tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)
+    if ! printf '%s' "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        _upg_reject "the GitHub release API returned no usable release tag — nothing was changed."
+        return 0
+    fi
+    if [ "$proposed" != "$tag" ]; then
+        _upg_reject "requested version $proposed is not the latest published release ($tag) — reload the dashboard and retry."
+        return 0
+    fi
+    if ! semver_newer "$tag" "v$PITHEAD_VERSION"; then
+        _upg_reject "already up to date (running v$PITHEAD_VERSION; latest release is $tag)."
+        return 0
+    fi
+    touch "$stamp"
+    control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"running",version:$v,ts:(now|floor)}')"
+    control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "started"
+    # Bundle URL built from the HOST-derived tag only; fetched over the same Tor SOCKS.
+    local bundle="$cdir/staged/.$id.tar.gz" logf="$cdir/staged/.$id.log"
+    if ! curl -fsSL --max-time 900 --socks5-hostname "$socks" -o "$bundle" \
+        "https://github.com/p2pool-starter-stack/pithead/releases/download/$tag/pithead.tar.gz" 2>/dev/null; then
+        rm -f "$bundle"
+        _upg_fail "could not download the $tag release bundle over Tor — the stack keeps running v$PITHEAD_VERSION."
+        return 0
+    fi
+    # -U (unlink first): the archive contains THIS running script — replacing it via unlink keeps
+    # the running copy executing from its old inode, where an in-place truncate would corrupt it.
+    if ! tar -xzUf "$bundle" --strip-components=1 -C "$PWD" 2>"$logf"; then
+        rm -f "$bundle"
+        _upg_fail "the $tag release bundle failed to extract: $(tail -c 500 "$logf") — the stack keeps running v$PITHEAD_VERSION."
+        rm -f "$logf"
+        return 0
+    fi
+    rm -f "$bundle"
+    # The extraction replaced this script on disk (the running copy keeps executing from its old
+    # inode); run the NEW pithead's `upgrade`, which re-renders the generated config and pulls the
+    # $tag images — exactly what the manual bundle update does.
+    if "$PWD/pithead" upgrade >"$logf" 2>&1; then
+        control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"upgraded",version:$v,ts:(now|floor)}')"
+        control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "upgraded"
+    else
+        control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" \
+            '{status:"failed",version:$v,error:($e + " — finish the upgrade from the host with ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
+        control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
+    fi
+    rm -f "$logf"
+}
+
 # Validate + dispatch one CLAIMED request file. Trusts no byte of it: must be JSON, only the keys
-# id/action/config/actor, the id must be a UUID (it becomes the result/staged FILENAME — anything
-# else is rejected before it can touch a path), and the action one of the two known verbs.
+# id/action/config/actor/version, the id must be a UUID (it becomes the result/staged FILENAME —
+# anything else is rejected before it can touch a path), and the action one of the three known verbs.
 control_process_request() { # <claimed-file> <control-dir>
     local file="$1" cdir="$2" id action actor size
     # Refuse a symlinked / non-regular claimed file (graft #437): a symlink dropped in requests/
@@ -3855,7 +3966,7 @@ control_process_request() { # <claimed-file> <control-dir>
         warn "Control request has a malformed id — discarded (no result can be addressed)."
         return 0
     fi
-    if [ "$(jq -r '[keys[] | select(. != "id" and . != "action" and . != "config" and . != "actor")] | length' "$file")" != "0" ]; then
+    if [ "$(jq -r '[keys[] | select(. != "id" and . != "action" and . != "config" and . != "actor" and . != "version")] | length' "$file")" != "0" ]; then
         control_write_result "$cdir/results" "$id" "$(jq -n '{status:"rejected",error:"unexpected keys in request",ts:(now|floor)}')"
         control_audit "$cdir/audit/control.log" "$id" "" "invalid" "rejected"
         return 0
@@ -3868,6 +3979,7 @@ control_process_request() { # <claimed-file> <control-dir>
     case "$action" in
     preview) control_preview "$file" "$id" "$actor" "$cdir" ;;
     commit) control_commit "$id" "$actor" "$cdir" ;;
+    upgrade) control_upgrade "$file" "$id" "$actor" "$cdir" ;;
     *)
         control_write_result "$cdir/results" "$id" "$(jq -n '{status:"rejected",error:"unknown action",ts:(now|floor)}')"
         control_audit "$cdir/audit/control.log" "$id" "$actor" "${action:-none}" "rejected"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -268,6 +268,18 @@ assert_rc "rejects hostname" "$?" "1"
 run_sourced "$SANDBOX" is_ipv4 "" >/dev/null 2>&1
 assert_rc "rejects empty" "$?" "1"
 
+echo "== unit: semver_newer (#59 — the upgrade downgrade guard) =="
+# The comparison gates the upgrade button: a lexical bug would let 1.9.0 look "newer" than 1.10.0
+# and could be leveraged to force an older, vulnerable release.
+run_sourced "$SANDBOX" semver_newer "v1.10.0" "v1.9.0" >/dev/null 2>&1
+assert_rc "1.10.0 is newer than 1.9.0 (no lexical bug)" "$?" "0"
+run_sourced "$SANDBOX" semver_newer "v1.9.0" "v1.10.0" >/dev/null 2>&1
+assert_rc "1.9.0 is NOT newer than 1.10.0" "$?" "1"
+run_sourced "$SANDBOX" semver_newer "v1.3.1" "v1.3.1" >/dev/null 2>&1
+assert_rc "equal versions are not newer" "$?" "1"
+run_sourced "$SANDBOX" semver_newer "v2.0.0" "v1.99.99" >/dev/null 2>&1
+assert_rc "major bump beats a high minor/patch" "$?" "0"
+
 echo "== unit: resolve_dashboard_host (dashboard.host 'auto' revert, 247c5a0) =="
 # A configured dashboard.host is used verbatim.
 # shellcheck disable=SC1090,SC2034  # $STACK path is dynamic; DASHBOARD_HOST is read by the sourced function
@@ -3332,6 +3344,12 @@ assert_eq "container-proposed non-latest version is rejected" "$(jq -r '.status'
 assert_contains "forged-version rejection names the real latest" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "v9.9.9"
 assert_eq "forged version downloads no bundle" "$(grep -c 'releases/download' "$UPG/curl.log" || true)" "0"
 assert_eq "forged version leaves the install untouched" "$(cat "$UPG/VERSION")" "1.3.1"
+# ...and it still CLAIMED the throttle (stamp taken before the network dial), so a compromised
+# container can't flood well-formed-but-stale intents to grind the GitHub API / beacon over Tor:
+# a second attempt straight after — without reset — is throttled (#59 review, egress-beacon guard).
+upgrade_intent "$UUPG" "v1.9.9"
+urun >/dev/null
+assert_contains "a non-latest attempt still claims the throttle" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "less than 10 minutes"
 
 # Already up to date: latest equals the running version — refused, no download.
 reset_upgrade_state

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -3212,6 +3212,190 @@ out="$(run_pending)"
 assert_contains "next run drains the remainder" "$out" "Processed 10 control request(s)"
 assert_eq "spool empty after the second run" "$(ls "$REQS" | wc -l | tr -d ' ')" "0"
 
+echo "== black-box: control upgrade verb (#59) =="
+# A RELEASE install (no build/*/Dockerfile → is_source_checkout false) with the control channel
+# on. The runner's upgrade verb runs against a stub curl (GitHub release API + bundle download)
+# and a fake release bundle whose pithead records what it was asked to do — no network, no docker.
+UPG="$SANDBOX/upgrade59"
+UPGREQS="$UPG/data/control/requests"
+UPGRESULTS="$UPG/data/control/results"
+UPGAUDIT="$UPG/data/control/audit/control.log"
+mkdir -p "$UPGREQS" "$UPG/data/control/staged" "$UPGRESULTS" "$UPG/data/control/audit"
+cp "$STACK" "$UPG/pithead"
+make_stubs "$UPG/bin"
+printf '1.3.1' >"$UPG/VERSION"
+# The stub curl serves the canned API response for the release-API URL and copies the fake bundle
+# for the download URL; every call is logged so the tests can assert what was (not) dialled.
+cat >"$UPG/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "[curl] $*" >>"${CURL_LOG:-/dev/null}"
+[ "${CURL_FAIL:-}" = "1" ] && exit 22
+url="${*: -1}"
+out=""
+prev=""
+for a in "$@"; do
+    [ "$prev" = "-o" ] && out="$a"
+    prev="$a"
+done
+case "$url" in
+*api.github.com*) cat "${CURL_API_RESPONSE:?}" ;;
+*releases/download/*) cp "${CURL_BUNDLE:?}" "$out" ;;
+*) exit 22 ;;
+esac
+EOF
+chmod +x "$UPG/bin/curl"
+# The fake v9.9.9 release bundle: a pithead that logs its invocation (and can be told to fail).
+UPGB="$SANDBOX/upgrade59-bundle"
+mkdir -p "$UPGB/pithead-src"
+cat >"$UPGB/pithead-src/pithead" <<'EOF'
+#!/usr/bin/env bash
+echo "new-pithead $*" >>upgrade-invocations.log
+[ "${NEW_PITHEAD_FAIL:-}" = "1" ] && exit 1
+exit 0
+EOF
+chmod +x "$UPGB/pithead-src/pithead"
+printf '9.9.9' >"$UPGB/pithead-src/VERSION"
+tar -czf "$UPGB/bundle.tar.gz" -C "$UPGB" pithead-src
+printf '{"tag_name":"v9.9.9","html_url":"https://example.invalid/rel"}' >"$UPGB/api.json"
+seed_upgrade_env() { # <control-enabled true|false>
+    cat >"$UPG/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+DASHBOARD_CONTROL_ENABLED=$1
+CONTROL_DIR=$UPG/data/control
+NETWORK_PREFIX=10.9.0
+EOF
+}
+urun() {
+    (cd "$UPG" && PATH="$UPG/bin:$PATH" CURL_LOG="$UPG/curl.log" \
+        CURL_API_RESPONSE="$UPGB/api.json" CURL_BUNDLE="$UPGB/bundle.tar.gz" \
+        ./pithead control-run-pending 2>&1)
+}
+upgrade_intent() { # <id> [version] — drop an upgrade request into the spool
+    if [ "$#" -ge 2 ]; then
+        printf '{"id":"%s","action":"upgrade","actor":"admin","version":"%s"}\n' "$1" "$2" >"$UPGREQS/$1.json"
+    else
+        printf '{"id":"%s","action":"upgrade","actor":"admin"}\n' "$1" >"$UPGREQS/$1.json"
+    fi
+}
+UUPG="66666666-6666-4666-8666-666666666666"
+reset_upgrade_state() { # restore between attempts: fresh runner copy, running version, no throttle
+    cp "$STACK" "$UPG/pithead"
+    printf '1.3.1' >"$UPG/VERSION"
+    rm -f "$UPG/data/control/staged/.upgrade-stamp" "$UPGRESULTS/$UUPG.json" "$UPG/upgrade-invocations.log"
+    : >"$UPG/curl.log"
+}
+
+# Source checkout ($C): the upgrade verb is refused outright — its update path is `git pull`.
+printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$UUPG" >"$REQS/$UUPG.json"
+run_pending >/dev/null
+assert_eq "upgrade on a source checkout is rejected" "$(jq -r '.status' "$RESULTS/$UUPG.json" 2>/dev/null)" "rejected"
+assert_contains "source-checkout refusal points at git pull" "$(jq -r '.error' "$RESULTS/$UUPG.json" 2>/dev/null)" "git pull"
+rm -f "$RESULTS/$UUPG.json"
+
+# Channel off: the runner refuses to process ANYTHING — the intent stays unclaimed, no result.
+seed_upgrade_env false
+reset_upgrade_state
+upgrade_intent "$UUPG" "v9.9.9"
+out="$(urun)"
+assert_rc "upgrade runner refuses when the channel is off" "$?" "1"
+assert_contains "channel-off refusal names the flag" "$out" "not enabled"
+[ -f "$UPGREQS/$UUPG.json" ] && ok "channel-off intent left unclaimed" || bad "channel-off intent left unclaimed" "claimed"
+[ ! -f "$UPGRESULTS/$UUPG.json" ] && ok "channel-off intent gets no result" || bad "channel-off intent gets no result" "result written"
+rm -f "$UPGREQS/$UUPG.json"
+seed_upgrade_env true
+
+# Malformed / missing version: refused BEFORE any network dial (curl must never run).
+reset_upgrade_state
+upgrade_intent "$UUPG" 'v9.9.9;curl evil.tld'
+urun >/dev/null
+assert_eq "shell-metacharacter version is rejected" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "rejected"
+assert_contains "malformed-version rejection names the field" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "version"
+assert_eq "no network dial for a malformed version" "$(cat "$UPG/curl.log" 2>/dev/null)" ""
+reset_upgrade_state
+upgrade_intent "$UUPG"
+urun >/dev/null
+assert_eq "missing version is rejected" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "rejected"
+assert_eq "no network dial for a missing version" "$(cat "$UPG/curl.log" 2>/dev/null)" ""
+
+# A smuggled target field (the image-swap vector): the closed key set refuses the whole request.
+reset_upgrade_state
+printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9","target":"evil.tld/img:tag"}\n' "$UUPG" >"$UPGREQS/$UUPG.json"
+urun >/dev/null
+assert_contains "upgrade intent smuggling a target is rejected" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "unexpected keys"
+
+# Forged/stale version: the container proposes v1.9.9 but the host-derived latest is v9.9.9 —
+# refused, nothing downloaded, nothing extracted. The container cannot choose the target.
+reset_upgrade_state
+upgrade_intent "$UUPG" "v1.9.9"
+urun >/dev/null
+assert_eq "container-proposed non-latest version is rejected" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "rejected"
+assert_contains "forged-version rejection names the real latest" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "v9.9.9"
+assert_eq "forged version downloads no bundle" "$(grep -c 'releases/download' "$UPG/curl.log" || true)" "0"
+assert_eq "forged version leaves the install untouched" "$(cat "$UPG/VERSION")" "1.3.1"
+
+# Already up to date: latest equals the running version — refused, no download.
+reset_upgrade_state
+printf '{"tag_name":"v1.3.1","html_url":"https://example.invalid/rel"}' >"$UPGB/api-same.json"
+upgrade_intent "$UUPG" "v1.3.1"
+(cd "$UPG" && PATH="$UPG/bin:$PATH" CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api-same.json" \
+    CURL_BUNDLE="$UPGB/bundle.tar.gz" ./pithead control-run-pending >/dev/null 2>&1)
+assert_contains "same-version upgrade is rejected as up to date" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "already up to date"
+
+# Release API unreachable / unusable: refused, nothing changed (fail closed, silent stack).
+reset_upgrade_state
+upgrade_intent "$UUPG" "v9.9.9"
+(cd "$UPG" && PATH="$UPG/bin:$PATH" CURL_FAIL=1 CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api.json" \
+    CURL_BUNDLE="$UPGB/bundle.tar.gz" ./pithead control-run-pending >/dev/null 2>&1)
+assert_contains "unreachable release API rejects the upgrade" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "could not reach"
+reset_upgrade_state
+printf '{"tag_name":"main","html_url":"https://example.invalid/rel"}' >"$UPGB/api-bad.json"
+upgrade_intent "$UUPG" "v9.9.9"
+(cd "$UPG" && PATH="$UPG/bin:$PATH" CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api-bad.json" \
+    CURL_BUNDLE="$UPGB/bundle.tar.gz" ./pithead control-run-pending >/dev/null 2>&1)
+assert_contains "non-semver API tag rejects the upgrade" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "no usable release tag"
+
+# Bundle download failure AFTER the checks pass: the attempt fails, the stack keeps running.
+reset_upgrade_state
+upgrade_intent "$UUPG" "v9.9.9"
+(cd "$UPG" && PATH="$UPG/bin:$PATH" CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api.json" \
+    CURL_BUNDLE="$UPGB/missing.tar.gz" ./pithead control-run-pending >/dev/null 2>&1)
+assert_eq "failed bundle download reports failed" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "failed"
+assert_contains "download failure says the stack keeps running" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "keeps running"
+assert_eq "download failure extracts nothing" "$(cat "$UPG/VERSION")" "1.3.1"
+
+# `pithead upgrade` itself fails after extraction: status failed, error points at the host CLI.
+reset_upgrade_state
+upgrade_intent "$UUPG" "v9.9.9"
+(cd "$UPG" && PATH="$UPG/bin:$PATH" NEW_PITHEAD_FAIL=1 CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api.json" \
+    CURL_BUNDLE="$UPGB/bundle.tar.gz" ./pithead control-run-pending >/dev/null 2>&1)
+assert_eq "failed upgrade run reports failed" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "failed"
+assert_contains "failed upgrade points at the host CLI" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "./pithead upgrade"
+assert_contains "failed upgrade audited" "$(cat "$UPGAUDIT" 2>/dev/null)" "\"action\":\"upgrade\",\"status\":\"failed\""
+
+# Happy path: proposed == host-derived latest and newer than running → bundle extracted, the NEW
+# pithead's `upgrade` ran, both dials went through the stack's Tor SOCKS, everything audited.
+reset_upgrade_state
+: >"$UPGAUDIT"
+upgrade_intent "$UUPG" "v9.9.9"
+out="$(urun)"
+assert_rc "runner exits 0 on a valid upgrade" "$?" "0"
+assert_eq "upgrade result status" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "upgraded"
+assert_eq "upgrade result carries the host-derived version" "$(jq -r '.version' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "v9.9.9"
+assert_eq "bundle extracted over the install" "$(cat "$UPG/VERSION")" "9.9.9"
+assert_contains "the NEW pithead ran the upgrade" "$(cat "$UPG/upgrade-invocations.log" 2>/dev/null)" "new-pithead upgrade"
+assert_eq "both GitHub dials went over Tor SOCKS" "$(grep -c -- '--socks5-hostname 10.9.0.25:9050' "$UPG/curl.log")" "2"
+assert_contains "upgrade start audited" "$(cat "$UPGAUDIT")" "\"action\":\"upgrade\",\"status\":\"started\""
+assert_contains "upgrade completion audited" "$(cat "$UPGAUDIT")" "\"action\":\"upgrade\",\"status\":\"upgraded\""
+
+# Throttle: a second attempt straight after is refused for 10 minutes (egress-beacon guard).
+# The happy path replaced $U/pithead with the fake bundle's script — restore the real runner
+# (keeping the throttle stamp the successful attempt left behind).
+cp "$STACK" "$UPG/pithead"
+upgrade_intent "$UUPG" "v9.9.9"
+urun >/dev/null
+assert_contains "immediate second upgrade attempt is throttled" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "less than 10 minutes"
+reset_upgrade_state
+
 # The runner refuses to run at all when the channel is off (fail-closed).
 control_config main
 "$C/bin/docker" >/dev/null 2>&1 || true


### PR DESCRIPTION
Closes #59.

## What this is

The dashboard's new-version warning (#224/#58) gains its **act** half: with `dashboard.control.enabled` on, a release install shows an **Upgrade to vX.Y.Z** button next to the new-release badge. A typed `UPGRADE` confirm (same pattern as the Configuration view's `APPLY`) hands the job to the host, which performs the documented update — download the new release bundle, run `pithead upgrade` — with no SSH. Built directly on the #33 control channel (#439): same spool, same systemd runner, no new socket, no docker.sock, no second channel.

## Intent schema

One new typed intent through the existing `requests/` leg, same shape discipline as preview/commit:

```json
{ "id": "<uuid4>", "action": "upgrade", "actor": "<X-Auth-User>", "version": "vX.Y.Z" }
```

- Closed key set (`id/action/config/actor/version`) — anything else rejects the whole request (the smuggled-`target` test pins the image-swap vector shut).
- `version` is a **proposal**, shape-checked (`^v\d+\.\d+\.\d+$`) on both sides and used only in an equality comparison. It exists so the host can prove the operator confirmed the release that is actually latest (TOCTOU guard), not so the container can pick one.
- The endpoint (`POST /api/control/upgrade`, control-header CSRF guard, 404 when the channel is off) answers 202 immediately and the client polls `results/` — the upgrade recreates the dashboard container itself.

## How the host re-derives the target

1. The runner asks the GitHub release API (fixed URL, over the stack's own Tor SOCKS) for the latest release tag — never the request.
2. It refuses unless the proposed version **equals** that tag, the tag is a strict `vX.Y.Z`, and it is strictly newer than the running `VERSION`.
3. The bundle URL is built from the **host-derived** tag only; after extraction (`tar -U`, so the running script survives on its old inode) it runs the new release's `pithead upgrade`.

Additional refusals, all audited: source checkout (its update is `git pull`), channel off (the runner's existing gate refuses everything), malformed/missing version (before any network dial), unreachable/unusable release API, and more than one attempt per 10 minutes (a compromised container cannot use the root runner as an egress beacon).

**Failure semantics, stated honestly in the docs:** a failed release lookup or bundle download changes nothing; a failure inside `pithead upgrade` leaves containers that were not yet recreated on the previous images (previous images stay on disk), and recovery is one `./pithead upgrade` on the host. No automatic rollback is added.

## Red-then-green

Both required guards were shown to fail before passing:
- Forged-version guard removed → `container-proposed non-latest version is rejected`, `forged version downloads no bundle`, `forged version leaves the install untouched` all fail.
- Channel-off gate removed → `upgrade runner refuses when the channel is off`, `channel-off intent left unclaimed`, `runner refuses when the channel is disabled` all fail.

## Gate results

- `make lint` ✓ (shellcheck/shfmt -i 4, ruff, biome, yaml/md/docs-voice/proto/toml)
- `make test` ✓ — 775 shell + 1054 pytest; `node --test` 102 ✓
- Dashboard coverage 96% total; **patch coverage 100%** (gate ≥90%)
- Tier 2: 34 new black-box spool assertions (happy path incl. Tor SOCKS on both dials + audit trail, and the refusal matrix above) against a stub curl + fake release bundle
- Tier 1: endpoint shape/refusal tests (403 without the control header, 400 on malformed versions with an empty spool, 404 when off, sanitized 500), intent-shape unit test, client-flow node tests (post → skip `running` → ride out the restart fetch failure → outcome; typed-confirm arming; render gating on `update × control_enabled`)

## Tier-4 gouda items (flagged, not simulatable here)

- Live end-to-end: badge → button → confirm → real bundle download over Tor → `pithead upgrade` recreating the whole stack, including the dashboard container the request came from, with the page riding out the real 502 window and reporting the result after restart.
- systemd path-unit behavior while the oneshot is mid-upgrade (event coalescing), and the runner surviving its own script replacement on ext4 (validated here on APFS via `tar -U` inode semantics).
- Real GitHub API/tag interaction on the next actual release (the #54 release gate means only validated releases are ever offered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)