### PR TITLE
Move config-prefill masking host-side so the dashboard never mounts config.json (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,18 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Security
 
+- **The dashboard container never sees a plaintext secret (#440).** The one accepted residual
+  from the #33 control-channel reviews is closed: the dashboard no longer bind-mounts the raw
+  `config.json` to prefill its Configuration form. The host now renders a pre-masked copy —
+  every set secret (node RPC credentials, stratum and dashboard passwords, the Telegram bot
+  token, the Healthchecks ping URL) already replaced by a sentinel — into a read-only leg of the
+  control spool (`data/control/masked/`), and the form serves from that. The
+  "leave blank to keep the current value" merge moved host-side too: an untouched secret rides
+  back as the sentinel and the runner swaps in the live value at staging, so the request spool
+  is also secret-free. A fully compromised dashboard container can now read masked config,
+  results, and the audit log, and ask to change an allowlisted key — nothing else. The copy is
+  re-rendered on every `setup`/`apply`/`upgrade` and runner pass, so it never serves stale state
+  for long. See [SECURITY.md](SECURITY.md#secret-trust-boundary-for-dashboard-config-editing).
 - **Signed releases, verified before upgrade (#376).** The release pipeline now cosign-signs the
   five promoted image digests and the install bundle with a key that lives only on the release
   box; the public key is committed as `cosign.pub` and ships in every bundle. On a release

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -88,13 +88,16 @@ The stack's defaults:
 
 ### Secret trust boundary for dashboard config editing
 
-When `dashboard.control` is on, the dashboard reads `config.json` through a **read-only bind
-mount** to prefill the editor form. The API masks every secret leaf before serving it to the
-browser — but that masking protects the *browser*, not the container. The bind mount itself is the
-real secret boundary: a backend compromise of the dashboard container can read the plaintext
-`config.json` (including the dashboard login and stratum passwords) directly off the mount,
-regardless of the API masking. Treat the dashboard container as semi-trusted, keep the onion behind
-Tor client authorization, and do not co-host untrusted workloads in that container. Host-side
-staged copies that carry merged secrets are written mode 600.
+The dashboard container never mounts the raw `config.json` (#440). When `dashboard.control` is
+on, the host renders a **pre-masked copy** of the config into the control spool — every set
+secret leaf (node credentials, the stratum and dashboard passwords, the Telegram token, the
+Healthchecks ping URL) already replaced by a sentinel — and the editor form prefills from that
+copy, mounted read-only. An untouched secret rides back to the host as the same sentinel, and the
+host swaps it for the live value when it stages the intent, so the container never holds a secret
+the operator didn't just type into the form. A full backend compromise of the dashboard container
+can therefore read masked config, results, and the audit log, and *ask* to change an allowlisted
+key — nothing else. Host-side staged copies, which do carry the merged secrets, live outside
+every mount and are written mode 600. Still treat the container as semi-trusted and keep the
+onion behind Tor client authorization: the request spool remains a mutation-request surface.
 
 Report any gap in these.

--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -161,8 +161,10 @@ CONTROL_RESULTS_DIR = os.environ.get("CONTROL_RESULTS_DIR", "/control/results")
 # written and rotated host-side, and every field read from them is sanitized before serving.
 CONTROL_AUDIT_LOG = os.environ.get("CONTROL_AUDIT_LOG", "/control/audit/control.log")
 ACCESS_LOG_PATH = os.environ.get("ACCESS_LOG_PATH", "/access-log/access.log")
-# The live config.json, bind-mounted read-only for form prefill; secrets are masked before serving.
-HOST_CONFIG_PATH = os.environ.get("HOST_CONFIG_PATH", "/host-config/config.json")
+# The PRE-MASKED config copy, bind-mounted read-only for form prefill (#440): the host renders it
+# with every set secret leaf already replaced by the sentinel, so the container never holds a raw
+# secret. The raw config.json is not mounted into the container at all.
+HOST_CONFIG_PATH = os.environ.get("HOST_CONFIG_PATH", "/control/masked/config.json")
 # config.reference.json (every key with its default), bind-mounted read-only. read_config merges it
 # UNDER the operator's sparse config.json so the editor form covers the full schema, not just the
 # keys the operator happens to have set (#33 "edit every setting"). A missing reference degrades to

--- a/build/dashboard/mining_dashboard/service/control_service.py
+++ b/build/dashboard/mining_dashboard/service/control_service.py
@@ -1,13 +1,14 @@
 """Dashboard side of the host-mutation control channel (#33).
 
-The container can only ASK. This module reads the bind-mounted live config (masking every secret
-leaf), writes typed JSON intents into the requests/ spool — the container's single writable leg —
-and reads results back from the read-only results/ mount. The host-side runner
-(``pithead control-run-pending``) re-validates and executes; nothing here runs a command.
+The container can only ASK. This module reads the host-rendered PRE-MASKED config copy (#440) to
+prefill the editor form, writes typed JSON intents into the requests/ spool — the container's
+single writable leg — and reads results back from the read-only results/ mount. The host-side
+runner (``pithead control-run-pending``) re-validates and executes; nothing here runs a command.
 
-Secrets round-trip masked: ``read_config`` replaces each non-empty secret value with the
-``{"__secret__": true}`` sentinel, and ``merge_secrets`` swaps a sentinel coming back in a
-proposed config for the current live value ("unchanged"). The raw secret is never served.
+Secrets never enter the container: the host masks every set secret to the ``{"__secret__": true}``
+sentinel before the copy is mounted (the raw config.json is not mounted at all), a proposal
+carries the sentinel back for an untouched secret, and the host swaps it for the live value when
+it stages the intent. ``read_config`` re-applies the same masking as defense-in-depth.
 """
 
 import asyncio
@@ -21,7 +22,8 @@ from mining_dashboard.config import config
 
 logger = logging.getLogger("ControlService")
 
-# Config paths whose leaves are secrets. Mirrors what pithead's describe_change refuses to echo.
+# Config paths whose leaves are secrets. Mirrors pithead's CONTROL_SECRET_PATHS (the host-side
+# masking source, #440) — keep the two lists in step.
 SECRET_PATHS = [
     ("dashboard", "auth", "password"),
     ("telegram", "bot_token"),
@@ -38,7 +40,8 @@ SECRET_SENTINEL = {"__secret__": True}
 _RESULT_POLL_S = 0.5
 
 
-def _load_raw():
+def _load_host_config():
+    """The host-rendered, pre-masked config copy (#440) — no raw secret ever crosses the mount."""
     with open(config.HOST_CONFIG_PATH) as f:
         return json.load(f)
 
@@ -62,10 +65,6 @@ def _set(cfg, path, value):
     node[path[-1]] = value
 
 
-def is_secret_sentinel(value):
-    return isinstance(value, dict) and value.get("__secret__") is True
-
-
 def _deep_merge(base, override):
     """Recursively lay ``override`` over ``base`` (dicts merge; any other value replaces)."""
     merged = dict(base)
@@ -80,11 +79,12 @@ def _deep_merge(base, override):
 def read_config():
     """The full config schema for the editor's form, every set secret masked to the sentinel.
 
-    ``config.reference.json`` (every key with its default) is merged UNDER the operator's sparse
-    ``config.json`` so the form covers the whole schema — a missing/unreadable reference degrades to
-    the host config alone (graft #437). An *empty* secret stays empty, so the UI can tell
-    "set — leave blank to keep" from "not set"; masking runs AFTER the merge."""
-    cfg = _load_raw()
+    ``config.reference.json`` (every key with its default) is merged UNDER the host's sparse,
+    pre-masked copy so the form covers the whole schema — a missing/unreadable reference degrades
+    to the host copy alone (graft #437). An *empty* secret stays empty, so the UI can tell
+    "set — leave blank to keep" from "not set". The copy arrives already masked (#440); the
+    masking pass here is defense-in-depth and runs AFTER the merge."""
+    cfg = _load_host_config()
     try:
         with open(config.HOST_REFERENCE_PATH) as f:
             reference = json.load(f)
@@ -97,19 +97,6 @@ def read_config():
         if found and value:
             _set(cfg, path, dict(SECRET_SENTINEL))
     return cfg
-
-
-def merge_secrets(proposed):
-    """Re-insert live secret values wherever the proposed config carries the sentinel
-    (= "unchanged"). Mutates and returns ``proposed``. A sentinel for a secret that is not
-    actually set collapses to empty rather than leaking a dict into config.json."""
-    raw = _load_raw()
-    for path in SECRET_PATHS:
-        found, value = _get(proposed, path)
-        if found and is_secret_sentinel(value):
-            raw_found, raw_value = _get(raw, path)
-            _set(proposed, path, raw_value if raw_found else "")
-    return proposed
 
 
 def submit(action, cfg=None, actor="", intent_id=None, version=None):

--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -121,8 +121,10 @@ async def handle_control_preview(request):
         raise web.HTTPBadRequest(text="'config' must be a JSON object.")
     actor = request.headers.get("X-Auth-User", "")
     try:
-        merged = control_service.merge_secrets(proposed)
-        rid = control_service.submit("preview", merged, actor)
+        # The proposal ships as-is: an untouched secret rides as the {"__secret__": true}
+        # sentinel, and the HOST swaps it for the live value when it stages the intent (#440) —
+        # this container never holds a secret the operator didn't just type.
+        rid = control_service.submit("preview", proposed, actor)
         res = await control_service.wait_result(rid)
     except Exception:
         logger.exception("Error submitting control preview")

--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -1,5 +1,7 @@
-"""Unit tests for the dashboard side of the control channel (#33): secret masking round-trip,
-atomic request submission, result reads, and the UUID gate on ids that become host filenames."""
+"""Unit tests for the dashboard side of the control channel (#33): defense-in-depth secret
+masking, atomic request submission, result reads, and the UUID gate on ids that become host
+filenames. The host serves a PRE-MASKED config copy (#440); read_config's own masking pass is
+the second layer, so these tests feed it raw values on purpose."""
 
 import json
 import os
@@ -70,27 +72,17 @@ class TestSecretMasking:
         assert cfg["monero"]["prune"] is True
         assert cfg["p2pool"]["pool"] == "mini"
 
-    def test_merge_secrets_round_trip(self, spool):
-        # Sentinel in → live value out; an actually-edited secret passes through.
-        proposed = control_service.read_config()
-        proposed["p2pool"]["pool"] = "main"
-        proposed["telegram"]["bot_token"] = "456:new"  # explicit new value
-        merged = control_service.merge_secrets(proposed)
-        assert merged["dashboard"]["auth"]["password"] == "correct horse"
-        assert merged["monero"]["node_password"] == "hunter2"
-        assert merged["telegram"]["bot_token"] == "456:new"
-        assert merged["p2pool"]["pool"] == "main"
-
-    def test_merge_sentinel_for_unset_secret_collapses_to_empty(self, spool):
-        # A forged sentinel where no secret exists must not leak a dict into config.json.
-        proposed = {"workers": {"api_token": {"__secret__": True}}}
-        assert control_service.merge_secrets(proposed)["workers"]["api_token"] == ""
-
-    def test_merge_missing_sections_tolerated(self, spool):
-        # A proposed config that omits whole sections merges without KeyErrors.
-        assert control_service.merge_secrets({"p2pool": {"pool": "nano"}}) == {
-            "p2pool": {"pool": "nano"}
-        }
+    def test_pre_masked_host_copy_served_as_is(self, spool):
+        # The production shape (#440): the host copy already carries sentinels; read_config
+        # serves them unchanged (its own masking pass is an idempotent second layer).
+        pre_masked = json.loads(json.dumps(CONFIG))
+        pre_masked["monero"]["node_password"] = {"__secret__": True}
+        pre_masked["dashboard"]["auth"]["password"] = {"__secret__": True}
+        (spool / "config.json").write_text(json.dumps(pre_masked))
+        cfg = control_service.read_config()
+        assert cfg["monero"]["node_password"] == {"__secret__": True}
+        assert cfg["dashboard"]["auth"]["password"] == {"__secret__": True}
+        assert cfg["p2pool"]["pool"] == "mini"
 
 
 class TestSubmit:

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -260,10 +260,13 @@ class TestControlRoutesEnabled:
         body = await resp.json()
         assert body["id"] == rid
         assert body["status"] == "previewed"
-        # The spooled request carries the merged config: the sentinel became the live secret.
+        # The spooled request keeps the sentinel (#440): the container never merges live secrets
+        # back in — the HOST swaps sentinels for live values when it stages the intent, so the
+        # container-readable requests/ spool stays secret-free.
         req = json.loads((control_spool / "requests" / f"{rid}.json").read_text())
         assert req["action"] == "preview"
-        assert req["config"]["dashboard"]["auth"]["password"] == "correct horse"
+        assert req["config"]["dashboard"]["auth"]["password"] == {"__secret__": True}
+        assert "correct horse" not in json.dumps(req)
 
     async def test_preview_actor_taken_from_caddy_header(self, control_client, control_spool):
         resp = await control_client.post(
@@ -368,9 +371,9 @@ class TestControlRoutesEnabled:
         assert (await control_client.get("/api/control/result?id=..%2Fx")).status == 400
 
     async def test_preview_spool_failure_is_sanitized(self, control_client, monkeypatch):
-        # A broken spool (here: the host config can't be read for the secret merge) must come
-        # back as a sanitized 500, never a traceback.
-        monkeypatch.setattr(control_service.config, "HOST_CONFIG_PATH", "/nonexistent/config.json")
+        # A broken spool (unwritable requests dir) must come back as a sanitized 500, never a
+        # traceback.
+        monkeypatch.setattr(control_service.config, "CONTROL_REQUESTS_DIR", "/nonexistent/requests")
         resp = await control_client.post(
             "/api/control/preview", json={"config": {"p2pool": {}}}, headers=CONTROL_HEADERS
         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -410,15 +410,15 @@ services:
       - ${CONTROL_DIR:-./data/control}/requests:/control/requests
       - ${CONTROL_DIR:-./data/control}/results:/control/results:ro
       - ${CONTROL_DIR:-./data/control}/audit:/control/audit:ro
+      # Pre-masked config copy (#440), read-only: the host renders config.json with every set
+      # secret leaf replaced by a sentinel, and the Configuration view prefills from THIS file.
+      # The raw config.json is never mounted — a fully compromised container reads masked config,
+      # results, and the audit log, nothing else (see SECURITY.md).
+      - ${CONTROL_DIR:-./data/control}/masked:/control/masked:ro
       # Caddy's JSON access log (#349), read-only: the dashboard tails it to show recent accesses
       # and a failed-login count (a burst of 401s = rotate the password / onion). Caddy owns the
       # write side and the rotation; every field read from here is treated as hostile input.
       - ${CADDY_LOG_DIR:-./data/caddy-logs}:/access-log:ro
-      # The live config, read-only, prefills the Configuration view (#33). Secret leaves are masked
-      # server-side (control_service.read_config); the raw values never leave the API. NOTE: this
-      # bind-mount — not the API masking — is the real secret trust boundary; a backend compromise
-      # reads config.json plaintext here (see SECURITY.md).
-      - ./config.json:/host-config/config.json:ro
       # config.reference.json (every key with its default), read-only, so the editor form covers the
       # full schema even for keys the operator's sparse config.json omits (#33). No secrets.
       - ./config.reference.json:/host-config/config.reference.json:ro

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -347,9 +347,12 @@ button then appears next to the Simple/Advanced toggle.
 
 The flow mirrors the CLI's `apply`:
 
-1. The form is prefilled from the live `config.json`, grouped by section. Secrets (the dashboard
-   password, the Telegram bot token, node RPC credentials, the stratum password) show as
-   "set — leave blank to keep"; their values are never sent to the browser.
+1. The form is prefilled from a pre-masked copy of `config.json` the host renders into the
+   control spool ([#440](https://github.com/p2pool-starter-stack/pithead/issues/440)), grouped by
+   section. Secrets (the dashboard password, the Telegram bot token, node RPC credentials, the
+   stratum password) show as "set — leave blank to keep"; their values never enter the dashboard
+   container, let alone the browser — leaving one untouched sends a sentinel back, and the host
+   swaps in the live value when it stages the change.
 2. **Save & preview changes** stages the edited config on the host, which dry-runs it and returns
    the same change preview `./pithead apply` prints — one row per changed setting, disruptive rows
    (⚠) styled as warnings. A config that fails validation is rejected here with pithead's own

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -140,7 +140,11 @@ The runner dispatches exactly three actions: `apply --dry-run --porcelain` (prev
 target from the GitHub release API itself and refuses any other version.
 
 The spool lives under `./data/control/`: `requests/` (the only directory the dashboard container
-can write), `staged/` (host-only), and `results/` + `audit/` (container read-only).
+can write), `staged/` (host-only), and `results/` + `audit/` + `masked/` (container read-only).
+`masked/config.json` is a host-rendered copy of the config with every set secret replaced by a
+sentinel ([#440](https://github.com/p2pool-starter-stack/pithead/issues/440)); the Configuration
+form prefills from it, and the raw `config.json` is never mounted into the container. It is
+re-rendered on every `setup`/`apply`/`upgrade` and on every runner pass.
 `audit/control.log` records one JSON line per handled request — timestamp, the logged-in dashboard
 user, action, outcome, and the names of the changed settings (never their values) — and the
 container cannot rewrite it. The writer trims the log to its newest 2000 entries once it passes

--- a/pithead
+++ b/pithead
@@ -2457,14 +2457,55 @@ prepare_directories() {
     prepare_control_dirs
 }
 
+# Secret leaves in config.json, as jq path arrays. The single host-side source for BOTH control-
+# channel maskings (#440): the pre-masked prefill copy (render_masked_config) and the sentinel
+# swap at staging (control_preview). Mirrors the dashboard's control_service.SECRET_PATHS — keep
+# the two lists in step.
+readonly CONTROL_SECRET_PATHS='[
+    ["dashboard","auth","password"],
+    ["telegram","bot_token"],
+    ["workers","api_token"],
+    ["monero","node_username"],
+    ["monero","node_password"],
+    ["p2pool","stratum_password"],
+    ["healthchecks","ping_url"]]'
+
+# Render the pre-masked prefill copy (#440): the live config with every SET secret leaf replaced
+# by the {"__secret__":true} sentinel, written atomically to <control-dir>/masked/config.json.
+# The dashboard serves the Configuration form from THIS file (mounted read-only) — the raw
+# config.json is never mounted into the container, so a full container compromise reads masked
+# config, results, and the audit log, nothing more. An EMPTY secret stays empty, so the UI can
+# tell "set — leave blank to keep" from "not set". World-readable on purpose (it holds no secret
+# values; the container reads it as $APP_UID); best-effort, so a render hiccup degrades to a
+# stale prefill, never a failed apply.
+render_masked_config() { # <control-dir>
+    local mdir="$1/masked" tmp
+    mkdir -p "$mdir" 2>/dev/null || true
+    tmp="$mdir/.config.json.tmp"
+    if jq --argjson paths "$CONTROL_SECRET_PATHS" '
+        reduce $paths[] as $p (.;
+            if ((try getpath($p) catch null) // "") == "" then .
+            else setpath($p; {"__secret__": true}) end)' "$CONFIG_FILE" >"$tmp" 2>/dev/null; then
+        chmod 644 "$tmp" 2>/dev/null || true
+        mv "$tmp" "$mdir/config.json" 2>/dev/null ||
+            warn "Could not write $mdir/config.json — the dashboard editor prefill may be stale."
+    else
+        rm -f "$tmp"
+        warn "Could not render the masked config copy — the dashboard editor prefill may be stale."
+    fi
+}
+
 # Control-channel spool layout (#33). requests/ is the ONLY leg the dashboard container may write
-# (chowned to its uid); staged/, results/ and audit/ stay host-owned — the container mounts
-# results/ and audit/ read-only and never sees staged/ at all. That rw/ro split IS the trust
-# boundary: the container can only ask; it cannot forge a result, rewrite the audit log, or alter
-# a staged intent between preview and commit.
+# (chowned to its uid); staged/ stays host-only — the container mounts results/, audit/ and the
+# pre-masked masked/ copy (#440) read-only and never sees staged/ at all. That rw/ro split is the
+# trust boundary: the container can only ask; it cannot forge a result, rewrite the audit log,
+# alter a staged intent between preview and commit, or read a secret out of the live config.
 prepare_control_dirs() {
     mkdir -p "$CONTROL_DIR/requests" "$CONTROL_DIR/staged" "$CONTROL_DIR/results" "$CONTROL_DIR/audit"
     ensure_owner "$CONTROL_DIR/requests" "$APP_UID" "$APP_GID"
+    # Re-render the masked prefill copy on every setup/apply/upgrade (#440) — any path that can
+    # change config.json runs through here, so the copy can never serve a stale schema for long.
+    render_masked_config "$CONTROL_DIR"
     # Caddy access-log dir (#349): root-owned so the capability-stripped caddy container (uid 0,
     # no CAP_DAC_OVERRIDE) can write it; the dashboard (uid 1000) reads it via a ro mount — the
     # Caddyfile's `mode 0644` keeps the files readable.
@@ -4053,7 +4094,9 @@ run_chain() {
 # (its single writable spool mount). This host-side runner claims each request, validates it, and
 # dispatches EXACTLY three actions — `apply --dry-run --porcelain` (preview), `apply -y` (commit),
 # and `upgrade` to the latest published release (#59, target re-derived host-side).
-# Outcomes land in results/ and an audit line in audit/, both mounted read-only in the container.
+# Outcomes land in results/ and an audit line in audit/, both mounted read-only in the container —
+# as is masked/, the pre-masked config copy the editor form prefills from (#440); the raw
+# config.json is never mounted, so the container holds no secret it wasn't given.
 # No string from the container is ever executed or interpolated into a command; the candidate
 # config crosses the boundary only as a FILE handed to `apply` via PITHEAD_CONFIG_FILE.
 
@@ -4179,13 +4222,21 @@ control_preview() { # <request-file> <id> <actor> <control-dir>
         control_audit "$cdir/audit/control.log" "$id" "$actor" "preview" "rejected"
         return 0
     fi
-    # The staged copy carries the operator's MERGED secrets (the dashboard re-inserted real values
-    # for unchanged sentinels before submitting). It lives in host-only staged/ — never mounted —
-    # but pin it owner-only anyway so a co-tenant on the host can't read secrets from it (#33
-    # hardening; the config.json bind-mount, not this file, is the real secret trust boundary —
-    # see SECURITY.md). Created under umask 077 so it is never even briefly world-readable
-    # (create-then-chmod race); the chmod stays as belt-and-suspenders.
-    (umask 077 && jq '.config' "$file" >"$staged")
+    # The "blank secret keeps the live value" merge happens HERE, host-side (#440): the request
+    # arrives with {"__secret__":true} sentinels for untouched secrets (the container never held
+    # the real values — it prefills from the pre-masked copy), and each sentinel is swapped for
+    # the live config.json value at staging. A sentinel for a secret that is not actually set
+    # collapses to "" rather than leaking a dict into config.json. The staged copy therefore
+    # carries merged secrets: it lives in host-only staged/ — never mounted — and is pinned
+    # owner-only so a co-tenant on the host can't read secrets from it (#33 hardening). Created
+    # under umask 077 so it is never even briefly world-readable (create-then-chmod race); the
+    # chmod stays as belt-and-suspenders.
+    (umask 077 && jq --argjson paths "$CONTROL_SECRET_PATHS" --slurpfile live "$CONFIG_FILE" '
+        reduce $paths[] as $p (.config;
+            (try getpath($p) catch null) as $v
+            | if ($v | type) == "object" and $v.__secret__ == true
+              then setpath($p; (($live[0] | try getpath($p) catch null) // ""))
+              else . end)' "$file" >"$staged")
     chmod 600 "$staged" 2>/dev/null || true
     if out=$(PITHEAD_CONFIG_FILE="$staged" "$0" apply --dry-run --porcelain 2>"$errf"); then
         result=$(printf '%s\n' "$out" | jq -R -s '
@@ -4229,8 +4280,9 @@ control_commit() { # <id> <actor> <control-dir>
         return 0
     fi
     keys="$gate_out"
-    # Keep a pre-change backup; on failure it is named in the result and left in place. cp (not mv)
-    # keeps config.json's inode stable — the container bind-mounts the file read-only for prefill.
+    # Keep a pre-change backup; on failure it is named in the result and left in place. The
+    # `apply -y` below re-renders the pre-masked prefill copy (#440), so the dashboard's editor
+    # form reflects the committed config on the next load.
     cp "$CONFIG_FILE" "${CONFIG_FILE}.bak-control"
     cp "$staged" "$CONFIG_FILE"
     "$0" apply -y >"$logf" 2>&1 || rc=$?
@@ -4464,6 +4516,9 @@ control_run_pending() {
     cdir=$(env_get CONTROL_DIR)
     [ -n "$cdir" ] || cdir="$PWD/data/control"
     mkdir -p "$cdir/staged" "$cdir/results" "$cdir/audit"
+    # Freshen the pre-masked prefill copy (#440) before draining: hand-edits to config.json since
+    # the last apply show up in the editor form. A commit re-renders it again via its `apply -y`.
+    render_masked_config "$cdir"
     # Time-bounded DoS sweep (#33 hardening): drop staged/ copies and stray requests/ files older
     # than an hour that no commit ever claimed, so a burst that is never committed cannot pile up
     # (staged intents already expire per-commit at 10 min; this bounds accumulation regardless).

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -3572,6 +3572,73 @@ run_pending >/dev/null
 assert_contains "expired staged intent is rejected" "$(jq -r '.error' "$RESULTS/$UUID2.json" 2>/dev/null)" "expired"
 [ ! -f "$STAGED/$UUID2.json" ] && ok "expired staged intent cleared" || bad "expired staged intent cleared" "still staged"
 
+echo "== black-box: pre-masked prefill copy + host-side secret merge (#440) =="
+# The dashboard container never mounts the raw config.json: apply/run-pending render a PRE-MASKED
+# copy into the spool's masked/ leg, and the "blank secret keeps the live value" sentinel swap
+# happens host-side at staging. Current state: pool mini committed above, node_password "p",
+# dashboard password "a control passphrase".
+MASKED="$C/data/control/masked/config.json"
+[ -f "$MASKED" ] && ok "masked prefill copy rendered by apply" || bad "masked prefill copy rendered by apply" "$MASKED missing"
+assert_eq "masked copy is world-readable for the container (644)" "$(file_mode "$MASKED")" "644"
+assert_eq "set secret masked to the sentinel" "$(jq -c '.monero.node_password' "$MASKED" 2>/dev/null)" '{"__secret__":true}'
+assert_eq "dashboard password masked to the sentinel" "$(jq -c '.dashboard.auth.password' "$MASKED" 2>/dev/null)" '{"__secret__":true}'
+assert_eq "non-secret keys survive the masking" "$(jq -r '.p2pool.pool' "$MASKED" 2>/dev/null)" "mini"
+case "$(cat "$MASKED")" in
+*"a control passphrase"* | *'"p"'*) bad "masked copy holds no secret values" "a secret leaked into $MASKED" ;;
+*) ok "masked copy holds no secret values" ;;
+esac
+
+# Staleness: a hand-edit to config.json (new BOTSECRET token) is re-masked by the next runner
+# pass — run-pending freshens the copy even with an empty request spool.
+jq '.telegram = {"bot_token":"BOTSECRET","chat_id":"-100123"}' "$C/config.json" >"$C/config.json.tmp" &&
+    mv "$C/config.json.tmp" "$C/config.json"
+run_pending >/dev/null
+assert_eq "run-pending re-renders the masked copy" "$(jq -c '.telegram.bot_token' "$MASKED" 2>/dev/null)" '{"__secret__":true}'
+case "$(cat "$MASKED")" in
+*BOTSECRET*) bad "hand-edited secret never reaches the masked copy" "BOTSECRET leaked into $MASKED" ;;
+*) ok "hand-edited secret never reaches the masked copy" ;;
+esac
+
+# Sync .env with the hand-edited config so the sentinel commit below only changes allowlisted
+# P2POOL keys (TELEGRAM_BOT_TOKEN is deliberately NOT dashboard-committable).
+(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead apply -y >/dev/null 2>&1)
+
+# Host-side sentinel swap: a proposal carrying {"__secret__":true} for untouched secrets (what the
+# dashboard now submits) stages with the LIVE values merged back in, and a sentinel for an UNSET
+# secret collapses to "" instead of leaking a dict into config.json.
+UUID5="55555555-5555-4555-8555-555555555555"
+jq -n --arg w "$WALLET" --arg id "$UUID5" '{id:$id, action:"preview", actor:"admin", config:{
+    monero:{mode:"local",wallet_address:$w,node_username:"u",node_password:{"__secret__":true}},
+    tari:{wallet_address:"T"}, p2pool:{pool:"main"}, workers:{api_token:{"__secret__":true}},
+    telegram:{bot_token:{"__secret__":true},chat_id:"-100123"},
+    dashboard:{secure:true,host:"box.lan",auth:{username:"admin",password:{"__secret__":true}},control:{enabled:true}}}}' >"$REQS/$UUID5.json"
+run_pending >/dev/null
+assert_eq "sentinel-carrying preview validates" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "previewed"
+assert_eq "sentinel swapped for the live node password at staging" "$(jq -r '.monero.node_password' "$STAGED/$UUID5.json" 2>/dev/null)" "p"
+assert_eq "sentinel swapped for the live dashboard password" "$(jq -r '.dashboard.auth.password' "$STAGED/$UUID5.json" 2>/dev/null)" "a control passphrase"
+assert_eq "sentinel swapped for the live telegram token" "$(jq -r '.telegram.bot_token' "$STAGED/$UUID5.json" 2>/dev/null)" "BOTSECRET"
+assert_eq "sentinel for an unset secret collapses to empty" "$(jq -r '.workers.api_token' "$STAGED/$UUID5.json" 2>/dev/null)" ""
+# The container-visible legs of this round trip stay secret-free (the request carried sentinels,
+# the merged copy lives only in host-only staged/).
+case "$(cat "$RESULTS/$UUID5.json")$(cat "$AUDIT")" in
+*BOTSECRET* | *"a control passphrase"*) bad "results/audit stay secret-free on a sentinel preview" "a live secret leaked" ;;
+*) ok "results/audit stay secret-free on a sentinel preview" ;;
+esac
+
+# Commit the sentinel intent: the committed config.json carries the LIVE secrets ("blank keeps"),
+# and the masked prefill copy is re-rendered to match the new state.
+printf '{"id":"%s","action":"commit","actor":"admin"}\n' "$UUID5" >"$REQS/$UUID5.json"
+run_pending >/dev/null
+assert_eq "sentinel commit applies" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
+assert_eq "committed config keeps the live node password" "$(jq -r '.monero.node_password' "$C/config.json")" "p"
+assert_eq "committed config keeps the live telegram token" "$(jq -r '.telegram.bot_token' "$C/config.json")" "BOTSECRET"
+assert_eq "committed config never carries a sentinel dict" "$(jq -r '[.. | objects | select(.__secret__?)] | length' "$C/config.json")" "0"
+assert_eq "masked copy re-rendered after the commit" "$(jq -r '.p2pool.pool' "$MASKED" 2>/dev/null)" "main"
+case "$(cat "$MASKED")" in
+*BOTSECRET* | *"a control passphrase"*) bad "re-rendered masked copy still holds no secrets" "a secret leaked into $MASKED" ;;
+*) ok "re-rendered masked copy still holds no secrets" ;;
+esac
+
 echo "== black-box: .env line-injection guard (#33 hardening, per field) =="
 # A newline in any config string that renders into .env unquoted would inject a SECOND KEY=value
 # line — e.g. PITHEAD_REGISTRY=evil.tld — which the root apply then trusts for every image: pull

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -231,17 +231,19 @@ else
 fi
 
 # Control-channel spool mounts (#33): the rw/ro split IS the trust boundary. requests/ is the
-# dashboard's ONLY writable leg; results/, audit/ and the config prefill are read-only; staged/
-# is never mounted at all — so the container can ask, but cannot forge a result, rewrite the
-# audit log, or alter a staged intent.
+# dashboard's ONLY writable leg; results/, audit/ and the pre-masked config prefill (#440) are
+# read-only; staged/ is never mounted at all — so the container can ask, but cannot forge a
+# result, rewrite the audit log, alter a staged intent, or read a raw secret.
 jq_assert "dashboard control requests/ mounted read-write (#33)" \
     '.services.dashboard.volumes | any((.target == "/control/requests") and ((.read_only // false) == false))'
 jq_assert "dashboard control results/ mounted read-only (#33)" \
     '.services.dashboard.volumes | any((.target == "/control/results") and (.read_only == true))'
 jq_assert "dashboard control audit/ mounted read-only (#33)" \
     '.services.dashboard.volumes | any((.target == "/control/audit") and (.read_only == true))'
-jq_assert "dashboard config.json prefill mounted read-only (#33)" \
-    '.services.dashboard.volumes | any((.target == "/host-config/config.json") and (.read_only == true))'
+jq_assert "dashboard pre-masked config prefill mounted read-only (#440)" \
+    '.services.dashboard.volumes | any((.target == "/control/masked") and (.read_only == true))'
+jq_assert "raw config.json never enters the dashboard container (#440)" \
+    '.services.dashboard.volumes | any(.source | tostring | endswith("/config.json")) | not'
 jq_assert "dashboard config.reference.json prefill mounted read-only (#33)" \
     '.services.dashboard.volumes | any((.target == "/host-config/config.reference.json") and (.read_only == true))'
 jq_assert "control staged/ dir never enters the container (#33)" \


### PR DESCRIPTION
Closes #440.

## What

Closes the one accepted residual from the four #33 control-channel security reviews (shipped as #439): with `dashboard.control` on, the dashboard container bind-mounted the live `config.json` read-only to prefill its Configuration form. The API masked secrets for the *browser*, but a compromised container could read the raw file — node RPC credentials, stratum and dashboard passwords, Telegram token, Healthchecks ping URL — straight off the mount. `SECURITY.md` documented that mount as the real secret trust boundary.

The merge moves host-side:

- **`render_masked_config`** (host) writes `data/control/masked/config.json` — the live config with every *set* secret leaf replaced by the `{"__secret__":true}` sentinel, using the single `CONTROL_SECRET_PATHS` source. World-readable (holds no secrets), atomic temp+rename, best-effort. Re-rendered on every `setup`/`apply`/`upgrade` (`prepare_control_dirs`) and every runner pass (`control_run_pending`); a commit re-renders via its `apply -y`.
- **`GET /api/config`** serves from the masked copy (`HOST_CONFIG_PATH` → `/control/masked/config.json`). The container's own masking pass stays as idempotent defense-in-depth.
- **The `config.json:ro` bind mount is gone** from the dashboard service; `masked/` is mounted read-only in its place.
- **The sentinel swap moved into `control_preview`** (host): an untouched secret arrives as the sentinel and is swapped for the live value at staging; a sentinel for an unset secret collapses to `""`. `merge_secrets`/`is_secret_sentinel` deleted from the container — the request spool is now secret-free too.

Payoff: a fully compromised dashboard container can read masked config, results, and the audit log, and *ask* to change an allowlisted key — nothing else.

## Tests

- Stack suite (`tests/stack/run.sh`): masked copy is rendered/644/sentinel-masked and holds no secret values (BOTSECRET/passphrase greps), run-pending re-renders after a hand-edit, host-side sentinel swap merges live values at staging while results/audit stay secret-free, commit keeps live secrets and re-renders. Red-then-green verified on the no-secrets assertions.
- Compose (`tests/stack/test_compose.sh`): `masked/` mounted read-only; a new invariant asserts no volume source ends in `/config.json`.
- Dashboard unit/web tests updated for the pre-masked shape; `merge_secrets` tests replaced with "host copy served as-is" + "request spool keeps the sentinel".

`make lint` + `make test` green; patch coverage 100% (control_service 100%, config 99%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)