### PR TITLE
feat(dashboard): one-time Simple-view hint pointing at the Advanced calculators (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- **Simple view points at the Advanced-only calculators (#425).** The P2Pool Earnings card — the
+  XMR/XTM estimates and the XvB tier calculator — renders only in Advanced view, and operators on
+  the default Simple view concluded it didn't exist. Simple view now shows a one-time dismissible
+  banner linking to Advanced view; dismissing it (or opening Advanced view) retires it for good
+  in that browser.
 - **Subcommand chaining + bash/zsh tab-completion (#94).** `./pithead apply upgrade` runs both
   commands in order, failing fast on the first non-zero step and reporting what did and didn't
   run. The whole chain is validated first: non-chainable commands (`setup`, `logs`, `restore`,

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -711,6 +711,23 @@ function ComponentHealth({ topology, egress }) {
     </div>`;
 }
 
+// One-time discoverability hint (#425). The earnings + XvB tier calculators are Advanced-view
+// cards, so an operator on the default Simple view never sees them and concludes they don't
+// exist. This banner points at Advanced view until the operator acts on it: the inline button
+// switches views (dashboard.js retires the hint on any visit to Advanced), and the × dismisses
+// it outright. `ui.hintDismissed` is persisted in localStorage by dashboard.js like the other
+// UI state, so the hint shows once per browser, not once per reload.
+function AdvancedHint({ ui, onView, onDismissHint }) {
+  if (ui.view !== "simple" || ui.hintDismissed) return null;
+  return html`
+    <div class="advanced-hint" id="advanced-hint">
+        <span>Looking for earnings estimates or the XvB tier calculator? They live in${" "}
+            <button type="button" class="btn-link" onClick=${() => onView("advanced")}>Advanced view</button>.</span>
+        <button type="button" class="advanced-hint-dismiss" aria-label="Dismiss hint"
+                title="Dismiss" onClick=${onDismissHint}>×</button>
+    </div>`;
+}
+
 function DashboardView({
   state,
   ui,
@@ -721,6 +738,7 @@ function DashboardView({
   onResetZoom,
   onToggleSeries,
   onAvgWindow,
+  onDismissHint,
 }) {
   const advanced = ui.view === "advanced";
   const configView = ui.view === "config";
@@ -736,6 +754,7 @@ function DashboardView({
                 <button class=${"btn-toggle" + (configView ? " active" : "")} onClick=${() => onView("config")}>Configuration</button>
             </div>
         </div>
+        <${AdvancedHint} ui=${ui} onView=${onView} onDismissHint=${onDismissHint} />
         ${configView ? html`<${ConfigView} /><${SecurityPanel} />` : null}
         ${
           configView
@@ -779,6 +798,7 @@ export function App({
   onResetZoom,
   onToggleSeries,
   onAvgWindow,
+  onDismissHint,
 }) {
   // The theme toggle is fixed-position and always available, even before the first data load.
   const switcher = html`<${ThemeSwitcher} theme=${ui.theme} onTheme=${onTheme} />`;
@@ -798,7 +818,8 @@ export function App({
                 <${HeroBand} state=${state} />
                 <${DashboardView} state=${state} ui=${ui} onRange=${onRange} onSort=${onSort}
                                   onView=${onView} onZoom=${onZoom} onResetZoom=${onResetZoom}
-                                  onToggleSeries=${onToggleSeries} onAvgWindow=${onAvgWindow} />
+                                  onToggleSeries=${onToggleSeries} onAvgWindow=${onAvgWindow}
+                                  onDismissHint=${onDismissHint} />
               <//>`
         }
         ${switcher}

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -763,6 +763,42 @@ button.upgrade-btn {
   padding: 60px 20px;
   font-size: 1.1rem;
 }
+/* One-time Simple-view pointer to the Advanced-only calculators (#425). */
+.advanced-hint {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-bottom: 15px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+.advanced-hint .btn-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.advanced-hint-dismiss {
+  background: none;
+  border: none;
+  padding: 0 4px;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.advanced-hint-dismiss:hover {
+  color: var(--text);
+}
+
 .disconnected-banner {
   background: var(--bad);
   color: #fff;

--- a/build/dashboard/mining_dashboard/web/static/dashboard.js
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.js
@@ -53,6 +53,9 @@ const ui = {
   // theme-init.js already applied it to <html> before first paint; we mirror it into the UI
   // state and re-apply on toggle.
   theme: normalizeTheme(localStorage.getItem("dashboardTheme")),
+  // Simple-view pointer to the Advanced-only earnings/XvB calculators (#425). Persisted once
+  // dismissed — either explicitly or by visiting Advanced view — so it shows once per browser.
+  hintDismissed: localStorage.getItem("dashboardCalcHint") === "dismissed",
 };
 
 // Reflect the current theme onto <html data-theme>; the CSS palette (and the chart, which reads
@@ -70,7 +73,7 @@ function rerender() {
     html`<${App} state=${state} connected=${connected} ui=${ui}
                      onRange=${setRange} onSort=${onSort} onView=${setView} onTheme=${setTheme}
                      onZoom=${setZoom} onResetZoom=${resetZoom} onToggleSeries=${toggleSeries}
-                     onAvgWindow=${setAvgWindow} />`,
+                     onAvgWindow=${setAvgWindow} onDismissHint=${dismissHint} />`,
     root,
   );
 }
@@ -132,6 +135,18 @@ function onSort(idx) {
 function setView(mode) {
   ui.view = mode;
   localStorage.setItem("dashboardView", mode);
+  // Visiting Advanced retires the calculators hint (#425) — its discoverability job is done.
+  if (mode === "advanced" && !ui.hintDismissed) {
+    ui.hintDismissed = true;
+    localStorage.setItem("dashboardCalcHint", "dismissed");
+  }
+  rerender();
+}
+
+// Dismiss the Simple-view calculators hint (#425) without leaving Simple view.
+function dismissHint() {
+  ui.hintDismissed = true;
+  localStorage.setItem("dashboardCalcHint", "dismissed");
   rerender();
 }
 

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -27,6 +27,7 @@ const noop = () => {};
 const HANDLERS = {
     onRange: noop, onSort: noop, onView: noop, onTheme: noop,
     onZoom: noop, onResetZoom: noop, onToggleSeries: noop, onAvgWindow: noop,
+    onDismissHint: noop,
 };
 
 function renderApp({ state = BASE, connected = true, ui = UI } = {}) {
@@ -87,6 +88,22 @@ test('operational App renders the remaining advanced cards', () => {
     assert.match(html, /XMR Network/);
     assert.match(html, /Tari Merge-Mining/);
     assert.match(html, /P2Pool Earnings \(estimated\)/);
+});
+
+test('Simple view shows the calculators hint until dismissed, never elsewhere (#425)', () => {
+    // Fresh browser on the default Simple view: the pointer to the Advanced-only calculators shows.
+    const simple = renderApp({ ui: { ...UI, view: 'simple', hintDismissed: false } });
+    assert.match(simple, /advanced-hint/);
+    assert.match(simple, /earnings estimates or the XvB tier calculator/);
+    assert.match(simple, /Advanced view/);
+    // Dismissed (dashboard.js persists it): gone from Simple view.
+    const dismissed = renderApp({ ui: { ...UI, view: 'simple', hintDismissed: true } });
+    assert.doesNotMatch(dismissed, /advanced-hint/);
+    // Never shown outside Simple view — Advanced already has the calculators on screen.
+    const advanced = renderApp({ ui: { ...UI, view: 'advanced', hintDismissed: false } });
+    assert.doesNotMatch(advanced, /advanced-hint/);
+    const config = renderApp({ ui: { ...UI, view: 'config', hintDismissed: false } });
+    assert.doesNotMatch(config, /advanced-hint/);
 });
 
 test('EarningsCard shows the fallback when stats are down, the calculator when available', () => {

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -229,6 +229,10 @@ same data in more detail: **My P2Pool Node Stats**, **Global P2Pool Stats**, **X
 **XMR Network**, **Tari Merge-Mining**, and the **P2Pool Earnings (estimated)** calculator below. The
 choice is remembered across reloads.
 
+The earnings estimates and the XvB tier calculator live only in Advanced view. Simple view shows a
+one-time banner pointing there; it goes away once you dismiss it or open Advanced view, and stays
+away across reloads.
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../images/launch/advanced.png">
   <img alt="Dashboard — Advanced view" src="../images/launch/advanced-light.png">


### PR DESCRIPTION
Closes #425.

## What

The P2Pool Earnings card — the XMR estimate, the Tari XTM rows (#117), and the XvB tier/cost block (#118) — is a `card-advanced`, so an operator on the default Simple view never sees it and reasonably concludes the calculators don't exist. This surfaced live on v1.3.0.

This implements the issue's first (and lowest-effort) option: a one-time, dismissible hint in Simple view.

- `AdvancedHint` (components.mjs): a slim banner under the view toggle, Simple view only — "Looking for earnings estimates or the XvB tier calculator? They live in **Advanced view**." The inline button switches views; the × dismisses in place.
- Persistence (dashboard.js): `ui.hintDismissed`, backed by `localStorage` (`dashboardCalcHint`) like the other persisted UI state. Visiting Advanced view at all also retires the hint — once the operator has found the toggle, its job is done. Shows once per browser, not once per reload.
- No new pre-auth data exposure: the banner is static copy, no server data, no injected HTML.

Deliberately NOT the compact Simple-view earnings summary from the issue's second option — the hint solves the discoverability gap without duplicating the calculator surface. If a Simple-view lite summary is still wanted, that's a follow-on.

## Tests

- `components.test.mjs`: hint renders in Simple view, absent once dismissed, never rendered in Advanced or Configuration view. Verified red-then-green: inverting the visibility condition fails the test.
- `make lint` and `make test` green (111 frontend node --test cases; full suite passes). `make test-patch-coverage`: no Python lines in the diff.

## Docs

- `docs/dashboard.md` (Simple vs. Advanced view): names where the calculators live and how the hint behaves.
- `CHANGELOG.md` under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)